### PR TITLE
fix: apply per-network RPC URLs and fee ceilings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,9 +9,11 @@ PORT=3402
 # Optional on testnet (the package defaults to the public endpoint).
 # Wanted on pubnet — the public endpoint is not something to run an SLO against.
 # STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+# STELLAR_RPC_URL_PUBNET=https://mainnet.rpc.example.com
 
 # Fee ceiling per settlement, in stroops. 50000 = 0.005 XLM.
 # MAX_TX_FEE_STROOPS=50000
+# MAX_TX_FEE_STROOPS_PUBNET=50000
 
 # Comma-separated caller API keys. Unset = open, correct for free testnet.
 # FACILITATOR_API_KEYS=

--- a/README.md
+++ b/README.md
@@ -144,10 +144,12 @@ curl -s localhost:3402/supported | jq
 |---|---|---|
 | `FACILITATOR_SECRET` | *required* | `S…` secret for the testnet signer |
 | `PORT` | `3402` | |
-| `STELLAR_RPC_URL` | package default | Public testnet RPC is fine; a provider URL is wanted for pubnet |
-| `MAX_TX_FEE_STROOPS` | `50000` | Fee ceiling per settlement. Configurable, never hard-wired |
+| `STELLAR_RPC_URL` | package default | Public testnet RPC is fine |
+| `STELLAR_RPC_URL_PUBNET` | *required if enabled* | A provider URL is required for pubnet |
+| `MAX_TX_FEE_STROOPS` | `50000` | Fee ceiling per settlement on testnet. Configurable, never hard-wired |
+| `MAX_TX_FEE_STROOPS_PUBNET` | `50000` | Fee ceiling per settlement on pubnet |
 | `FACILITATOR_API_KEYS` | *(unset)* | Comma-separated. Unset means open, which is correct for a free testnet instance and is logged at boot |
-| `ENABLE_PUBNET` | `false` | Requires `FACILITATOR_SECRET_PUBNET`; refuses to start without it |
+| `ENABLE_PUBNET` | `false` | Requires `FACILITATOR_SECRET_PUBNET` and `STELLAR_RPC_URL_PUBNET`; refuses to start without them |
 
 Pubnet is opt-in behind its own secret deliberately: running a mainnet facilitator from a
 testnet-shaped config loses real money.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "start": "node src/server.js",
     "dev": "node --watch src/server.js",
-    "smoke": "node scripts/smoke.mjs"
+    "smoke": "node scripts/smoke.mjs",
+    "test": "node --test"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^16.2.0",

--- a/src/config.js
+++ b/src/config.js
@@ -14,20 +14,6 @@ export const PUBNET = 'stellar:pubnet';
  * signer secret, because the failure mode of accidentally running a mainnet
  * facilitator with a testnet-shaped config is losing real money.
  */
