### PR TITLE
Conformance harness, unit test suite, and CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Something is broken that is not a wire-format conformance failure
+title: ''
+labels: 'bug'
+---
+
+## What happened
+
+## What you expected instead
+
+## Reproducing it
+
+1.
+2.
+
+## Environment
+
+| | |
+|---|---|
+| Node version | |
+| Commit or version | |
+| Network | <!-- stellar:testnet / stellar:pubnet --> |
+| Deployment | <!-- local, docker, hosted --> |
+
+## Logs
+
+<!-- Redact FACILITATOR_SECRET and any API key before pasting. -->
+
+```
+```

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: x402 specification
+    url: https://github.com/x402-foundation/x402
+    about: Questions about the protocol itself, rather than this facilitator, belong upstream.

--- a/.github/ISSUE_TEMPLATE/conformance_failure.md
+++ b/.github/ISSUE_TEMPLATE/conformance_failure.md
@@ -1,0 +1,43 @@
+---
+name: Conformance failure
+about: A canonical x402 client did something this facilitator did not handle correctly
+title: 'conformance: '
+labels: 'area: facilitator'
+---
+
+<!--
+This is the most useful issue you can file here. The whole point of the service
+is that stock SDK code works against it unmodified, so a case where it does not
+is worth more than a feature request.
+-->
+
+## What you pointed at it
+
+| | |
+|---|---|
+| Client | <!-- e.g. @x402/core 2.21.0 --> |
+| Scheme / network | <!-- e.g. exact / stellar:testnet --> |
+| Facilitator URL or commit | |
+
+## What you expected
+
+<!-- Quote the spec or the package if you can. -->
+
+## What happened
+
+<!-- The actual request and response. Redact secrets, but do not paraphrase the
+     wire format — the exact field names are usually the whole issue. -->
+
+```http
+```
+
+## Reproducing it
+
+<!-- Ideally the smallest stock-SDK snippet that shows it. -->
+
+```js
+```
+
+## Anything else
+
+<!-- Settled transaction hash, ledger, timing — whatever you have. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+## What changed
+
+<!-- One or two sentences. What does this do that the tree did not do before? -->
+
+## Why
+
+<!-- The problem, not the patch. If it fixes an issue, link it: Closes #N -->
+
+## How it was verified
+
+<!-- Commands run and their result. "npm test passes" is fine; "should work" is not. -->
+
+- [ ] `npm test`
+- [ ] `npx eslint .`
+- [ ] `npx prettier --check .`
+
+## Wire format
+
+Does this change anything a client can observe — a route, a status code, a
+field name, a reason code, or the shape of a response?
+
+- [ ] No
+- [ ] Yes, and it is described below
+
+<!--
+Conformance here is judged at the wire level: reviewers point stock SDK code at
+the service rather than read a claim. A field renamed by accident is a
+conformance failure that passes every local test, so it needs saying out loud.
+-->
+
+## Anything a reviewer should push back on
+
+<!-- Shortcuts taken, assumptions made, things you were unsure about. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,87 @@
+name: CI
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+
+# A second push to a PR cancels the first: the older run's result is about code
+# nobody will merge.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          # ESLint 9 requires Node >= 22, so lint runs on 22 only. The test
+          # matrix below is what covers the >= 20 engines claim.
+          node-version: '22'
+          cache: npm
+      - run: npm ci
+      - run: npx eslint .
+
+  format:
+    name: format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+      - run: npm ci
+      # --check, never --write. CI reports; it does not silently rewrite the
+      # code under review.
+      - run: npx prettier --check .
+
+  test:
+    name: test (node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # package.json says engines >= 20. A claim nothing tests is a guess.
+        node: ['20', '22']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+      - run: npm ci
+      # No network, no funded account, no .env. The end-to-end conformance run
+      # needs testnet and lives in its own workflow.
+      - run: npm test
+
+  audit:
+    name: audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+      - run: npm ci
+      - run: npm audit --audit-level=high
+
+  licenses:
+    name: licenses
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+      - run: npm ci
+      # This project commits to a permissive OSI licence with no AGPL in the
+      # dependency path. That commitment is enforced here rather than asserted
+      # in a README.
+      - run: node scripts/check-licenses.mjs --list

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+node_modules
+package-lock.json
+
+# Prose is hand-tuned — centred HTML, tables, mermaid blocks. Reflowing it
+# produces large diffs that hide the change being reviewed, and formatting
+# markdown is not what this check is for.
+*.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "printWidth": 100,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "arrowParens": "avoid",
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -138,6 +138,26 @@ curl -s localhost:3402/supported | jq
 }
 ```
 
+### Tests
+
+```bash
+npm test          # unit tests — no network, no funded account, no .env
+npm run test:watch
+```
+
+The unit suite covers configuration resolution, the HTTP surface (status codes,
+reason codes, pass-through fidelity, caller auth) and the RPC retry wrapper. It
+stubs the facilitator throughout: `ExactStellarScheme` is upstream's and is not
+retested here.
+
+The end-to-end conformance run is separate, because it needs testnet and two
+funded accounts:
+
+```bash
+FACILITATOR_SECRET=$(stellar keys show facilitator) npm start &
+ALICE_SECRET=$(stellar keys show alice) npm run e2e
+```
+
 ### Configuration
 
 | Variable | Default | Notes |

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
   <h1>x402-facilitator-stellar</h1>
   <p><strong>An x402 facilitator for Stellar — verify, settle, supported</strong></p>
   <p>
+    <img src="https://img.shields.io/github/actions/workflow/status/accensa/x402-facilitator-stellar/ci.yml?branch=main" alt="CI Status" />
     <img src="https://img.shields.io/badge/status-conformance%20spike-orange.svg" alt="Status: conformance spike" />
     <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License Apache 2.0" />
     <img src="https://img.shields.io/badge/stellar-testnet-success.svg" alt="Stellar testnet" />

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,60 @@
+/**
+ * Deliberately small.
+ *
+ * This is a five-file service whose job is to be a thin, readable transport
+ * over @x402/stellar. Importing a forty-rule preset into it would generate
+ * churn that has nothing to do with correctness, and would make the diff on a
+ * conformance fix harder to read. The rules here are the ones that catch real
+ * mistakes in this codebase: unused bindings left behind by a refactor, and
+ * accidental globals.
+ *
+ * Formatting is Prettier's job and is checked separately, so nothing here
+ * concerns itself with whitespace.
+ */
+export default [
+  {
+    files: ['**/*.js', '**/*.mjs'],
+    languageOptions: {
+      ecmaVersion: 2023,
+      sourceType: 'module',
+      globals: {
+        // Node globals used across src/, scripts/ and test/.
+        process: 'readonly',
+        console: 'readonly',
+        globalThis: 'readonly',
+        fetch: 'readonly',
+        Response: 'readonly',
+        Request: 'readonly',
+        AbortController: 'readonly',
+        setTimeout: 'readonly',
+        clearTimeout: 'readonly',
+        Buffer: 'readonly',
+        URL: 'readonly',
+      },
+    },
+    linterOptions: {
+      reportUnusedDisableDirectives: 'error',
+    },
+    rules: {
+      // An import left behind by a refactor is the failure mode this catches:
+      // it reads as a dependency that is no longer one.
+      'no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+      'no-undef': 'error',
+      'no-var': 'error',
+      'prefer-const': 'error',
+      eqeqeq: ['error', 'smart'],
+
+      // Silent failure is the thing this repo is most trying to avoid, and an
+      // empty catch is how it usually arrives. `catch {}` with a comment
+      // explaining why is still allowed.
+      'no-empty': ['error', { allowEmptyCatch: false }],
+
+      // await inside a loop is correct in the settle path and in the retry
+      // wrapper; flagging it would be noise.
+      'no-await-in-loop': 'off',
+    },
+  },
+  {
+    ignores: ['node_modules/**', 'coverage/**'],
+  },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,9 @@
         "undici": "^7.29.0"
       },
       "devDependencies": {
-        "@x402/express": "^2.21.0"
+        "@x402/express": "^2.21.0",
+        "eslint": "^9.39.5",
+        "prettier": "^3.9.6"
       },
       "engines": {
         "node": ">=20"
@@ -28,6 +30,240 @@
       "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
     },
     "node_modules/@noble/ciphers": {
       "version": "1.3.0",
@@ -239,6 +475,20 @@
         "node": ">=22.0.0"
       }
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@x402/core": {
       "version": "2.21.0",
       "resolved": "https://registry.npmjs.org/@x402/core/-/core-2.21.0.tgz",
@@ -334,6 +584,29 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -363,12 +636,35 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/apg-js": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/apg-js/-/apg-js-4.4.0.tgz",
       "integrity": "sha512-fefmXFknJmtgtNEXfPwZKYkMFX4Fyeyz+fNF6JWp87biGOPslJbCBVU158zvKRZfHBKnJDy8CMM40oLFGkXT8Q==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -387,6 +683,13 @@
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/base32.js": {
       "version": "0.1.0",
@@ -460,6 +763,17 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -522,6 +836,53 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -542,6 +903,13 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
@@ -583,6 +951,21 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -599,6 +982,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -698,6 +1088,197 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -785,6 +1366,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
@@ -811,6 +1406,19 @@
         "is-retry-allowed": "^3.0.0"
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -831,6 +1439,44 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -953,6 +1599,32 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -963,6 +1635,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-symbols": {
@@ -1073,6 +1755,43 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1086,6 +1805,29 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-promise": {
@@ -1105,6 +1847,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/isows": {
       "version": "1.0.7",
@@ -1132,10 +1881,94 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1198,10 +2031,30 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -1244,6 +2097,24 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/ox": {
@@ -1306,6 +2177,51 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1313,6 +2229,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-to-regexp": {
@@ -1323,6 +2259,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/proxy-addr": {
@@ -1345,6 +2307,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -1399,6 +2371,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/router": {
@@ -1473,6 +2455,29 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.1",
@@ -1567,6 +2572,32 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1582,6 +2613,19 @@
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
       "dev": true,
       "license": "Unlicense"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/type-is": {
       "version": "2.1.0",
@@ -1642,6 +2686,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/vary": {
@@ -1713,6 +2767,32 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -1739,6 +2819,19 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,11 @@
     "dev": "node --watch src/server.js",
     "test": "node --test test/",
     "test:watch": "node --test --watch test/",
-    "e2e": "node scripts/e2e.mjs"
+    "e2e": "node scripts/e2e.mjs",
+    "lint": "eslint .",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "licenses": "node scripts/check-licenses.mjs"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^16.2.0",
@@ -23,6 +27,8 @@
     "undici": "^7.29.0"
   },
   "devDependencies": {
-    "@x402/express": "^2.21.0"
+    "@x402/express": "^2.21.0",
+    "eslint": "^9.39.5",
+    "prettier": "^3.9.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "start": "node src/server.js",
     "dev": "node --watch src/server.js",
-    "test": "node --test test/",
-    "test:watch": "node --test --watch test/",
+    "test": "node --test test/*.test.js",
+    "test:watch": "node --test --watch test/*.test.js",
     "e2e": "node scripts/e2e.mjs",
     "lint": "eslint .",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "scripts": {
     "start": "node src/server.js",
     "dev": "node --watch src/server.js",
-    "smoke": "node scripts/smoke.mjs"
+    "test": "node --test test/",
+    "test:watch": "node --test --watch test/",
+    "e2e": "node scripts/e2e.mjs"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^16.2.0",

--- a/scripts/check-licenses.mjs
+++ b/scripts/check-licenses.mjs
@@ -1,0 +1,138 @@
+/**
+ * Fails the build if a copyleft licence appears anywhere in the dependency
+ * tree.
+ *
+ * A permissive OSI licence with no AGPL in the dependency path is a hard
+ * requirement for this project, not a preference — an AGPL dependency would
+ * make the service undistributable on the terms it promises. That requirement
+ * is currently a sentence in a README, and a sentence is not a check. This is
+ * the check.
+ *
+ * Deliberately dependency-free. Pulling in a licence-scanning package to
+ * enforce a licence policy adds another package to the tree the policy is
+ * about, and the whole job is reading `license` out of every package.json.
+ *
+ * Usage:
+ *   node scripts/check-licenses.mjs           # fail on a forbidden licence
+ *   node scripts/check-licenses.mjs --list    # print the full inventory
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * Licences that must never appear.
+ *
+ * AGPL is the named one. SSPL, BUSL and CC-BY-NC are here because they are
+ * likewise not permissive OSI licences and would fail the same requirement for
+ * the same reason — better to catch them now than to discover the rule was
+ * written too narrowly.
+ */
+const FORBIDDEN = [/\bAGPL/i, /\bSSPL/i, /\bBUSL/i, /\bCC-BY-NC/i];
+
+/** Matched only when a package declares nothing else — see classify(). */
+const WEAK_COPYLEFT = [/\bGPL-/i, /\bLGPL/i, /\bMPL-/i, /\bEPL-/i];
+
+/**
+ * Reads the licence of one package, tolerating every shape npm has ever used:
+ * a string, an SPDX expression, a {type} object, or a legacy `licenses` array.
+ */
+function licenseOf(pkg) {
+  if (typeof pkg.license === 'string') return pkg.license;
+  if (pkg.license && typeof pkg.license.type === 'string') return pkg.license.type;
+  if (Array.isArray(pkg.licenses)) {
+    return pkg.licenses.map(l => (typeof l === 'string' ? l : l.type)).join(' OR ');
+  }
+  return 'UNKNOWN';
+}
+
+/** Walks node_modules, including scoped and nested trees. */
+function* packages(dir) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    // No node_modules at this level. Not an error: a package with no
+    // dependencies of its own simply has none.
+    return;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+    if (entry.name === '.bin' || entry.name === '.cache') continue;
+
+    const full = join(dir, entry.name);
+
+    if (entry.name.startsWith('@')) {
+      yield* packages(full);
+      continue;
+    }
+
+    try {
+      const manifest = JSON.parse(readFileSync(join(full, 'package.json'), 'utf8'));
+      if (manifest.name) {
+        yield { name: manifest.name, version: manifest.version, license: licenseOf(manifest) };
+      }
+    } catch {
+      // Not a package directory, or an unreadable manifest. Skipping is right:
+      // this walks a directory tree, not a resolved dependency graph.
+    }
+
+    const nested = join(full, 'node_modules');
+    try {
+      if (statSync(nested).isDirectory()) yield* packages(nested);
+    } catch {
+      // No nested tree.
+    }
+  }
+}
+
+function classify(license) {
+  if (FORBIDDEN.some(re => re.test(license))) return 'forbidden';
+  // A dual licence offering a permissive option is fine — we take that option.
+  if (WEAK_COPYLEFT.some(re => re.test(license)) && !/\bOR\b/i.test(license)) return 'review';
+  if (license === 'UNKNOWN') return 'review';
+  return 'ok';
+}
+
+const found = [...packages(join(ROOT, 'node_modules'))];
+if (found.length === 0) {
+  console.error('No packages found. Run npm ci first.');
+  process.exit(2);
+}
+
+const forbidden = [];
+const review = [];
+for (const pkg of found) {
+  const verdict = classify(pkg.license);
+  if (verdict === 'forbidden') forbidden.push(pkg);
+  else if (verdict === 'review') review.push(pkg);
+}
+
+if (process.argv.includes('--list')) {
+  const counts = new Map();
+  for (const pkg of found) counts.set(pkg.license, (counts.get(pkg.license) ?? 0) + 1);
+  for (const [license, n] of [...counts].sort((a, b) => b[1] - a[1])) {
+    console.log(`${String(n).padStart(4)}  ${license}`);
+  }
+  console.log(`\n${found.length} packages`);
+}
+
+if (review.length > 0) {
+  console.log(`\n${review.length} package(s) need a human look (not a failure):`);
+  for (const pkg of review) console.log(`  ${pkg.name}@${pkg.version} — ${pkg.license}`);
+}
+
+if (forbidden.length > 0) {
+  console.error(`\nFORBIDDEN LICENCE in the dependency path:`);
+  for (const pkg of forbidden) console.error(`  ${pkg.name}@${pkg.version} — ${pkg.license}`);
+  console.error(
+    '\nThis project commits to a permissive OSI licence with no AGPL in the ' +
+      'dependency path. Remove the dependency or find a permissive alternative.',
+  );
+  process.exit(1);
+}
+
+console.log(`\nLicence check passed — ${found.length} packages, none forbidden.`);

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -43,8 +43,8 @@ installRpcRetry({ log: msg => console.log(`    ${msg}`) });
 
 const NETWORK = 'stellar:testnet';
 const XLM_SAC = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC';
-const MERCHANT = process.env.MERCHANT_ADDRESS
-  ?? 'GCALKSGAZRJLSUEJT3M5W6LN4R7XQOLIRCOS6ZA6EDZVTZDBIIPPFKJ6';
+const MERCHANT =
+  process.env.MERCHANT_ADDRESS ?? 'GCALKSGAZRJLSUEJT3M5W6LN4R7XQOLIRCOS6ZA6EDZVTZDBIIPPFKJ6';
 const FACILITATOR_URL = process.env.FACILITATOR_URL ?? 'http://localhost:3402';
 const RESOURCE_PORT = Number(process.env.RESOURCE_PORT ?? 3401);
 
@@ -155,11 +155,11 @@ try {
   console.log(`    status=${unpaid.status}`);
   if (unpaid.status !== 402) throw new Error(`expected 402, got ${unpaid.status}`);
 
-  const body = await unpaid.clone().json().catch(() => undefined);
-  const paymentRequired = http.getPaymentRequiredResponse(
-    name => unpaid.headers.get(name),
-    body,
-  );
+  const body = await unpaid
+    .clone()
+    .json()
+    .catch(() => undefined);
+  const paymentRequired = http.getPaymentRequiredResponse(name => unpaid.headers.get(name), body);
   const req0 = paymentRequired.accepts?.[0];
   console.log(`    asset=${req0?.asset}`);
   console.log(`    amount=${req0?.maxAmountRequired}  payTo=${req0?.payTo}`);

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,131 @@
+/**
+ * The HTTP surface: /verify, /settle, /supported.
+ *
+ * @x402/core ships no facilitator router — it gives you x402Facilitator with
+ * verify(), settle() and getSupported(), and the transport is yours. This file
+ * is that transport and nothing else.
+ *
+ * Conformance is judged at the wire level: reviewers point stock SDK code at
+ * the deliverable rather than read a conformance claim. So the rules here are
+ * narrow and deliberate:
+ *
+ *   - the spec's `payload: {transaction}` shape is accepted verbatim, unwrapped
+ *     and un-renamed;
+ *   - every rejection carries a non-null reason code, including transport-level
+ *     ones, so an agent can branch on a code instead of parsing prose;
+ *   - responses are passed through from the scheme untouched.
+ *
+ * Separated from server.js so the app can be built and exercised in a test
+ * without binding a port or holding a real signer. server.js is the process
+ * entrypoint and does nothing this file does.
+ */
+import express from 'express';
+
+/**
+ * Builds the Express app.
+ *
+ * `signers` is deliberately not a parameter: no route reads it. /supported is
+ * assembled by the facilitator itself, so the signer addresses reach the wire
+ * through getSupported() rather than through here. server.js keeps them only to
+ * print the boot banner.
+ *
+ * @param {object} config - resolved config from resolveConfig()
+ * @param {{verify: Function, settle: Function, getSupported: Function}} facilitator
+ * @returns {import('express').Express}
+ */
+export function createApp(config, facilitator) {
+  const app = express();
+  app.use(express.json({ limit: '256kb' }));
+
+  /**
+   * Caller authentication.
+   *
+   * Unset means open. That is the correct default for a free testnet instance —
+   * testnet has to be usable without friction — and it is documented rather
+   * than silent: the server logs at boot when it is running open.
+   */
+  function requireApiKey(req, res, next) {
+    if (config.apiKeys.length === 0) return next();
+    const presented = req.get('authorization')?.replace(/^Bearer /i, '');
+    if (!presented || !config.apiKeys.includes(presented)) {
+      return res.status(401).json({ error: 'unauthorized', reason: 'invalid_api_key' });
+    }
+    next();
+  }
+
+  /**
+   * Both /verify and /settle take {paymentPayload, paymentRequirements}.
+   * Returning a non-null reason on a malformed body matters as much as on a
+   * failed verification — a null reason anywhere is an acceptance failure.
+   */
+  function readPaymentBody(req, res) {
+    const { paymentPayload, paymentRequirements } = req.body ?? {};
+    if (!paymentPayload || !paymentRequirements) {
+      res.status(400).json({
+        isValid: false,
+        invalidReason: 'invalid_request',
+        invalidMessage: 'body must contain paymentPayload and paymentRequirements',
+      });
+      return null;
+    }
+    return { paymentPayload, paymentRequirements };
+  }
+
+  app.get('/healthz', (_req, res) => res.json({ ok: true }));
+
+  /**
+   * GET /supported
+   *
+   * Must emit the Stellar `extra` block including areFeesSponsored — an explicit
+   * acceptance item. getSupported() assembles it from the registered schemes, so
+   * it is passed through rather than hand-built.
+   */
+  app.get('/supported', (_req, res) => {
+    res.json(facilitator.getSupported());
+  });
+
+  app.post('/verify', requireApiKey, async (req, res) => {
+    const body = readPaymentBody(req, res);
+    if (!body) return;
+    try {
+      const result = await facilitator.verify(body.paymentPayload, body.paymentRequirements);
+      res.json(result);
+    } catch (err) {
+      // An exception must not become a 500 with an empty body: to a client that
+      // is indistinguishable from the service being down, and it carries no
+      // reason code. Shape it like a verification failure instead.
+      //
+      // Note ExactStellarScheme already absorbs its own internal exceptions and
+      // returns invalidReason "unexpected_verify_error" rather than throwing, so
+      // this path only catches failures above the scheme — an unregistered
+      // scheme/network pair, for instance. A distinct code keeps the two
+      // distinguishable to a client.
+      res.status(200).json({
+        isValid: false,
+        invalidReason: 'facilitator_error',
+        invalidMessage: err instanceof Error ? err.message : String(err),
+      });
+    }
+  });
+
+  app.post('/settle', requireApiKey, async (req, res) => {
+    const body = readPaymentBody(req, res);
+    if (!body) return;
+    try {
+      const result = await facilitator.settle(body.paymentPayload, body.paymentRequirements);
+      res.json(result);
+    } catch (err) {
+      // SettleResponse requires `transaction` and `network` even on failure, so
+      // a client can attribute the failure without correlating out of band.
+      res.status(200).json({
+        success: false,
+        errorReason: 'facilitator_error',
+        errorMessage: err instanceof Error ? err.message : String(err),
+        transaction: '',
+        network: req.body?.paymentRequirements?.network,
+      });
+    }
+  });
+
+  return app;
+}

--- a/src/server.js
+++ b/src/server.js
@@ -1,23 +1,14 @@
 /**
- * The HTTP surface: /verify, /settle, /supported.
+ * Process entrypoint.
  *
- * @x402/core ships no facilitator router — it gives you x402Facilitator with
- * verify(), settle() and getSupported(), and the transport is yours. This file
- * is that transport and nothing else.
- *
- * Conformance is judged at the wire level (RFP §3.6): reviewers point stock SDK
- * code at the deliverable rather than read a conformance claim. So the rules
- * here are narrow and deliberate:
- *
- *   - the spec's `payload: {transaction}` shape is accepted verbatim, unwrapped
- *     and un-renamed;
- *   - every rejection carries a non-null `reason`, including transport-level
- *     ones, so an agent can branch on a code instead of parsing prose;
- *   - responses are passed through from the scheme untouched.
+ * Resolves configuration, builds the facilitator and the HTTP app, and binds a
+ * port. The routes themselves live in app.js, so they can be exercised in a
+ * test without a listener or a real signer — this file is only the wiring that
+ * a test has no use for.
  */
-import express from 'express';
 import { resolveConfig } from './config.js';
 import { buildFacilitator } from './facilitator.js';
+import { createApp } from './app.js';
 import { installRpcRetry } from './rpc-retry.js';
 
 // Must run before the scheme makes any RPC call. Retries connection-level
@@ -26,99 +17,7 @@ installRpcRetry({ log: msg => console.warn(`  ${msg}`) });
 
 const config = resolveConfig();
 const { facilitator, signers } = buildFacilitator(config);
-
-const app = express();
-app.use(express.json({ limit: '256kb' }));
-
-/**
- * Caller authentication.
- *
- * Unset means open. That is the correct default for a free testnet instance —
- * the RFP requires testnet be usable without friction — and it is documented
- * rather than silent: the server logs at boot when it is running open.
- */
-function requireApiKey(req, res, next) {
-  if (config.apiKeys.length === 0) return next();
-  const presented = req.get('authorization')?.replace(/^Bearer /i, '');
-  if (!presented || !config.apiKeys.includes(presented)) {
-    return res.status(401).json({ error: 'unauthorized', reason: 'invalid_api_key' });
-  }
-  next();
-}
-
-/**
- * Both /verify and /settle take {paymentPayload, paymentRequirements}.
- * Returning a non-null reason on a malformed body matters as much as on a
- * failed verification — a null reason anywhere is an acceptance failure.
- */
-function readPaymentBody(req, res) {
-  const { paymentPayload, paymentRequirements } = req.body ?? {};
-  if (!paymentPayload || !paymentRequirements) {
-    res.status(400).json({
-      isValid: false,
-      invalidReason: 'invalid_request',
-      invalidMessage: 'body must contain paymentPayload and paymentRequirements',
-    });
-    return null;
-  }
-  return { paymentPayload, paymentRequirements };
-}
-
-app.get('/healthz', (_req, res) => res.json({ ok: true }));
-
-/**
- * GET /supported
- *
- * Must emit the Stellar `extra` block including areFeesSponsored — an explicit
- * acceptance item. getSupported() assembles it from the registered schemes, so
- * it is passed through rather than hand-built.
- */
-app.get('/supported', (_req, res) => {
-  res.json(facilitator.getSupported());
-});
-
-app.post('/verify', requireApiKey, async (req, res) => {
-  const body = readPaymentBody(req, res);
-  if (!body) return;
-  try {
-    const result = await facilitator.verify(body.paymentPayload, body.paymentRequirements);
-    res.json(result);
-  } catch (err) {
-    // An exception must not become a 500 with an empty body: to a client that
-    // is indistinguishable from the service being down, and it carries no
-    // reason code. Shape it like a verification failure instead.
-    //
-    // Note ExactStellarScheme already absorbs its own internal exceptions and
-    // returns invalidReason "unexpected_verify_error" rather than throwing, so
-    // this path only catches failures above the scheme — an unregistered
-    // scheme/network pair, for instance. A distinct code keeps the two
-    // distinguishable to a client.
-    res.status(200).json({
-      isValid: false,
-      invalidReason: 'facilitator_error',
-      invalidMessage: err instanceof Error ? err.message : String(err),
-    });
-  }
-});
-
-app.post('/settle', requireApiKey, async (req, res) => {
-  const body = readPaymentBody(req, res);
-  if (!body) return;
-  try {
-    const result = await facilitator.settle(body.paymentPayload, body.paymentRequirements);
-    res.json(result);
-  } catch (err) {
-    // SettleResponse requires `transaction` and `network` even on failure, so
-    // a client can attribute the failure without correlating out of band.
-    res.status(200).json({
-      success: false,
-      errorReason: 'facilitator_error',
-      errorMessage: err instanceof Error ? err.message : String(err),
-      transaction: '',
-      network: req.body?.paymentRequirements?.network,
-    });
-  }
-});
+const app = createApp(config, facilitator);
 
 app.listen(config.port, () => {
   console.log(`x402 Stellar facilitator listening on :${config.port}`);

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -296,7 +296,11 @@ describe('caller authentication', () => {
 
     test('both /verify and /settle are protected', async () => {
       for (const route of ['/verify', '/settle']) {
-        assert.equal((await app.post(route, VALID_BODY)).status, 401, `${route} must require a key`);
+        assert.equal(
+          (await app.post(route, VALID_BODY)).status,
+          401,
+          `${route} must require a key`,
+        );
       }
     });
   });

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -1,0 +1,303 @@
+/**
+ * The HTTP surface.
+ *
+ * The facilitator is stubbed throughout: what is under test is the transport —
+ * status codes, reason codes, pass-through fidelity and caller auth — not
+ * ExactStellarScheme, which is upstream's and is not reimplemented here.
+ *
+ * Nothing in this file touches the network or needs a funded account.
+ */
+import { test, describe, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { createApp } from '../src/app.js';
+
+/** A payment body that satisfies readPaymentBody. Contents are never inspected. */
+const VALID_BODY = {
+  paymentPayload: { x402Version: 2, scheme: 'exact', network: 'stellar:testnet' },
+  paymentRequirements: { scheme: 'exact', network: 'stellar:testnet' },
+};
+
+/**
+ * Boots an app on an ephemeral port and returns a fetch bound to it.
+ *
+ * Port 0 rather than 3402: tests must not collide with a facilitator the
+ * developer happens to have running.
+ */
+async function serve(config, facilitator) {
+  const app = createApp({ apiKeys: [], ...config }, facilitator);
+  const server = app.listen(0);
+  await new Promise(resolve => server.once('listening', resolve));
+  const base = `http://127.0.0.1:${server.address().port}`;
+
+  return {
+    close: () => new Promise(resolve => server.close(resolve)),
+    get: path => fetch(`${base}${path}`),
+    post: (path, body, headers = {}) =>
+      fetch(`${base}${path}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', ...headers },
+        body: typeof body === 'string' ? body : JSON.stringify(body),
+      }),
+  };
+}
+
+/** A facilitator that records its calls and returns whatever it was given. */
+function stubFacilitator(overrides = {}) {
+  const calls = [];
+  return {
+    calls,
+    getSupported: () => ({ kinds: [], extensions: [], signers: {} }),
+    verify: async (payload, requirements) => {
+      calls.push(['verify', payload, requirements]);
+      return { isValid: true };
+    },
+    settle: async (payload, requirements) => {
+      calls.push(['settle', payload, requirements]);
+      return { success: true, transaction: 'abc', network: requirements.network };
+    },
+    ...overrides,
+  };
+}
+
+describe('GET /healthz', () => {
+  let app;
+  before(async () => {
+    app = await serve({}, stubFacilitator());
+  });
+  after(() => app.close());
+
+  test('reports liveness', async () => {
+    const res = await app.get('/healthz');
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { ok: true });
+  });
+});
+
+describe('GET /supported', () => {
+  test('passes getSupported() through untouched, extra block and all', async () => {
+    // The Stellar extra block carrying areFeesSponsored is an explicit
+    // acceptance item, so the transport must not reshape it on the way out.
+    const supported = {
+      kinds: [
+        {
+          x402Version: 2,
+          scheme: 'exact',
+          network: 'stellar:testnet',
+          extra: { areFeesSponsored: true },
+        },
+      ],
+      extensions: [],
+      signers: { 'stellar:*': ['GABC'] },
+    };
+    const app = await serve({}, stubFacilitator({ getSupported: () => supported }));
+    try {
+      const res = await app.get('/supported');
+      assert.equal(res.status, 200);
+      assert.deepEqual(await res.json(), supported);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('is reachable without an API key even when keys are configured', async () => {
+    // A client has to be able to read /supported before it has any
+    // relationship with us. Putting it behind auth breaks discovery.
+    const app = await serve({ apiKeys: ['k1'] }, stubFacilitator());
+    try {
+      assert.equal((await app.get('/supported')).status, 200);
+      assert.equal((await app.get('/healthz')).status, 200);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('malformed bodies always carry a reason', () => {
+  let app;
+  before(async () => {
+    app = await serve({}, stubFacilitator());
+  });
+  after(() => app.close());
+
+  for (const route of ['/verify', '/settle']) {
+    for (const [label, body] of [
+      ['an empty object', {}],
+      ['paymentPayload only', { paymentPayload: VALID_BODY.paymentPayload }],
+      ['paymentRequirements only', { paymentRequirements: VALID_BODY.paymentRequirements }],
+      ['a null payload', { paymentPayload: null, paymentRequirements: {} }],
+    ]) {
+      test(`POST ${route} with ${label} → 400 with a non-null invalidReason`, async () => {
+        const res = await app.post(route, body);
+        assert.equal(res.status, 400);
+        const json = await res.json();
+        assert.equal(json.isValid, false);
+        // A null reason anywhere is an acceptance failure — an agent has to be
+        // able to branch on a code rather than parse prose.
+        assert.equal(json.invalidReason, 'invalid_request');
+        assert.ok(json.invalidMessage, 'invalidMessage must not be empty');
+      });
+    }
+  }
+});
+
+describe('POST /verify', () => {
+  test('passes the payload and requirements through unmodified', async () => {
+    const facilitator = stubFacilitator();
+    const app = await serve({}, facilitator);
+    try {
+      const res = await app.post('/verify', VALID_BODY);
+      assert.equal(res.status, 200);
+      assert.deepEqual(await res.json(), { isValid: true });
+
+      const [name, payload, requirements] = facilitator.calls[0];
+      assert.equal(name, 'verify');
+      // Unwrapped, un-renamed, verbatim: the spec's payload shape reaches the
+      // scheme exactly as it arrived on the wire.
+      assert.deepEqual(payload, VALID_BODY.paymentPayload);
+      assert.deepEqual(requirements, VALID_BODY.paymentRequirements);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('a thrown facilitator becomes a 200 verification failure, not a 500', async () => {
+    // A 500 with an empty body is indistinguishable from the service being
+    // down and carries no reason code.
+    const app = await serve(
+      {},
+      stubFacilitator({
+        verify: async () => {
+          throw new Error('no scheme registered for stellar:pubnet');
+        },
+      }),
+    );
+    try {
+      const res = await app.post('/verify', VALID_BODY);
+      assert.equal(res.status, 200);
+      const json = await res.json();
+      assert.equal(json.isValid, false);
+      assert.equal(json.invalidReason, 'facilitator_error');
+      assert.match(json.invalidMessage, /no scheme registered/);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('a non-Error throw still produces a reason and a message', async () => {
+    const app = await serve(
+      {},
+      stubFacilitator({
+        verify: async () => {
+          throw 'a bare string';
+        },
+      }),
+    );
+    try {
+      const json = await (await app.post('/verify', VALID_BODY)).json();
+      assert.equal(json.invalidReason, 'facilitator_error');
+      assert.equal(json.invalidMessage, 'a bare string');
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('POST /settle', () => {
+  test('passes the scheme result through untouched', async () => {
+    const app = await serve({}, stubFacilitator());
+    try {
+      const res = await app.post('/settle', VALID_BODY);
+      assert.equal(res.status, 200);
+      assert.deepEqual(await res.json(), {
+        success: true,
+        transaction: 'abc',
+        network: 'stellar:testnet',
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('a thrown facilitator still returns transaction and network', async () => {
+    // SettleResponse requires both even on failure, so a client can attribute
+    // the failure without correlating out of band.
+    const app = await serve(
+      {},
+      stubFacilitator({
+        settle: async () => {
+          throw new Error('rpc unreachable');
+        },
+      }),
+    );
+    try {
+      const res = await app.post('/settle', VALID_BODY);
+      assert.equal(res.status, 200);
+      const json = await res.json();
+      assert.equal(json.success, false);
+      assert.equal(json.errorReason, 'facilitator_error');
+      assert.match(json.errorMessage, /rpc unreachable/);
+      assert.equal(json.transaction, '');
+      assert.equal(json.network, 'stellar:testnet');
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('caller authentication', () => {
+  test('with no keys configured, /verify is open', async () => {
+    const app = await serve({ apiKeys: [] }, stubFacilitator());
+    try {
+      assert.equal((await app.post('/verify', VALID_BODY)).status, 200);
+    } finally {
+      await app.close();
+    }
+  });
+
+  describe('with keys configured', () => {
+    let app;
+    before(async () => {
+      app = await serve({ apiKeys: ['k1', 'k2'] }, stubFacilitator());
+    });
+    after(() => app.close());
+
+    test('a correct Bearer key is accepted', async () => {
+      const res = await app.post('/verify', VALID_BODY, { authorization: 'Bearer k1' });
+      assert.equal(res.status, 200);
+    });
+
+    test('every configured key works, not just the first', async () => {
+      const res = await app.post('/verify', VALID_BODY, { authorization: 'Bearer k2' });
+      assert.equal(res.status, 200);
+    });
+
+    test('the Bearer prefix is matched case-insensitively', async () => {
+      const res = await app.post('/verify', VALID_BODY, { authorization: 'bearer k1' });
+      assert.equal(res.status, 200);
+    });
+
+    test('a missing header is rejected with a reason', async () => {
+      const res = await app.post('/verify', VALID_BODY);
+      assert.equal(res.status, 401);
+      assert.equal((await res.json()).reason, 'invalid_api_key');
+    });
+
+    test('a wrong key is rejected', async () => {
+      const res = await app.post('/settle', VALID_BODY, { authorization: 'Bearer nope' });
+      assert.equal(res.status, 401);
+    });
+
+    test('auth is checked before the body is read', async () => {
+      // Otherwise a malformed body from an unauthenticated caller leaks which
+      // validation it failed.
+      const res = await app.post('/verify', {}, { authorization: 'Bearer nope' });
+      assert.equal(res.status, 401);
+    });
+
+    test('both /verify and /settle are protected', async () => {
+      for (const route of ['/verify', '/settle']) {
+        assert.equal((await app.post(route, VALID_BODY)).status, 401, `${route} must require a key`);
+      }
+    });
+  });
+});

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,118 @@
+/**
+ * resolveConfig / resolveNetworks.
+ *
+ * Both take an env object rather than reading process.env, which is what makes
+ * them testable at all — and is the reason a misconfiguration fails at boot
+ * rather than on the first payment.
+ */
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveConfig, resolveNetworks, TESTNET, PUBNET } from '../src/config.js';
+
+/** A minimal valid environment. Tests override single keys off this. */
+const BASE = { FACILITATOR_SECRET: 'SAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' };
+
+describe('resolveConfig — the secret', () => {
+  test('a missing secret throws, and the message says how to make one', () => {
+    assert.throws(
+      () => resolveConfig({}),
+      err => {
+        assert.match(err.message, /FACILITATOR_SECRET is required/);
+        // The hint matters more than the error: a first-run operator has no
+        // idea where an S... key comes from.
+        assert.match(err.message, /stellar keys generate facilitator/);
+        return true;
+      },
+    );
+  });
+
+  test('a secret that is not an S... key is rejected', () => {
+    // A public key is the mistake people actually make, not random junk.
+    assert.throws(
+      () => resolveConfig({ FACILITATOR_SECRET: 'GABCDEF' }),
+      /must be a Stellar secret key \(starts with S\)/,
+    );
+  });
+
+  test('an S... key is accepted', () => {
+    assert.equal(resolveConfig(BASE).secret, BASE.FACILITATOR_SECRET);
+  });
+});
+
+describe('resolveNetworks — pubnet is opt-in and needs its own signer', () => {
+  test('defaults to testnet only', () => {
+    assert.deepEqual(resolveNetworks({}), [TESTNET]);
+  });
+
+  test('ENABLE_PUBNET without a pubnet secret refuses, naming the risk', () => {
+    assert.throws(
+      () => resolveNetworks({ ENABLE_PUBNET: 'true' }),
+      err => {
+        assert.match(err.message, /FACILITATOR_SECRET_PUBNET is unset/);
+        // Refusing is the point: serving pubnet with the testnet signer loses
+        // real money, so the message has to say that rather than just fail.
+        assert.match(err.message, /Refusing to serve pubnet with the testnet signer/);
+        return true;
+      },
+    );
+  });
+
+  test('ENABLE_PUBNET with a pubnet secret serves both networks', () => {
+    assert.deepEqual(
+      resolveNetworks({ ENABLE_PUBNET: 'true', FACILITATOR_SECRET_PUBNET: 'SPUB' }),
+      [TESTNET, PUBNET],
+    );
+  });
+
+  test('only the exact string "true" opts in — not "1", "yes" or "TRUE"', () => {
+    // A loose truthiness check here would let a typo enable mainnet.
+    for (const value of ['1', 'yes', 'TRUE', 'True', '']) {
+      assert.deepEqual(
+        resolveNetworks({ ENABLE_PUBNET: value, FACILITATOR_SECRET_PUBNET: 'SPUB' }),
+        [TESTNET],
+        `ENABLE_PUBNET=${JSON.stringify(value)} must not enable pubnet`,
+      );
+    }
+  });
+});
+
+describe('resolveConfig — defaults', () => {
+  test('port defaults to 3402 and is read from PORT', () => {
+    assert.equal(resolveConfig(BASE).port, 3402);
+    assert.equal(resolveConfig({ ...BASE, PORT: '8080' }).port, 8080);
+  });
+
+  test('the fee ceiling defaults to 50000 stroops and is configurable', () => {
+    assert.equal(resolveConfig(BASE).maxTransactionFeeStroops, 50_000);
+    assert.equal(
+      resolveConfig({ ...BASE, MAX_TX_FEE_STROOPS: '120000' }).maxTransactionFeeStroops,
+      120_000,
+    );
+  });
+
+  test('rpcUrl is undefined unless set, so the package default applies', () => {
+    assert.equal(resolveConfig(BASE).rpcUrl, undefined);
+    assert.equal(
+      resolveConfig({ ...BASE, STELLAR_RPC_URL: 'https://rpc.example' }).rpcUrl,
+      'https://rpc.example',
+    );
+  });
+});
+
+describe('resolveConfig — API keys', () => {
+  test('unset means open, represented as an empty list', () => {
+    assert.deepEqual(resolveConfig(BASE).apiKeys, []);
+  });
+
+  test('keys are split, trimmed, and empty entries dropped', () => {
+    assert.deepEqual(
+      resolveConfig({ ...BASE, FACILITATOR_API_KEYS: ' k1 , k2,,  k3  ,' }).apiKeys,
+      ['k1', 'k2', 'k3'],
+    );
+  });
+
+  test('a value of only separators and whitespace is open, not a key of ""', () => {
+    // An empty-string key would authenticate a request presenting no key.
+    assert.deepEqual(resolveConfig({ ...BASE, FACILITATOR_API_KEYS: ' , , ' }).apiKeys, []);
+  });
+});

--- a/test/rpc-retry.test.js
+++ b/test/rpc-retry.test.js
@@ -1,0 +1,188 @@
+/**
+ * installRpcRetry.
+ *
+ * The distinction this module exists to hold is the one worth pinning: failures
+ * raised *before* a response is received are retried; anything the server
+ * actually said stands. Retrying a rejected simulation or a failed settlement
+ * would convert a real failure into a flaky success, which is the class of bug
+ * this repo exists to avoid.
+ *
+ * forceIpv4 is off throughout — the IPv4 connector is about reaching a real
+ * host, and these tests never leave the process.
+ */
+import { test, describe, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { installRpcRetry } from '../src/rpc-retry.js';
+
+/** The real fetch, restored after every test so the wrapper cannot leak. */
+const REAL_FETCH = globalThis.fetch;
+
+/** Builds an error shaped like the ones undici raises. */
+function transportError(code, { onCause = false } = {}) {
+  const err = new Error(`simulated ${code}`);
+  if (onCause) err.cause = { code };
+  else err.code = code;
+  return err;
+}
+
+/** A fetch stub that plays a scripted sequence and counts its calls. */
+function scriptedFetch(...outcomes) {
+  const stub = async () => {
+    stub.calls++;
+    const next = outcomes.shift();
+    if (next instanceof Error) throw next;
+    return next ?? new Response('ok');
+  };
+  stub.calls = 0;
+  return stub;
+}
+
+beforeEach(() => {
+  globalThis.fetch = REAL_FETCH;
+});
+
+afterEach(() => {
+  globalThis.fetch = REAL_FETCH;
+});
+
+describe('what is retried', () => {
+  for (const code of [
+    'ETIMEDOUT',
+    'ECONNRESET',
+    'ECONNREFUSED',
+    'EAI_AGAIN',
+    'UND_ERR_CONNECT_TIMEOUT',
+    'UND_ERR_SOCKET',
+  ]) {
+    test(`${code} is retried and can succeed`, async () => {
+      const stub = scriptedFetch(transportError(code), new Response('recovered'));
+      globalThis.fetch = stub;
+      installRpcRetry({ attempts: 3, baseDelayMs: 1, forceIpv4: false });
+
+      const res = await globalThis.fetch('http://rpc.invalid');
+      assert.equal(await res.text(), 'recovered');
+      assert.equal(stub.calls, 2);
+    });
+  }
+
+  test('the code is read from err.cause too, not only err.code', async () => {
+    // undici wraps the real cause, and reading only the top-level code is how
+    // a retryable failure gets misclassified as fatal.
+    const stub = scriptedFetch(
+      transportError('UND_ERR_CONNECT_TIMEOUT', { onCause: true }),
+      new Response('recovered'),
+    );
+    globalThis.fetch = stub;
+    installRpcRetry({ attempts: 3, baseDelayMs: 1, forceIpv4: false });
+
+    assert.equal(await (await globalThis.fetch('http://rpc.invalid')).text(), 'recovered');
+    assert.equal(stub.calls, 2);
+  });
+});
+
+describe('what is deliberately not retried', () => {
+  test('an HTTP error response is returned as-is, never retried', async () => {
+    // This is the important one. A 500 from the RPC is the server answering.
+    // Retrying it would turn a real failure into an intermittent success.
+    const stub = scriptedFetch(new Response('boom', { status: 500 }));
+    globalThis.fetch = stub;
+    installRpcRetry({ attempts: 5, baseDelayMs: 1, forceIpv4: false });
+
+    const res = await globalThis.fetch('http://rpc.invalid');
+    assert.equal(res.status, 500);
+    assert.equal(stub.calls, 1, 'an answered request must not be retried');
+  });
+
+  test('a non-transport error is rethrown on the first attempt', async () => {
+    const stub = scriptedFetch(transportError('ERR_INVALID_URL'));
+    globalThis.fetch = stub;
+    installRpcRetry({ attempts: 5, baseDelayMs: 1, forceIpv4: false });
+
+    await assert.rejects(() => globalThis.fetch('not a url'), /simulated ERR_INVALID_URL/);
+    assert.equal(stub.calls, 1);
+  });
+
+  test('an error with no code at all is not retried', async () => {
+    const stub = scriptedFetch(new Error('something else entirely'));
+    globalThis.fetch = stub;
+    installRpcRetry({ attempts: 5, baseDelayMs: 1, forceIpv4: false });
+
+    await assert.rejects(() => globalThis.fetch('http://rpc.invalid'), /something else entirely/);
+    assert.equal(stub.calls, 1);
+  });
+});
+
+describe('attempt bounds', () => {
+  test('attempts is a total, including the first call', async () => {
+    const stub = scriptedFetch(
+      transportError('ETIMEDOUT'),
+      transportError('ETIMEDOUT'),
+      transportError('ETIMEDOUT'),
+    );
+    globalThis.fetch = stub;
+    installRpcRetry({ attempts: 2, baseDelayMs: 1, forceIpv4: false });
+
+    await assert.rejects(() => globalThis.fetch('http://rpc.invalid'), /simulated ETIMEDOUT/);
+    assert.equal(stub.calls, 2, 'attempts: 2 means two calls, not two retries');
+  });
+
+  test('the last error is what surfaces after exhausting attempts', async () => {
+    const stub = scriptedFetch(transportError('ETIMEDOUT'), transportError('ECONNRESET'));
+    globalThis.fetch = stub;
+    installRpcRetry({ attempts: 2, baseDelayMs: 1, forceIpv4: false });
+
+    await assert.rejects(() => globalThis.fetch('http://rpc.invalid'), /simulated ECONNRESET/);
+  });
+
+  test('attempts: 1 disables retrying entirely', async () => {
+    const stub = scriptedFetch(transportError('ETIMEDOUT'), new Response('never reached'));
+    globalThis.fetch = stub;
+    installRpcRetry({ attempts: 1, baseDelayMs: 1, forceIpv4: false });
+
+    await assert.rejects(() => globalThis.fetch('http://rpc.invalid'));
+    assert.equal(stub.calls, 1);
+  });
+});
+
+describe('logging', () => {
+  test('each retry is logged once, with the code and the attempt', async () => {
+    const lines = [];
+    const stub = scriptedFetch(
+      transportError('ETIMEDOUT'),
+      transportError('ETIMEDOUT'),
+      new Response('ok'),
+    );
+    globalThis.fetch = stub;
+    installRpcRetry({ attempts: 4, baseDelayMs: 1, forceIpv4: false, log: l => lines.push(l) });
+
+    await globalThis.fetch('http://rpc.invalid/soroban');
+    assert.equal(lines.length, 2);
+    assert.match(lines[0], /ETIMEDOUT/);
+    assert.match(lines[0], /rpc\.invalid/);
+    assert.match(lines[0], /retry 1/);
+    assert.match(lines[1], /retry 2/);
+  });
+
+  test('a successful first attempt logs nothing', async () => {
+    const lines = [];
+    globalThis.fetch = scriptedFetch(new Response('ok'));
+    installRpcRetry({ attempts: 3, baseDelayMs: 1, forceIpv4: false, log: l => lines.push(l) });
+
+    await globalThis.fetch('http://rpc.invalid');
+    assert.deepEqual(lines, []);
+  });
+});
+
+describe('the wrapper does not leak', () => {
+  test('installing replaces globalThis.fetch, and the harness restores it', async () => {
+    assert.equal(globalThis.fetch, REAL_FETCH, 'beforeEach must hand back the real fetch');
+    globalThis.fetch = scriptedFetch(new Response('ok'));
+    installRpcRetry({ attempts: 1, baseDelayMs: 1, forceIpv4: false });
+    assert.notEqual(globalThis.fetch, REAL_FETCH);
+    // afterEach restores it; the assertion above in the next test proves it.
+  });
+
+  test('the previous test left the real fetch behind', () => {
+    assert.equal(globalThis.fetch, REAL_FETCH);
+  });
+});


### PR DESCRIPTION
Closes #2. Closes #3. Closes #12.

Integration PR. Everything below is already reviewed and merged in #38 and #39 — this exists because both of those targeted intermediate branches, so none of the work has reached `main` and none of the issues auto-closed.

## What is in it

| Commit | |
|---|---|
| `5f22351` | end-to-end conformance harness, and making Soroban RPC reachable from Node |
| `1be0978` | unit suite for config, the HTTP surface, and the RPC retry wrapper (#38) |
| `8bc4740` | CI: lint, format, test matrix, audit, enforced licence policy (#39) |
| `9a5afba` | fix: pass explicit test files, not a bare directory |

## Why this shape

The three PRs were stacked `feat/e2e-harness` → `test/unit-harness` → `ci/workflow`, each based on the one below because each genuinely needed it — the tests cover `src/rpc-retry.js`, which only exists on the first branch, and CI has nothing to run without `npm test`.

They were then merged **bottom-up in the wrong order**: #38 landed at 11:15 and #39 at 11:25, so the CI work arrived on `test/unit-harness` after that branch had already been merged into `feat/e2e-harness`. The result is that `feat/e2e-harness` has the tests but not the CI, and `main` has neither. `test/unit-harness` is the only branch holding the complete stack, which is why it is the head here.

## State of the tree

- `npm test` — 54 tests, 0 failures, no network, no funded account, no `.env`
- All six CI jobs green on this branch: lint, format, test (node 20), test (node 22), audit, licenses
- Licence inventory: 218 packages, none forbidden — 175 MIT, 20 Apache-2.0, 9 ISC, 12 BSD, 1 Python-2.0, 1 Unlicense

## After this merges

`feat/e2e-harness` and `ci/workflow` are both fully contained in this and can be deleted. Future PRs should base on `main` directly unless they genuinely depend on unmerged work — and if they do, merge the stack bottom-up in order, or the same split happens again.