### PR TITLE
End-to-end conformance harness, and make Soroban RPC reachable from Node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,63 @@
         "@stellar/stellar-sdk": "^16.2.0",
         "@x402/core": "^2.21.0",
         "@x402/stellar": "^2.21.0",
-        "express": "^5.2.1"
+        "express": "^5.2.1",
+        "undici": "^7.29.0"
+      },
+      "devDependencies": {
+        "@x402/express": "^2.21.0"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/ed25519": {
@@ -34,6 +87,117 @@
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@signinwithethereum/siwe": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@signinwithethereum/siwe/-/siwe-4.2.0.tgz",
+      "integrity": "sha512-6W+oyKgMFUZRJI4o9P9mTMzrokkXfu3tq1/CfOJj9QrMqyPqujJqv1xnxUAqDQwWVyCA8TMg0Fxk/+gXrDg2Nw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@signinwithethereum/siwe-parser": "^4.2.0"
+      },
+      "peerDependencies": {
+        "ethers": "^5.7.0 || ^6.13.0",
+        "viem": "^2.7.0"
+      },
+      "peerDependenciesMeta": {
+        "ethers": {
+          "optional": true
+        },
+        "viem": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@signinwithethereum/siwe-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@signinwithethereum/siwe-parser/-/siwe-parser-4.2.0.tgz",
+      "integrity": "sha512-e3edh8XpZrEjbzVYc0BZ4ySFOa8RKTZOQTafSf1E6ejCB5XcBH93jEpYmjzry1EEocgMNq4KlB3YunsFNCXakQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/hashes": "^1.7.0",
+        "apg-js": "^4.4.0"
+      }
+    },
+    "node_modules/@signinwithethereum/siwe-parser/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -84,6 +248,44 @@
         "zod": "^3.24.2"
       }
     },
+    "node_modules/@x402/express": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@x402/express/-/express-2.21.0.tgz",
+      "integrity": "sha512-sEKRsHZLimWiaROrnm3G0LEXW/a5+7U5/TEMQ8+kmmePcPcMBg8jzBNDK6WXm2KOWnTWTRbKrdJMuT7eerYW0Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@x402/core": "~2.21.0",
+        "@x402/extensions": "~2.21.0"
+      },
+      "peerDependencies": {
+        "@x402/paywall": "^2.21.0",
+        "express": "^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@x402/paywall": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@x402/extensions": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@x402/extensions/-/extensions-2.21.0.tgz",
+      "integrity": "sha512-0cZTRVtnWUUsp9KxBvbMERtLKo+57Ru1IhbAHtpgNdK08/LJWtK6CpqM4wgta8nMPth3jMvB/PdS3OdNaEPaBQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.9.0",
+        "@scure/base": "^1.2.6",
+        "@signinwithethereum/siwe": "^4.1.0",
+        "@x402/core": "~2.21.0",
+        "ajv": "^8.17.1",
+        "jose": "^5.9.6",
+        "tweetnacl": "^1.0.3",
+        "viem": "^2.48.11",
+        "zod": "^3.24.2"
+      }
+    },
     "node_modules/@x402/stellar": {
       "version": "2.21.0",
       "resolved": "https://registry.npmjs.org/@x402/stellar/-/stellar-2.21.0.tgz",
@@ -95,6 +297,28 @@
       },
       "engines": {
         "node": ">=22.0.0"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/accepts": {
@@ -121,6 +345,30 @@
       "engines": {
         "node": ">= 6.0.0"
       }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/apg-js": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/apg-js/-/apg-js-4.4.0.tgz",
+      "integrity": "sha512-fefmXFknJmtgtNEXfPwZKYkMFX4Fyeyz+fNF6JWp87biGOPslJbCBVU158zvKRZfHBKnJDy8CMM40oLFGkXT8Q==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -459,6 +707,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/eventsource": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-4.1.1.tgz",
@@ -522,6 +777,30 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/feaxios": {
       "version": "0.0.23",
@@ -827,6 +1106,39 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -934,6 +1246,66 @@
         "wrappy": "1"
       }
     },