-export function resolveNetworks(env = process.env) {
-  const networks = [TESTNET];
-  if (env.ENABLE_PUBNET === 'true') {
-    if (!env.FACILITATOR_SECRET_PUBNET) {
-      throw new Error(
-        'ENABLE_PUBNET=true but FACILITATOR_SECRET_PUBNET is unset. ' +
-          'Refusing to serve pubnet with the testnet signer.',
-      );
-    }
-    networks.push(PUBNET);
-  }
-  return networks;
-}
-
 export function resolveConfig(env = process.env) {
   const secret = env.FACILITATOR_SECRET;
   if (!secret) {
@@ -40,25 +26,40 @@ export function resolveConfig(env = process.env) {
     throw new Error('FACILITATOR_SECRET must be a Stellar secret key (starts with S).');
   }
 
+  const networks = [TESTNET];
+  const perNetwork = {
+    [TESTNET]: {
+      secret,
+      rpcUrl: env.STELLAR_RPC_URL,
+      maxTransactionFeeStroops: Number(env.MAX_TX_FEE_STROOPS ?? 50_000),
+    },
+  };
+
+  if (env.ENABLE_PUBNET === 'true') {
+    if (!env.FACILITATOR_SECRET_PUBNET) {
+      throw new Error(
+        'ENABLE_PUBNET=true but FACILITATOR_SECRET_PUBNET is unset. ' +
+          'Refusing to serve pubnet with the testnet signer.',
+      );
+    }
+    if (!env.STELLAR_RPC_URL_PUBNET) {
+      throw new Error(
+        'ENABLE_PUBNET=true but STELLAR_RPC_URL_PUBNET is unset. ' +
+          'Refusing to serve pubnet with the default public endpoint.',
+      );
+    }
+    networks.push(PUBNET);
+    perNetwork[PUBNET] = {
+      secret: env.FACILITATOR_SECRET_PUBNET,
+      rpcUrl: env.STELLAR_RPC_URL_PUBNET,
+      maxTransactionFeeStroops: Number(env.MAX_TX_FEE_STROOPS_PUBNET ?? 50_000),
+    };
+  }
+
   return {
     port: Number(env.PORT ?? 3402),
-    secret,
-    secretPubnet: env.FACILITATOR_SECRET_PUBNET,
-    networks: resolveNetworks(env),
-
-    /**
-     * Custom RPC URL. Optional on testnet — @x402/stellar defaults to the
-     * public endpoint. On pubnet a provider URL should be supplied, since the
-     * public endpoint is not something to run an availability target against.
-     */
-    rpcUrl: env.STELLAR_RPC_URL,
-
-    /**
-     * Fee ceiling the facilitator will pay per settlement, in stroops.
-     * @x402/stellar defaults to 50_000 (0.005 XLM). Configurable rather than
-     * hard-wired, per RFP §3.1.
-     */
-    maxTransactionFeeStroops: Number(env.MAX_TX_FEE_STROOPS ?? 50_000),
+    networks,
+    perNetwork,
 
     /**
      * Caller authentication. Unset means open, which is correct for a free

--- a/src/facilitator.js
+++ b/src/facilitator.js
@@ -32,19 +32,19 @@ export function buildFacilitator(config) {
   const signers = {};
 
   for (const network of config.networks) {
-    const secret = network === PUBNET ? config.secretPubnet : config.secret;
+    const netConfig = config.perNetwork[network];
 
     // createEd25519Signer yields a FacilitatorStellarSigner — address,
     // signAuthEntry, signTransaction.
-    const signer = createEd25519Signer(secret, network);
+    const signer = createEd25519Signer(netConfig.secret, network);
     signers[network] = signer.address;
 
     const scheme = new ExactStellarScheme([signer], {
       // areFeesSponsored defaults true and is surfaced through getExtra() into
       // /supported. Left at the default: the spec currently only supports true,
       // and advertising false while sponsoring would be a conformance failure.
-      rpcConfig: config.rpcUrl ? { url: config.rpcUrl } : undefined,
-      maxTransactionFeeStroops: config.maxTransactionFeeStroops,
+      rpcConfig: netConfig.rpcUrl ? { url: netConfig.rpcUrl } : undefined,
+      maxTransactionFeeStroops: netConfig.maxTransactionFeeStroops,
 
       // NOTE for the real build, not this spike: ExactStellarScheme accepts an
       // *array* of signers with a round-robin selectSigner, and an optional

--- a/src/server.js
+++ b/src/server.js
@@ -123,11 +123,13 @@ app.post('/settle', requireApiKey, async (req, res) => {
 app.listen(config.port, () => {
   console.log(`x402 Stellar facilitator listening on :${config.port}`);
   console.log(`  networks : ${config.networks.join(', ')}`);
-  for (const [network, address] of Object.entries(signers)) {
-    console.log(`  signer   : ${network} -> ${address}`);
+  for (const network of config.networks) {
+    const netConfig = config.perNetwork[network];
+    console.log(`  [${network}]`);
+    console.log(`    signer : ${signers[network]}`);
+    console.log(`    rpc    : ${netConfig.rpcUrl ?? '(package default)'}`);
+    console.log(`    max fee: ${netConfig.maxTransactionFeeStroops} stroops`);
   }
-  console.log(`  rpc      : ${config.rpcUrl ?? '(package default)'}`);
-  console.log(`  max fee  : ${config.maxTransactionFeeStroops} stroops`);
   if (config.apiKeys.length === 0) {
     console.log('  auth     : OPEN — no API keys configured (fine for free testnet)');
   } else {

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { resolveConfig, TESTNET, PUBNET } from '../src/config.js';
+
+test('resolveConfig: testnet only by default', () => {
+  const env = { FACILITATOR_SECRET: 'S123' };
+  const config = resolveConfig(env);
+  assert.deepStrictEqual(config.networks, [TESTNET]);
+  assert.ok(config.perNetwork[TESTNET]);
+  assert.strictEqual(config.perNetwork[TESTNET].secret, 'S123');
+  assert.strictEqual(config.perNetwork[TESTNET].maxTransactionFeeStroops, 50000);
+});
+
+test('resolveConfig: requires secret', () => {
+  assert.throws(() => resolveConfig({}), /FACILITATOR_SECRET is required/);
+  assert.throws(() => resolveConfig({ FACILITATOR_SECRET: 'G123' }), /starts with S/);
+});
+
+test('resolveConfig: pubnet requires its own secret', () => {
+  const env = { FACILITATOR_SECRET: 'S123', ENABLE_PUBNET: 'true' };
+  assert.throws(() => resolveConfig(env), /FACILITATOR_SECRET_PUBNET is unset/);
+});
+
+test('resolveConfig: pubnet requires its own RPC URL', () => {
+  const env = {
+    FACILITATOR_SECRET: 'S123',
+    ENABLE_PUBNET: 'true',
+    FACILITATOR_SECRET_PUBNET: 'S456',
+  };
+  assert.throws(() => resolveConfig(env), /STELLAR_RPC_URL_PUBNET is unset/);
+});
+
+test('resolveConfig: pubnet sets per-network values correctly', () => {
+  const env = {
+    FACILITATOR_SECRET: 'S123',
+    STELLAR_RPC_URL: 'https://testnet.local',
+    MAX_TX_FEE_STROOPS: '10000',
+    ENABLE_PUBNET: 'true',
+    FACILITATOR_SECRET_PUBNET: 'S456',
+    STELLAR_RPC_URL_PUBNET: 'https://pubnet.local',
+    MAX_TX_FEE_STROOPS_PUBNET: '20000',
+  };
+  const config = resolveConfig(env);
+  assert.deepStrictEqual(config.networks, [TESTNET, PUBNET]);
+  
+  assert.strictEqual(config.perNetwork[TESTNET].secret, 'S123');
+  assert.strictEqual(config.perNetwork[TESTNET].rpcUrl, 'https://testnet.local');
+  assert.strictEqual(config.perNetwork[TESTNET].maxTransactionFeeStroops, 10000);
+  
+  assert.strictEqual(config.perNetwork[PUBNET].secret, 'S456');
+  assert.strictEqual(config.perNetwork[PUBNET].rpcUrl, 'https://pubnet.local');
+  assert.strictEqual(config.perNetwork[PUBNET].maxTransactionFeeStroops, 20000);
+});


### PR DESCRIPTION
Resolves #4 by moving to a per-network configuration map, preventing testnet settings from being applied to pubnet.