### PR TITLE
test: unit suite for config, the HTTP surface, and the RPC retry wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,26 @@ curl -s localhost:3402/supported | jq
 }
 ```
 
+### Tests
+
+```bash
+npm test          # unit tests — no network, no funded account, no .env
+npm run test:watch
+```
+
+The unit suite covers configuration resolution, the HTTP surface (status codes,
+reason codes, pass-through fidelity, caller auth) and the RPC retry wrapper. It
+stubs the facilitator throughout: `ExactStellarScheme` is upstream's and is not
+retested here.
+
+The end-to-end conformance run is separate, because it needs testnet and two
+funded accounts:
+
+```bash
+FACILITATOR_SECRET=$(stellar keys show facilitator) npm start &
+ALICE_SECRET=$(stellar keys show alice) npm run e2e
+```
+
 ### Configuration
 
 | Variable | Default | Notes |

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "scripts": {
     "start": "node src/server.js",
     "dev": "node --watch src/server.js",
-    "smoke": "node scripts/smoke.mjs"
+    "test": "node --test test/",
+    "test:watch": "node --test --watch test/",
+    "e2e": "node scripts/e2e.mjs"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^16.2.0",

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,131 @@
+/**
+ * The HTTP surface: /verify, /settle, /supported.
+ *
+ * @x402/core ships no facilitator router — it gives you x402Facilitator with
+ * verify(), settle() and getSupported(), and the transport is yours. This file
+ * is that transport and nothing else.
+ *
+ * Conformance is judged at the wire level: reviewers point stock SDK code at
+ * the deliverable rather than read a conformance claim. So the rules here are
+ * narrow and deliberate:
+ *
+ *   - the spec's `payload: {transaction}` shape is accepted verbatim, unwrapped
+ *     and un-renamed;
+ *   - every rejection carries a non-null reason code, including transport-level
+ *     ones, so an agent can branch on a code instead of parsing prose;
+ *   - responses are passed through from the scheme untouched.
+ *
+ * Separated from server.js so the app can be built and exercised in a test
+ * without binding a port or holding a real signer. server.js is the process
+ * entrypoint and does nothing this file does.
+ */
+import express from 'express';
+
+/**
+ * Builds the Express app.
+ *
+ * `signers` is deliberately not a parameter: no route reads it. /supported is
+ * assembled by the facilitator itself, so the signer addresses reach the wire
+ * through getSupported() rather than through here. server.js keeps them only to
+ * print the boot banner.
+ *
+ * @param {object} config - resolved config from resolveConfig()
+ * @param {{verify: Function, settle: Function, getSupported: Function}} facilitator
+ * @returns {import('express').Express}
+ */
+export function createApp(config, facilitator) {
+  const app = express();
+  app.use(express.json({ limit: '256kb' }));
+
+  /**
+   * Caller authentication.
+   *
+   * Unset means open. That is the correct default for a free testnet instance —
+   * testnet has to be usable without friction — and it is documented rather
+   * than silent: the server logs at boot when it is running open.
+   */
+  function requireApiKey(req, res, next) {
+    if (config.apiKeys.length === 0) return next();
+    const presented = req.get('authorization')?.replace(/^Bearer /i, '');
+    if (!presented || !config.apiKeys.includes(presented)) {
+      return res.status(401).json({ error: 'unauthorized', reason: 'invalid_api_key' });
+    }
+    next();
+  }
+
+  /**
+   * Both /verify and /settle take {paymentPayload, paymentRequirements}.
+   * Returning a non-null reason on a malformed body matters as much as on a
+   * failed verification — a null reason anywhere is an acceptance failure.
+   */
+  function readPaymentBody(req, res) {
+    const { paymentPayload, paymentRequirements } = req.body ?? {};
+    if (!paymentPayload || !paymentRequirements) {
+      res.status(400).json({
+        isValid: false,
+        invalidReason: 'invalid_request',
+        invalidMessage: 'body must contain paymentPayload and paymentRequirements',
+      });
+      return null;
+    }
+    return { paymentPayload, paymentRequirements };
+  }
+
+  app.get('/healthz', (_req, res) => res.json({ ok: true }));
+
+  /**
+   * GET /supported
+   *
+   * Must emit the Stellar `extra` block including areFeesSponsored — an explicit
+   * acceptance item. getSupported() assembles it from the registered schemes, so
+   * it is passed through rather than hand-built.
+   */
+  app.get('/supported', (_req, res) => {
+    res.json(facilitator.getSupported());
+  });
+
+  app.post('/verify', requireApiKey, async (req, res) => {
+    const body = readPaymentBody(req, res);
+    if (!body) return;
+    try {
+      const result = await facilitator.verify(body.paymentPayload, body.paymentRequirements);
+      res.json(result);
+    } catch (err) {
+      // An exception must not become a 500 with an empty body: to a client that
+      // is indistinguishable from the service being down, and it carries no
+      // reason code. Shape it like a verification failure instead.
+      //
+      // Note ExactStellarScheme already absorbs its own internal exceptions and
+      // returns invalidReason "unexpected_verify_error" rather than throwing, so
+      // this path only catches failures above the scheme — an unregistered
+      // scheme/network pair, for instance. A distinct code keeps the two
+      // distinguishable to a client.
+      res.status(200).json({
+        isValid: false,
+        invalidReason: 'facilitator_error',
+        invalidMessage: err instanceof Error ? err.message : String(err),
+      });
+    }
+  });
+
+  app.post('/settle', requireApiKey, async (req, res) => {
+    const body = readPaymentBody(req, res);
+    if (!body) return;
+    try {
+      const result = await facilitator.settle(body.paymentPayload, body.paymentRequirements);
+      res.json(result);
+    } catch (err) {
+      // SettleResponse requires `transaction` and `network` even on failure, so
+      // a client can attribute the failure without correlating out of band.
+      res.status(200).json({
+        success: false,
+        errorReason: 'facilitator_error',
+        errorMessage: err instanceof Error ? err.message : String(err),
+        transaction: '',
+        network: req.body?.paymentRequirements?.network,
+      });
+    }
+  });
+
+  return app;
+}

--- a/src/server.js
+++ b/src/server.js
@@ -1,23 +1,14 @@
 /**
- * The HTTP surface: /verify, /settle, /supported.
+ * Process entrypoint.
  *
- * @x402/core ships no facilitator router — it gives you x402Facilitator with
- * verify(), settle() and getSupported(), and the transport is yours. This file
- * is that transport and nothing else.
- *
- * Conformance is judged at the wire level (RFP §3.6): reviewers point stock SDK
- * code at the deliverable rather than read a conformance claim. So the rules
- * here are narrow and deliberate:
- *
- *   - the spec's `payload: {transaction}` shape is accepted verbatim, unwrapped
- *     and un-renamed;
- *   - every rejection carries a non-null `reason`, including transport-level
- *     ones, so an agent can branch on a code instead of parsing prose;
- *   - responses are passed through from the scheme untouched.
+ * Resolves configuration, builds the facilitator and the HTTP app, and binds a
+ * port. The routes themselves live in app.js, so they can be exercised in a
+ * test without a listener or a real signer — this file is only the wiring that
+ * a test has no use for.
  */
-import express from 'express';
 import { resolveConfig } from './config.js';
 import { buildFacilitator } from './facilitator.js';
+import { createApp } from './app.js';
 import { installRpcRetry } from './rpc-retry.js';
 
 // Must run before the scheme makes any RPC call. Retries connection-level
@@ -26,99 +17,7 @@ installRpcRetry({ log: msg => console.warn(`  ${msg}`) });
 
 const config = resolveConfig();
 const { facilitator, signers } = buildFacilitator(config);
-
-const app = express();
-app.use(express.json({ limit: '256kb' }));
-
-/**
- * Caller authentication.
- *
- * Unset means open. That is the correct default for a free testnet instance —
- * the RFP requires testnet be usable without friction — and it is documented
- * rather than silent: the server logs at boot when it is running open.
- */
-function requireApiKey(req, res, next) {
-  if (config.apiKeys.length === 0) return next();
-  const presented = req.get('authorization')?.replace(/^Bearer /i, '');
-  if (!presented || !config.apiKeys.includes(presented)) {
-    return res.status(401).json({ error: 'unauthorized', reason: 'invalid_api_key' });
-  }
-  next();
-}
-
-/**
- * Both /verify and /settle take {paymentPayload, paymentRequirements}.
- * Returning a non-null reason on a malformed body matters as much as on a
- * failed verification — a null reason anywhere is an acceptance failure.
- */
-function readPaymentBody(req, res) {
-  const { paymentPayload, paymentRequirements } = req.body ?? {};
-  if (!paymentPayload || !paymentRequirements) {
-    res.status(400).json({
-      isValid: false,
-      invalidReason: 'invalid_request',
-      invalidMessage: 'body must contain paymentPayload and paymentRequirements',
-    });
-    return null;
-  }
-  return { paymentPayload, paymentRequirements };
-}
-
-app.get('/healthz', (_req, res) => res.json({ ok: true }));
-
-/**
- * GET /supported
- *
- * Must emit the Stellar `extra` block including areFeesSponsored — an explicit
- * acceptance item. getSupported() assembles it from the registered schemes, so
- * it is passed through rather than hand-built.
- */
-app.get('/supported', (_req, res) => {
-  res.json(facilitator.getSupported());
-});
-
-app.post('/verify', requireApiKey, async (req, res) => {
-  const body = readPaymentBody(req, res);
-  if (!body) return;
-  try {
-    const result = await facilitator.verify(body.paymentPayload, body.paymentRequirements);
-    res.json(result);
-  } catch (err) {
-    // An exception must not become a 500 with an empty body: to a client that
-    // is indistinguishable from the service being down, and it carries no
-    // reason code. Shape it like a verification failure instead.
-    //
-    // Note ExactStellarScheme already absorbs its own internal exceptions and
-    // returns invalidReason "unexpected_verify_error" rather than throwing, so
-    // this path only catches failures above the scheme — an unregistered
-    // scheme/network pair, for instance. A distinct code keeps the two
-    // distinguishable to a client.
-    res.status(200).json({
-      isValid: false,
-      invalidReason: 'facilitator_error',
-      invalidMessage: err instanceof Error ? err.message : String(err),
-    });
-  }
-});
-
-app.post('/settle', requireApiKey, async (req, res) => {
-  const body = readPaymentBody(req, res);
-  if (!body) return;
-  try {
-    const result = await facilitator.settle(body.paymentPayload, body.paymentRequirements);
-    res.json(result);
-  } catch (err) {
-    // SettleResponse requires `transaction` and `network` even on failure, so
-    // a client can attribute the failure without correlating out of band.
-    res.status(200).json({
-      success: false,
-      errorReason: 'facilitator_error',
-      errorMessage: err instanceof Error ? err.message : String(err),
-      transaction: '',
-      network: req.body?.paymentRequirements?.network,
-    });
-  }
-});
+const app = createApp(config, facilitator);
 
 app.listen(config.port, () => {
   console.log(`x402 Stellar facilitator listening on :${config.port}`);

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -1,0 +1,303 @@
+/**
+ * The HTTP surface.
+ *
+ * The facilitator is stubbed throughout: what is under test is the transport —
+ * status codes, reason codes, pass-through fidelity and caller auth — not
+ * ExactStellarScheme, which is upstream's and is not reimplemented here.
+ *
+ * Nothing in this file touches the network or needs a funded account.
+ */
+import { test, describe, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { createApp } from '../src/app.js';
+
+/** A payment body that satisfies readPaymentBody. Contents are never inspected. */
+const VALID_BODY = {
+  paymentPayload: { x402Version: 2, scheme: 'exact', network: 'stellar:testnet' },
+  paymentRequirements: { scheme: 'exact', network: 'stellar:testnet' },
+};
+
+/**
+ * Boots an app on an ephemeral port and returns a fetch bound to it.
+ *
+ * Port 0 rather than 3402: tests must not collide with a facilitator the
+ * developer happens to have running.
+ */
+async function serve(config, facilitator) {
+  const app = createApp({ apiKeys: [], ...config }, facilitator);
+  const server = app.listen(0);
+  await new Promise(resolve => server.once('listening', resolve));
+  const base = `http://127.0.0.1:${server.address().port}`;
+
+  return {
+    close: () => new Promise(resolve => server.close(resolve)),
+    get: path => fetch(`${base}${path}`),
+    post: (path, body, headers = {}) =>
+      fetch(`${base}${path}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', ...headers },
+        body: typeof body === 'string' ? body : JSON.stringify(body),
+      }),
+  };
+}
+
+/** A facilitator that records its calls and returns whatever it was given. */
+function stubFacilitator(overrides = {}) {
+  const calls = [];
+  return {
+    calls,
+    getSupported: () => ({ kinds: [], extensions: [], signers: {} }),
+    verify: async (payload, requirements) => {
+      calls.push(['verify', payload, requirements]);
+      return { isValid: true };
+    },
+    settle: async (payload, requirements) => {
+      calls.push(['settle', payload, requirements]);
+      return { success: true, transaction: 'abc', network: requirements.network };
+    },
+    ...overrides,
+  };
+}
+
+describe('GET /healthz', () => {
+  let app;
+  before(async () => {
+    app = await serve({}, stubFacilitator());
+  });
+  after(() => app.close());
+
+  test('reports liveness', async () => {
+    const res = await app.get('/healthz');
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { ok: true });
+  });
+});
+
+describe('GET /supported', () => {
+  test('passes getSupported() through untouched, extra block and all', async () => {
+    // The Stellar extra block carrying areFeesSponsored is an explicit
+    // acceptance item, so the transport must not reshape it on the way out.
+    const supported = {
+      kinds: [
+        {
+          x402Version: 2,
+          scheme: 'exact',
+          network: 'stellar:testnet',
+          extra: { areFeesSponsored: true },
+        },
+      ],
+      extensions: [],
+      signers: { 'stellar:*': ['GABC'] },
+    };
+    const app = await serve({}, stubFacilitator({ getSupported: () => supported }));
+    try {
+      const res = await app.get('/supported');
+      assert.equal(res.status, 200);
+      assert.deepEqual(await res.json(), supported);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('is reachable without an API key even when keys are configured', async () => {
+    // A client has to be able to read /supported before it has any
+    // relationship with us. Putting it behind auth breaks discovery.
+    const app = await serve({ apiKeys: ['k1'] }, stubFacilitator());
+    try {
+      assert.equal((await app.get('/supported')).status, 200);
+      assert.equal((await app.get('/healthz')).status, 200);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('malformed bodies always carry a reason', () => {
+  let app;
+  before(async () => {
+    app = await serve({}, stubFacilitator());
+  });
+  after(() => app.close());
+
+  for (const route of ['/verify', '/settle']) {
+    for (const [label, body] of [
+      ['an empty object', {}],
+      ['paymentPayload only', { paymentPayload: VALID_BODY.paymentPayload }],
+      ['paymentRequirements only', { paymentRequirements: VALID_BODY.paymentRequirements }],
+      ['a null payload', { paymentPayload: null, paymentRequirements: {} }],
+    ]) {
+      test(`POST ${route} with ${label} → 400 with a non-null invalidReason`, async () => {
+        const res = await app.post(route, body);
+        assert.equal(res.status, 400);
+        const json = await res.json();
+        assert.equal(json.isValid, false);
+        // A null reason anywhere is an acceptance failure — an agent has to be
+        // able to branch on a code rather than parse prose.
+        assert.equal(json.invalidReason, 'invalid_request');
+        assert.ok(json.invalidMessage, 'invalidMessage must not be empty');
+      });
+    }
+  }
+});
+
+describe('POST /verify', () => {
+  test('passes the payload and requirements through unmodified', async () => {
+    const facilitator = stubFacilitator();
+    const app = await serve({}, facilitator);
+    try {
+      const res = await app.post('/verify', VALID_BODY);
+      assert.equal(res.status, 200);
+      assert.deepEqual(await res.json(), { isValid: true });
+
+      const [name, payload, requirements] = facilitator.calls[0];
+      assert.equal(name, 'verify');
+      // Unwrapped, un-renamed, verbatim: the spec's payload shape reaches the
+      // scheme exactly as it arrived on the wire.
+      assert.deepEqual(payload, VALID_BODY.paymentPayload);
+      assert.deepEqual(requirements, VALID_BODY.paymentRequirements);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('a thrown facilitator becomes a 200 verification failure, not a 500', async () => {
+    // A 500 with an empty body is indistinguishable from the service being
+    // down and carries no reason code.
+    const app = await serve(
+      {},
+      stubFacilitator({
+        verify: async () => {
+          throw new Error('no scheme registered for stellar:pubnet');
+        },
+      }),
+    );
+    try {
+      const res = await app.post('/verify', VALID_BODY);
+      assert.equal(res.status, 200);
+      const json = await res.json();
+      assert.equal(json.isValid, false);
+      assert.equal(json.invalidReason, 'facilitator_error');
+      assert.match(json.invalidMessage, /no scheme registered/);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('a non-Error throw still produces a reason and a message', async () => {
+    const app = await serve(
+      {},
+      stubFacilitator({
+        verify: async () => {
+          throw 'a bare string';
+        },
+      }),
+    );
+    try {
+      const json = await (await app.post('/verify', VALID_BODY)).json();
+      assert.equal(json.invalidReason, 'facilitator_error');
+      assert.equal(json.invalidMessage, 'a bare string');
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('POST /settle', () => {
+  test('passes the scheme result through untouched', async () => {
+    const app = await serve({}, stubFacilitator());
+    try {
+      const res = await app.post('/settle', VALID_BODY);
+      assert.equal(res.status, 200);
+      assert.deepEqual(await res.json(), {
+        success: true,
+        transaction: 'abc',
+        network: 'stellar:testnet',
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('a thrown facilitator still returns transaction and network', async () => {
+    // SettleResponse requires both even on failure, so a client can attribute
+    // the failure without correlating out of band.
+    const app = await serve(
+      {},
+      stubFacilitator({
+        settle: async () => {
+          throw new Error('rpc unreachable');
+        },
+      }),
+    );
+    try {
+      const res = await app.post('/settle', VALID_BODY);
+      assert.equal(res.status, 200);
+      const json = await res.json();
+      assert.equal(json.success, false);
+      assert.equal(json.errorReason, 'facilitator_error');
+      assert.match(json.errorMessage, /rpc unreachable/);
+      assert.equal(json.transaction, '');
+      assert.equal(json.network, 'stellar:testnet');
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('caller authentication', () => {
+  test('with no keys configured, /verify is open', async () => {
+    const app = await serve({ apiKeys: [] }, stubFacilitator());
+    try {
+      assert.equal((await app.post('/verify', VALID_BODY)).status, 200);
+    } finally {
+      await app.close();
+    }
+  });
+
+  describe('with keys configured', () => {
+    let app;
+    before(async () => {
+      app = await serve({ apiKeys: ['k1', 'k2'] }, stubFacilitator());
+    });
+    after(() => app.close());
+
+    test('a correct Bearer key is accepted', async () => {
+      const res = await app.post('/verify', VALID_BODY, { authorization: 'Bearer k1' });
+      assert.equal(res.status, 200);
+    });
+
+    test('every configured key works, not just the first', async () => {
+      const res = await app.post('/verify', VALID_BODY, { authorization: 'Bearer k2' });
+      assert.equal(res.status, 200);
+    });
+
+    test('the Bearer prefix is matched case-insensitively', async () => {
+      const res = await app.post('/verify', VALID_BODY, { authorization: 'bearer k1' });
+      assert.equal(res.status, 200);
+    });
+
+    test('a missing header is rejected with a reason', async () => {
+      const res = await app.post('/verify', VALID_BODY);
+      assert.equal(res.status, 401);
+      assert.equal((await res.json()).reason, 'invalid_api_key');
+    });
+
+    test('a wrong key is rejected', async () => {
+      const res = await app.post('/settle', VALID_BODY, { authorization: 'Bearer nope' });
+      assert.equal(res.status, 401);
+    });
+
+    test('auth is checked before the body is read', async () => {
+      // Otherwise a malformed body from an unauthenticated caller leaks which
+      // validation it failed.
+      const res = await app.post('/verify', {}, { authorization: 'Bearer nope' });
+      assert.equal(res.status, 401);
+    });
+
+    test('both /verify and /settle are protected', async () => {
+      for (const route of ['/verify', '/settle']) {
+        assert.equal((await app.post(route, VALID_BODY)).status, 401, `${route} must require a key`);
+      }
+    });
+  });
+});

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,118 @@
+/**
+ * resolveConfig / resolveNetworks.
+ *
+ * Both take an env object rather than reading process.env, which is what makes
+ * them testable at all — and is the reason a misconfiguration fails at boot
+ * rather than on the first payment.
+ */
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveConfig, resolveNetworks, TESTNET, PUBNET } from '../src/config.js';
+
+/** A minimal valid environment. Tests override single keys off this. */
+const BASE = { FACILITATOR_SECRET: 'SAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' };
+
+describe('resolveConfig — the secret', () => {
+  test('a missing secret throws, and the message says how to make one', () => {
+    assert.throws(
+      () => resolveConfig({}),
+      err => {
+        assert.match(err.message, /FACILITATOR_SECRET is required/);
+        // The hint matters more than the error: a first-run operator has no
+        // idea where an S... key comes from.
+        assert.match(err.message, /stellar keys generate facilitator/);
+        return true;
+      },
+    );
+  });
+
+  test('a secret that is not an S... key is rejected', () => {
+    // A public key is the mistake people actually make, not random junk.
+    assert.throws(
+      () => resolveConfig({ FACILITATOR_SECRET: 'GABCDEF' }),
+      /must be a Stellar secret key \(starts with S\)/,
+    );
+  });
+
+  test('an S... key is accepted', () => {
+    assert.equal(resolveConfig(BASE).secret, BASE.FACILITATOR_SECRET);
+  });
+});
+
+describe('resolveNetworks — pubnet is opt-in and needs its own signer', () => {
+  test('defaults to testnet only', () => {
+    assert.deepEqual(resolveNetworks({}), [TESTNET]);
+  });
+
+  test('ENABLE_PUBNET without a pubnet secret refuses, naming the risk', () => {
+    assert.throws(
+      () => resolveNetworks({ ENABLE_PUBNET: 'true' }),
+      err => {
+        assert.match(err.message, /FACILITATOR_SECRET_PUBNET is unset/);
+        // Refusing is the point: serving pubnet with the testnet signer loses
+        // real money, so the message has to say that rather than just fail.
+        assert.match(err.message, /Refusing to serve pubnet with the testnet signer/);
+        return true;
+      },
+    );
+  });
+
+  test('ENABLE_PUBNET with a pubnet secret serves both networks', () => {
+    assert.deepEqual(
+      resolveNetworks({ ENABLE_PUBNET: 'true', FACILITATOR_SECRET_PUBNET: 'SPUB' }),
+      [TESTNET, PUBNET],
+    );
+  });
+
+  test('only the exact string "true" opts in — not "1", "yes" or "TRUE"', () => {
+    // A loose truthiness check here would let a typo enable mainnet.
+    for (const value of ['1', 'yes', 'TRUE', 'True', '']) {
+      assert.deepEqual(
+        resolveNetworks({ ENABLE_PUBNET: value, FACILITATOR_SECRET_PUBNET: 'SPUB' }),
+        [TESTNET],
+        `ENABLE_PUBNET=${JSON.stringify(value)} must not enable pubnet`,
+      );
+    }
+  });
+});
+
+describe('resolveConfig — defaults', () => {
+  test('port defaults to 3402 and is read from PORT', () => {
+    assert.equal(resolveConfig(BASE).port, 3402);
+    assert.equal(resolveConfig({ ...BASE, PORT: '8080' }).port, 8080);
+  });
+
+  test('the fee ceiling defaults to 50000 stroops and is configurable', () => {
+    assert.equal(resolveConfig(BASE).maxTransactionFeeStroops, 50_000);
+    assert.equal(
+      resolveConfig({ ...BASE, MAX_TX_FEE_STROOPS: '120000' }).maxTransactionFeeStroops,
+      120_000,
+    );
+  });
+
+  test('rpcUrl is undefined unless set, so the package default applies', () => {
+    assert.equal(resolveConfig(BASE).rpcUrl, undefined);
+    assert.equal(
+      resolveConfig({ ...BASE, STELLAR_RPC_URL: 'https://rpc.example' }).rpcUrl,
+      'https://rpc.example',
+    );
+  });
+});
+
+describe('resolveConfig — API keys', () => {
+  test('unset means open, represented as an empty list', () => {
+    assert.deepEqual(resolveConfig(BASE).apiKeys, []);
+  });
+
+  test('keys are split, trimmed, and empty entries dropped', () => {
+    assert.deepEqual(
+      resolveConfig({ ...BASE, FACILITATOR_API_KEYS: ' k1 , k2,,  k3  ,' }).apiKeys,
+      ['k1', 'k2', 'k3'],
+    );
+  });
+
+  test('a value of only separators and whitespace is open, not a key of ""', () => {
+    // An empty-string key would authenticate a request presenting no key.
+    assert.deepEqual(resolveConfig({ ...BASE, FACILITATOR_API_KEYS: ' , , ' }).apiKeys, []);
+  });
+});

--- a/test/rpc-retry.test.js
+++ b/test/rpc-retry.test.js
@@ -1,0 +1,188 @@
+/**
+ * installRpcRetry.
+ *
+ * The distinction this module exists to hold is the one worth pinning: failures
+ * raised *before* a response is received are retried; anything the server
+ * actually said stands. Retrying a rejected simulation or a failed settlement
+ * would convert a real failure into a flaky success, which is the class of bug
+ * this repo exists to avoid.
+ *
+ * forceIpv4 is off throughout — the IPv4 connector is about reaching a real
+ * host, and these tests never leave the process.
+ */
+import { test, describe, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { installRpcRetry } from '../src/rpc-retry.js';
+
+/** The real fetch, restored after every test so the wrapper cannot leak. */
+const REAL_FETCH = globalThis.fetch;
+
+/** Builds an error shaped like the ones undici raises. */
+function transportError(code, { onCause = false } = {}) {
+  const err = new Error(`simulated ${code}`);
+  if (onCause) err.cause = { code };
+  else err.code = code;
+  return err;
+}
+
+/** A fetch stub that plays a scripted sequence and counts its calls. */
+function scriptedFetch(...outcomes) {
+  const stub = async () => {
+    stub.calls++;
+    const next = outcomes.shift();
+    if (next instanceof Error) throw next;
+    return next ?? new Response('ok');
+  };
+  stub.calls = 0;
+  return stub;
+}
+
+beforeEach(() => {
+  globalThis.fetch = REAL_FETCH;
+});
+
+afterEach(() => {
+  globalThis.fetch = REAL_FETCH;
+});
+
+describe('what is retried', () => {
+  for (const code of [
+    'ETIMEDOUT',
+    'ECONNRESET',
+    'ECONNREFUSED',
+    'EAI_AGAIN',
+    'UND_ERR_CONNECT_TIMEOUT',
+    'UND_ERR_SOCKET',
+  ]) {
+    test(`${code} is retried and can succeed`, async () => {
+      const stub = scriptedFetch(transportError(code), new Response('recovered'));
+      globalThis.fetch = stub;
+      installRpcRetry({ attempts: 3, baseDelayMs: 1, forceIpv4: false });
+
+      const res = await globalThis.fetch('http://rpc.invalid');
+      assert.equal(await res.text(), 'recovered');
+      assert.equal(stub.calls, 2);
+    });
+  }
+
+  test('the code is read from err.cause too, not only err.code', async () => {
+    // undici wraps the real cause, and reading only the top-level code is how
+    // a retryable failure gets misclassified as fatal.
+    const stub = scriptedFetch(
+      transportError('UND_ERR_CONNECT_TIMEOUT', { onCause: true }),
+      new Response('recovered'),
+    );
+    globalThis.fetch = stub;
+    installRpcRetry({ attempts: 3, baseDelayMs: 1, forceIpv4: false });
+
+    assert.equal(await (await globalThis.fetch('http://rpc.invalid')).text(), 'recovered');
+    assert.equal(stub.calls, 2);
+  });
+});
+
+describe('what is deliberately not retried', () => {
+  test('an HTTP error response is returned as-is, never retried', async () => {
+    // This is the important one. A 500 from the RPC is the server answering.
+    // Retrying it would turn a real failure into an intermittent success.
+    const stub = scriptedFetch(new Response('boom', { status: 500 }));
+    globalThis.fetch = stub;
+    installRpcRetry({ attempts: 5, baseDelayMs: 1, forceIpv4: false });
+
+    const res = await globalThis.fetch('http://rpc.invalid');
+    assert.equal(res.status, 500);
+    assert.equal(stub.calls, 1, 'an answered request must not be retried');
+  });
+
+  test('a non-transport error is rethrown on the first attempt', async () => {
+    const stub = scriptedFetch(transportError('ERR_INVALID_URL'));
+    globalThis.fetch = stub;
+    installRpcRetry({ attempts: 5, baseDelayMs: 1, forceIpv4: false });
+
+    await assert.rejects(() => globalThis.fetch('not a url'), /simulated ERR_INVALID_URL/);
+    assert.equal(stub.calls, 1);
+  });
+
+  test('an error with no code at all is not retried', async () => {
+    const stub = scriptedFetch(new Error('something else entirely'));
+    globalThis.fetch = stub;
+    installRpcRetry({ attempts: 5, baseDelayMs: 1, forceIpv4: false });
+
+    await assert.rejects(() => globalThis.fetch('http://rpc.invalid'), /something else entirely/);
+    assert.equal(stub.calls, 1);
+  });
+});
+
+describe('attempt bounds', () => {
+  test('attempts is a total, including the first call', async () => {
+    const stub = scriptedFetch(
+      transportError('ETIMEDOUT'),
+      transportError('ETIMEDOUT'),
+      transportError('ETIMEDOUT'),
+    );
+    globalThis.fetch = stub;
+    installRpcRetry({ attempts: 2, baseDelayMs: 1, forceIpv4: false });
+
+    await assert.rejects(() => globalThis.fetch('http://rpc.invalid'), /simulated ETIMEDOUT/);
+    assert.equal(stub.calls, 2, 'attempts: 2 means two calls, not two retries');
+  });
+
+  test('the last error is what surfaces after exhausting attempts', async () => {
+    const stub = scriptedFetch(transportError('ETIMEDOUT'), transportError('ECONNRESET'));
+    globalThis.fetch = stub;
+    installRpcRetry({ attempts: 2, baseDelayMs: 1, forceIpv4: false });
+
+    await assert.rejects(() => globalThis.fetch('http://rpc.invalid'), /simulated ECONNRESET/);
+  });
+
+  test('attempts: 1 disables retrying entirely', async () => {
+    const stub = scriptedFetch(transportError('ETIMEDOUT'), new Response('never reached'));
+    globalThis.fetch = stub;
+    installRpcRetry({ attempts: 1, baseDelayMs: 1, forceIpv4: false });
+
+    await assert.rejects(() => globalThis.fetch('http://rpc.invalid'));
+    assert.equal(stub.calls, 1);
+  });
+});
+
+describe('logging', () => {
+  test('each retry is logged once, with the code and the attempt', async () => {
+    const lines = [];
+    const stub = scriptedFetch(
+      transportError('ETIMEDOUT'),
+      transportError('ETIMEDOUT'),
+      new Response('ok'),
+    );
+    globalThis.fetch = stub;
+    installRpcRetry({ attempts: 4, baseDelayMs: 1, forceIpv4: false, log: l => lines.push(l) });
+
+    await globalThis.fetch('http://rpc.invalid/soroban');
+    assert.equal(lines.length, 2);
+    assert.match(lines[0], /ETIMEDOUT/);
+    assert.match(lines[0], /rpc\.invalid/);
+    assert.match(lines[0], /retry 1/);
+    assert.match(lines[1], /retry 2/);
+  });
+
+  test('a successful first attempt logs nothing', async () => {
+    const lines = [];
+    globalThis.fetch = scriptedFetch(new Response('ok'));
+    installRpcRetry({ attempts: 3, baseDelayMs: 1, forceIpv4: false, log: l => lines.push(l) });
+
+    await globalThis.fetch('http://rpc.invalid');
+    assert.deepEqual(lines, []);
+  });
+});
+
+describe('the wrapper does not leak', () => {
+  test('installing replaces globalThis.fetch, and the harness restores it', async () => {
+    assert.equal(globalThis.fetch, REAL_FETCH, 'beforeEach must hand back the real fetch');
+    globalThis.fetch = scriptedFetch(new Response('ok'));
+    installRpcRetry({ attempts: 1, baseDelayMs: 1, forceIpv4: false });
+    assert.notEqual(globalThis.fetch, REAL_FETCH);
+    // afterEach restores it; the assertion above in the next test proves it.
+  });
+
+  test('the previous test left the real fetch behind', () => {
+    assert.equal(globalThis.fetch, REAL_FETCH);
+  });
+});


### PR DESCRIPTION
Closes #2. Closes #3.

## Why

There were no tests in this repo. Every behavioural claim in the README — non-null `invalidReason` on every rejection, verbatim `payload: {transaction}` acceptance, pubnet refusing to start without its own secret — was asserted by someone having run `curl` once. That is the "CI theater" shape this project is trying to avoid, and it blocks #12, #13, #14 and #15.

## What changed

**`createApp()` extracted into `src/app.js`.** The routes can now be built and exercised without binding a port or holding a real signer. `src/server.js` is reduced to the process entrypoint — resolve config, build, listen, print the banner.

One deviation from the issue: it specified `createApp(config, facilitator, signers)`, and this is `createApp(config, facilitator)`. No route reads `signers` — the addresses reach the wire through `facilitator.getSupported()`, and `server.js` keeps them only for the boot banner. The reason is in the docstring rather than left to be rediscovered.

**54 tests**, no network, no funded account, no `.env`:

| Suite | Covers |
|---|---|
| `test/config.test.js` | secret validation and its `stellar keys generate` hint, the pubnet opt-in gate, port/fee/RPC defaults, API-key parsing |
| `test/app.test.js` | status codes, reason codes, pass-through fidelity, caller auth, `/supported` staying open |
| `test/rpc-retry.test.js` | what is retried, what deliberately is not, attempt bounds, logging, no wrapper leakage |

The facilitator is stubbed throughout. `ExactStellarScheme` is upstream's and is not retested here — reimplementing or re-verifying it is what this repo exists not to do.

**The retry boundary is the assertion that matters most.** An HTTP 500 from the RPC is the server *answering*; retrying it would convert a real failure into an intermittent success. `test/rpc-retry.test.js` pins that a 500 is returned as-is and called exactly once, so a future "let's just retry harder" change has to argue with a test.

**`npm run smoke` is gone.** It pointed at `scripts/smoke.mjs`, which does not exist — a broken advertised command. Replaced with `npm run e2e`, which points at the harness that does exist, and the README now documents commands that resolve.

## Verification

- `npm test` — 54 pass, 0 fail, ~400ms, from a clean clone with no network
- Server boots and `/supported` still emits `{"extra":{"areFeesSponsored":true}}`, so the refactor left the acceptance item intact
- `grep -rn smoke` finds nothing outside `node_modules`

## Notes for review

**Base branch is `feat/e2e-harness`, not `main`.** `src/rpc-retry.js` exists only there, and #2 requires covering it. That PR should land first, or these merge together.

**The tests pin today's 401 shape.** `requireApiKey` returns `{error, reason}` while everything else returns `{isValid, invalidReason}` — three response shapes for one client to parse. That is #6's problem, not this PR's; the assertion is written so #6 has to change it deliberately rather than silently.