+    "node_modules/ox": {
+      "version": "0.14.33",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.33.tgz",
+      "integrity": "sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ox/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1017,6 +1389,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/router": {
@@ -1194,6 +1576,13 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "dev": true,
+      "license": "Unlicense"
+    },
     "node_modules/type-is": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
@@ -1237,6 +1626,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -1255,11 +1653,93 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/viem": {
+      "version": "2.55.13",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.55.13.tgz",
+      "integrity": "sha512-Rt1NAsdtTdvJgqaCxsv2TuO55xv2d2dKEuRuzrg34xMGxvTSFOX0iIFvEfymPvh+fwN2tbgEU2JwN0YHOVM+Bg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.33",
+        "ws": "8.21.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "@stellar/stellar-sdk": "^16.2.0",
     "@x402/core": "^2.21.0",
     "@x402/stellar": "^2.21.0",
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "undici": "^7.29.0"
+  },
+  "devDependencies": {
+    "@x402/express": "^2.21.0"
   }
 }

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -1,0 +1,215 @@
+/**
+ * End-to-end conformance run.
+ *
+ * The acceptance criterion this targets (RFP §3.6) is that an *unmodified*
+ * canonical client completes a payment against the facilitator. So the client
+ * here is `x402Client` + `x402HTTPClient` from @x402/core with the stock
+ * `ExactStellarScheme` client — no local subclass, no patched transport, no
+ * hand-rolled payload. If this passes, it passes because the wire format is
+ * right, not because the test was shaped to fit.
+ *
+ * Topology, three distinct accounts because the scheme requires it:
+ *
+ *   alice (payer) ──pays──> deployer (merchant)
+ *                    │
+ *                    └── facilitator (submits + sponsors fee), must be neither
+ *
+ *   :3401  resource server  — @x402/express, points at our facilitator
+ *   :3402  facilitator      — this repo, must already be running
+ *
+ * Usage:
+ *   FACILITATOR_SECRET=$(stellar keys show facilitator) npm start &
+ *   ALICE_SECRET=$(stellar keys show alice) node scripts/e2e.mjs
+ */
+import express from 'express';
+import {
+  paymentMiddlewareFromHTTPServer,
+  x402ResourceServer,
+  x402HTTPResourceServer,
+} from '@x402/express';
+import { HTTPFacilitatorClient } from '@x402/core/server';
+import { x402Client, x402HTTPClient } from '@x402/core/client';
+import { ExactStellarScheme as ExactStellarServer } from '@x402/stellar/exact/server';
+import { ExactStellarScheme as ExactStellarClient } from '@x402/stellar/exact/client';
+import { createEd25519Signer } from '@x402/stellar';
+import { installRpcRetry } from '../src/rpc-retry.js';
+
+// The client makes its own RPC calls to build and simulate the payment. Install
+// the wrapper at the fetch layer rather than around createPaymentPayload: the
+// SDK wraps transport errors in an AxiosError that drops `cause.code`, so by the
+// time the call returns, a connection timeout is indistinguishable from any
+// other failure.
+installRpcRetry({ log: msg => console.log(`    ${msg}`) });
+
+const NETWORK = 'stellar:testnet';
+const XLM_SAC = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC';
+const MERCHANT = process.env.MERCHANT_ADDRESS
+  ?? 'GCALKSGAZRJLSUEJT3M5W6LN4R7XQOLIRCOS6ZA6EDZVTZDBIIPPFKJ6';
+const FACILITATOR_URL = process.env.FACILITATOR_URL ?? 'http://localhost:3402';
+const RESOURCE_PORT = Number(process.env.RESOURCE_PORT ?? 3401);
+
+/** 1000 stroops = 0.0001 XLM. Small enough to run repeatedly on testnet. */
+const PRICE_STROOPS = '1000';
+
+const aliceSecret = process.env.ALICE_SECRET;
+if (!aliceSecret) {
+  console.error('ALICE_SECRET is required: ALICE_SECRET=$(stellar keys show alice)');
+  process.exit(2);
+}
+
+function step(n, msg) {
+  console.log(`\n[${n}] ${msg}`);
+}
+
+/**
+ * Retries a call that failed for transport reasons.
+ *
+ * This exists for local network flakiness, not to mask protocol failures. On
+ * this machine Node's fetch intermittently times out against
+ * soroban-testnet.stellar.org where curl to the same host succeeds every time —
+ * both resolved IPs answer fine, so it is the Node HTTP stack and the local
+ * link, not the RPC.
+ *
+ * Only connection-level failures are retried. A protocol error — a rejected
+ * payment, a bad signature, a non-conformant response — is returned to the
+ * caller on the first attempt, because retrying those would turn a conformance
+ * failure into a flaky pass, which is the opposite of what this script is for.
+ */
+async function withTransportRetry(label, fn, attempts = 6) {
+  for (let i = 1; i <= attempts; i++) {
+    try {
+      return await fn();
+    } catch (err) {
+      const cause = err?.cause?.code ?? err?.code;
+      const transport =
+        cause === 'ETIMEDOUT' ||
+        cause === 'ECONNRESET' ||
+        cause === 'ECONNREFUSED' ||
+        cause === 'UND_ERR_CONNECT_TIMEOUT' ||
+        cause === 'EAI_AGAIN';
+      if (!transport || i === attempts) throw err;
+      console.log(`    ${label}: ${cause}, retry ${i}/${attempts - 1}`);
+      await new Promise(r => setTimeout(r, 1500 * i));
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Resource server — an ordinary x402 seller that happens to point at us
+// ---------------------------------------------------------------------------
+
+const resourceServer = new x402ResourceServer([
+  new HTTPFacilitatorClient({ url: FACILITATOR_URL }),
+]);
+resourceServer.register(NETWORK, new ExactStellarServer());
+
+let settlementSeen = null;
+resourceServer.onAfterSettle(async ctx => {
+  settlementSeen = ctx.result;
+});
+
+const httpServer = new x402HTTPResourceServer(resourceServer, {
+  '/api/quote': {
+    accepts: {
+      scheme: 'exact',
+      price: { asset: XLM_SAC, amount: PRICE_STROOPS },
+      network: NETWORK,
+      payTo: MERCHANT,
+    },
+  },
+});
+
+const app = express();
+app.use(paymentMiddlewareFromHTTPServer(httpServer));
+app.get('/api/quote', (_req, res) => {
+  res.json({ symbol: 'XLM', price: '0.42', asOf: new Date().toISOString() });
+});
+
+const server = app.listen(RESOURCE_PORT);
+await new Promise(r => server.once('listening', r));
+
+// ---------------------------------------------------------------------------
+// Canonical client — stock SDK, no modifications
+// ---------------------------------------------------------------------------
+
+const payer = createEd25519Signer(aliceSecret, NETWORK);
+const client = new x402Client().register(NETWORK, new ExactStellarClient(payer));
+const http = new x402HTTPClient(client);
+
+const RESOURCE = `http://localhost:${RESOURCE_PORT}/api/quote`;
+let exitCode = 0;
+
+try {
+  step(1, 'Facilitator /supported');
+  const supported = await (await fetch(`${FACILITATOR_URL}/supported`)).json();
+  const kind = supported.kinds?.find(k => k.network === NETWORK);
+  if (!kind) throw new Error(`facilitator does not advertise ${NETWORK}`);
+  console.log(`    scheme=${kind.scheme} x402Version=${kind.x402Version}`);
+  console.log(`    extra=${JSON.stringify(kind.extra)}`);
+  if (kind.extra?.areFeesSponsored !== true) {
+    throw new Error('extra.areFeesSponsored missing or not true');
+  }
+
+  step(2, `Unpaid GET ${RESOURCE} — expecting 402`);
+  const unpaid = await fetch(RESOURCE);
+  console.log(`    status=${unpaid.status}`);
+  if (unpaid.status !== 402) throw new Error(`expected 402, got ${unpaid.status}`);
+
+  const body = await unpaid.clone().json().catch(() => undefined);
+  const paymentRequired = http.getPaymentRequiredResponse(
+    name => unpaid.headers.get(name),
+    body,
+  );
+  const req0 = paymentRequired.accepts?.[0];
+  console.log(`    asset=${req0?.asset}`);
+  console.log(`    amount=${req0?.maxAmountRequired}  payTo=${req0?.payTo}`);
+
+  step(3, 'Client signs the auth entry (payer never sees a transaction)');
+  const paymentPayload = await withTransportRetry('sign', () =>
+    http.createPaymentPayload(paymentRequired),
+  );
+  console.log(`    payload keys: ${Object.keys(paymentPayload.payload ?? {}).join(', ')}`);
+
+  step(4, 'Retry with X-PAYMENT — facilitator verifies, submits, sponsors the fee');
+  const paid = await withTransportRetry('pay', () =>
+    fetch(RESOURCE, { headers: http.encodePaymentSignatureHeader(paymentPayload) }),
+  );
+  console.log(`    status=${paid.status}`);
+  const payload = await paid.text();
+
+  const settle = http.getPaymentSettleResponse(name => paid.headers.get(name));
+
+  if (paid.status !== 200) {
+    console.log(`    body=${payload.slice(0, 400)}`);
+    throw new Error(
+      `payment did not complete: ${settle?.errorReason ?? 'unknown'} ` +
+        `${settle?.errorMessage ?? ''}`.trim(),
+    );
+  }
+
+  console.log(`    body=${payload}`);
+
+  step(5, 'Settlement');
+  const result = settle ?? settlementSeen;
+  console.log(`    success=${result?.success}`);
+  console.log(`    payer=${result?.payer}`);
+  console.log(`    network=${result?.network}`);
+  console.log(`    tx=${result?.transaction}`);
+
+  if (!result?.success || !result?.transaction) {
+    throw new Error('settlement reported no transaction hash');
+  }
+
+  console.log('\n────────────────────────────────────────────────────────────');
+  console.log('PASS — unmodified canonical client completed a payment');
+  console.log(`  tx     https://stellar.expert/explorer/testnet/tx/${result.transaction}`);
+  console.log('────────────────────────────────────────────────────────────');
+} catch (err) {
+  exitCode = 1;
+  console.error(`\nFAIL — ${err instanceof Error ? err.message : err}`);
+  if (err?.cause) console.error(`  cause: ${err.cause?.message ?? err.cause}`);
+  if (process.env.VERBOSE) console.error(err);
+} finally {
+  server.close();
+  process.exit(exitCode);
+}

--- a/src/rpc-retry.js
+++ b/src/rpc-retry.js
@@ -1,0 +1,96 @@
+/**
+ * Makes Soroban RPC reachable from Node, and retries connection-level failures.
+ *
+ * `@stellar/stellar-sdk` reaches Soroban RPC through the global `fetch`, so
+ * wrapping it here covers every RPC call the scheme makes — simulate, send and
+ * poll — without reaching inside `ExactStellarScheme`.
+ *
+ * WHY THIS EXISTS — two distinct problems, one wrapper.
+ *
+ * 1. IPv6 dead-ends. `soroban-testnet.stellar.org` advertises AAAA records
+ *    (Cloudflare). On an IPv4-only host those addresses fail with ENETUNREACH,
+ *    and Node's built-in fetch does not reliably fall back to the A records —
+ *    every request times out, while `curl` to the same host succeeds every
+ *    time because it falls back immediately. Forcing `family: 4` on the
+ *    connector removes the dead path. This is not exotic: any machine without
+ *    working IPv6 hits it, which makes it a self-hosting footgun worth handling
+ *    in the code rather than in a troubleshooting note.
+ *
+ * 2. Transient timeouts on top of that, retried below.
+ *
+ * WHAT IS AND IS NOT RETRIED. Only failures raised *before* a response is
+ * received — connection timeouts and resets. Once the server has answered,
+ * whatever it said stands: an RPC error, a rejected simulation or a failed
+ * settlement is returned unchanged. Retrying those would convert a real failure
+ * into a flaky success, which is precisely the class of bug this repo exists to
+ * avoid.
+ *
+ * ON RESUBMISSION SAFETY. A retry can in principle resend `sendTransaction`.
+ * That is safe here for two reasons: a connection-level failure means the
+ * request most likely never arrived, and a Soroban transaction is identified by
+ * its hash, so a genuine duplicate is rejected as such by the network rather
+ * than settling twice. It is not a substitute for idempotency keys in a
+ * production facilitator, and should be revisited alongside the durable
+ * settlement-status store this spike does not have.
+ */
+
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+const RETRYABLE = new Set([
+  'ETIMEDOUT',
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'EAI_AGAIN',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_SOCKET',
+]);
+
+/**
+ * Installs the retrying wrapper over the global fetch.
+ *
+ * @param {object} [options]
+ * @param {number} [options.attempts] - total attempts including the first
+ * @param {number} [options.baseDelayMs] - linear backoff step
+ * @param {(msg: string) => void} [options.log]
+ */
+export function installRpcRetry({
+  attempts = 5,
+  baseDelayMs = 800,
+  log = () => {},
+  forceIpv4 = process.env.RPC_FORCE_IPV4 !== 'false',
+} = {}) {
+  const builtinFetch = globalThis.fetch;
+
+  // undici's fetch is used rather than the built-in one because only the former
+  // accepts a dispatcher. Note the npm `undici` and Node's bundled copy are
+  // separate module instances, so `setGlobalDispatcher` from the package does
+  // NOT affect `globalThis.fetch` — the dispatcher has to travel with the call.
+  let call = builtinFetch;
+  if (forceIpv4) {
+    const { Agent, fetch: undiciFetch } = require('undici');
+    const agent = new Agent({ connect: { family: 4 } });
+    call = (input, init) => undiciFetch(input, { ...init, dispatcher: agent });
+  }
+
+  globalThis.fetch = async function retryingFetch(input, init) {
+    let lastError;
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+      try {
+        return await call(input, init);
+      } catch (err) {
+        const code = err?.cause?.code ?? err?.code;
+        if (!RETRYABLE.has(code) || attempt === attempts) {
+          lastError = err;
+          break;
+        }
+        lastError = err;
+        const url = typeof input === 'string' ? input : (input?.url ?? '');
+        log(`rpc ${code} on ${url} — retry ${attempt}/${attempts - 1}`);
+        await new Promise(r => setTimeout(r, baseDelayMs * attempt));
+      }
+    }
+    throw lastError;
+  };
+}

--- a/src/server.js
+++ b/src/server.js
@@ -18,6 +18,11 @@
 import express from 'express';
 import { resolveConfig } from './config.js';
 import { buildFacilitator } from './facilitator.js';
+import { installRpcRetry } from './rpc-retry.js';
+
+// Must run before the scheme makes any RPC call. Retries connection-level
+// failures only; see rpc-retry.js for what that deliberately excludes.
+installRpcRetry({ log: msg => console.warn(`  ${msg}`) });
 
 const config = resolveConfig();
 const { facilitator, signers } = buildFacilitator(config);


### PR DESCRIPTION
Adds the harness that answers the question this repo exists for — *can an unmodified canonical x402 client complete a payment against a facilitator we operate?* — and fixes the connectivity problem that was blocking it.

**Settlement is not yet proven.** Steps 1–3 pass; the README's conformance list still shows the end-to-end payment and the settled transaction hash unchecked. This PR gets the harness to the point where the remaining question is about the payment path and nothing else.

## `scripts/e2e.mjs`

The client is stock: `x402Client` + `x402HTTPClient` from `@x402/core` with the unmodified `ExactStellarScheme` client. No subclass, no patched transport, no hand-built payload — if this passes it passes because the wire format is right, not because the test was shaped to fit. It pays a real `@x402/express` resource server that settles through this facilitator.

Three accounts, because the scheme requires it: `alice` pays `deployer`, and the facilitator is neither.

What passes today:

```
[1] /supported → scheme=exact x402Version=2 extra={"areFeesSponsored":true}
[2] unpaid GET → 402, requirements parsed
[3] client signs auth entry → payload keys: transaction
```

That third line is the spec's `payload: {transaction}` shape, produced by the stock client and accepted verbatim.

## `src/rpc-retry.js` — the actual blocker

Nothing could reach Soroban RPC from Node on this host, and the cause was neither the code nor the RPC.

`soroban-testnet.stellar.org` advertises Cloudflare AAAA records. This host has no working IPv6 — a raw TLS connect to the v6 address returns `ENETUNREACH` immediately, while IPv4 connects fine. Node's built-in `fetch` does not fall back to the A records; `curl` does. Hence `curl` succeeding 3/3 and Node failing 3/3, back to back, against the same URL.

Routing RPC through undici with `connect: { family: 4 }` fixes it (verified: ledger 4086996).

This belongs in code rather than a troubleshooting note. Any self-hoster without working IPv6 hits it, and the symptom — every settlement timing out against a service that looks healthy — points nowhere near the cause.

### What the retry does and does not cover

There is genuine intermittency on top of the IPv6 problem, so the same wrapper retries connection failures. It retries **only** failures raised before a response arrives. Once the server has answered, whatever it said stands — retrying a rejected payment or a failed simulation would convert a conformance failure into a flaky pass, which is the opposite of what this repo is for.

## Two things deliberately left open

- **Forcing IPv4 is defaulted on** (`RPC_FORCE_IPV4=false` disables). Right for a spike; silently disabling an address family is the kind of default that stays invisible until it is wrong. Worth an explicit decision for the production build.
- **A retry can in principle resend `sendTransaction`.** Safe enough here — a connection-level failure means the request most likely never arrived, and a Soroban transaction is identified by its hash, so a genuine duplicate is rejected rather than settling twice. Not a substitute for idempotency keys and a durable settlement-status store.

## Dependencies

`undici` becomes a runtime dependency. `@x402/express` is a devDependency, used only by the harness — the facilitator itself does not depend on it.
