### PR TITLE
docs: role-based developer guide — seller, buyer/agent, operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,108 +62,12 @@ gives you `x402Facilitator` with `verify()`, `settle()` and `getSupported()`, an
 surface is yours to write. That surface, plus configuration, caller authentication and
 operational concerns, is what lives here.
 
-## Architecture
+## Documentation
 
-```mermaid
-flowchart LR
-    A[Buyer agent] -->|1. request| RS[Resource server]
-    RS -->|2. 402 + terms| A
-    A -->|3. PaymentPayload| RS
-    RS -->|4. POST /verify, /settle| F
-
-    subgraph F[" this repo "]
-        HTTP["/verify · /settle · /supported"]
-        SCHEME["ExactStellarScheme<br/>@x402/stellar"]
-        HTTP --> SCHEME
-    end
-
-    SCHEME -->|5. submit auth entry| SOR[(Stellar / Soroban)]
-    SCHEME -.->|fee sponsored by facilitator| SOR
-```
-
-| Route | Purpose |
-|---|---|
-| `GET /supported` | Supported kinds, extensions and signers — including the Stellar `extra` block with `areFeesSponsored` |
-| `POST /verify` | `{paymentPayload, paymentRequirements}` → `VerifyResponse` |
-| `POST /settle` | `{paymentPayload, paymentRequirements}` → `SettleResponse` |
-| `GET /healthz` | Liveness |
-
-## Getting Started
-
-### Prerequisites
-
-- Node.js ≥ 20
-- [Stellar CLI](https://developers.stellar.org/docs/tools/developer-tools) for key management
-
-### Three distinct accounts are required
-
-`ExactStellarScheme` rejects any payment where the facilitator is a party to the transfer.
-Payer, recipient and facilitator must therefore be three different accounts — reusing the
-merchant key as the facilitator key fails verification on the very first request.
-
-```bash
-stellar keys generate facilitator --network testnet --fund
-```
-
-### Run locally
-
-**Option A: Node.js**
-
-```bash
-# 1. Install
-npm install
-
-# 2. Configure
-cp .env.example .env
-export FACILITATOR_SECRET=$(stellar keys show facilitator)
-
-# 3. Serve
-npm start
-```
-
-**Option B: Docker Compose**
-
-For a production-like setup including the database (see [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for details):
-
-```bash
-export FACILITATOR_SECRET=$(stellar keys show facilitator)
-docker compose up
-```
-
-```bash
-curl -s localhost:3402/supported | jq
-```
-
-```json
-{
-  "kinds": [
-    {
-      "x402Version": 2,
-      "scheme": "exact",
-      "network": "stellar:testnet",
-      "extra": { "areFeesSponsored": true }
-    }
-  ],
-  "extensions": [],
-  "signers": { "stellar:*": ["G..."] }
-}
-```
-
-### Configuration
-
-| Variable | Default | Notes |
-|---|---|---|
-| `FACILITATOR_SECRET` | *required* | `S…` secret for the testnet signer |
-| `PORT` | `3402` | |
-| `STELLAR_RPC_URL` | package default | Public testnet RPC is fine; a provider URL is wanted for pubnet |
-| `MAX_TX_FEE_STROOPS` | `50000` | Fee ceiling per settlement. Configurable, never hard-wired |
-| `FACILITATOR_API_KEYS` | *(unset)* | Comma-separated. See [docs/AUTHENTICATION.md](docs/AUTHENTICATION.md). Unset means open. |
-| `RATE_LIMIT_GLOBAL` | *(unset)* | Global rate limit configuration. See [docs/OPERATIONS.md](docs/OPERATIONS.md). |
-| `RATE_LIMIT_<keyId>` | *(unset)* | Per-key rate limit override. |
-| `ENABLE_PUBNET` | `false` | Requires `FACILITATOR_SECRET_PUBNET`; refuses to start without it |
-
-Pubnet is opt-in behind its own secret deliberately: running a mainnet facilitator from a
-testnet-shaped config loses real money.
+Please refer to our [Documentation Hub](docs/README.md) for detailed role-based guides:
+- [Seller Guide](docs/SELLER.md)
+- [Buyer / Agent Guide](docs/BUYER.md)
+- [Operator Guide](docs/OPERATOR.md)
 
 ## Conformance
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,19 @@
+# Architecture
+
+```mermaid
+flowchart LR
+    A[Buyer agent] -->|1. request| RS[Resource server]
+    RS -->|2. 402 + terms| A
+    A -->|3. PaymentPayload| RS
+    RS -->|4. POST /verify, /settle| F
+
+    subgraph F[" Facilitator "]
+        HTTP["/verify · /settle · /supported"]
+        BAZAAR["/discovery/search"]
+        SCHEME["ExactStellarScheme"]
+        HTTP --> SCHEME
+    end
+
+    SCHEME -->|5. submit auth entry| SOR[(Stellar / Soroban)]
+    RS -.->|register| BAZAAR
+```

--- a/docs/BUYER.md
+++ b/docs/BUYER.md
@@ -1,0 +1,10 @@
+# Buyer / Agent Guide
+
+1. **Fund a testnet account:** Use the Stellar laboratory or CLI to create and fund a keypair.
+2. **Discover a resource:** Query the Bazaar (`GET /discovery/search`) or use the MCP server.
+3. **Pay for a call:** 
+   ```bash
+   curl -X POST -H "Authorization: X402 ..." <resource_url>
+   ```
+4. **Spending controls:** Ensure your agent checks the `402 Payment Required` terms before signing any payload.
+5. **Smart-account payers:** Use multi-sig or smart accounts for policy-based spending.

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,8 @@
+# Glossary
+
+- **Facilitator:** The service that verifies and settles payments on-chain.
+- **Resource Server:** The seller's API server.
+- **Auth Entry:** A signed authorization for a transaction.
+- **Stroop:** The smallest unit of a Stellar Lumen (XLM) - 1/10,000,000.
+- **SAC (Stellar Asset Contract):** A Soroban contract representing an asset.
+- **Scheme:** The protocol rule for verification (e.g. `exact` or `upto`).

--- a/docs/OPERATOR.md
+++ b/docs/OPERATOR.md
@@ -1,0 +1,7 @@
+# Operator Guide
+
+1. **Run the facilitator:** See `docker-compose.yml` for self-hosting.
+2. **Configure signers:** Set up `FACILITATOR_SECRET` and fee ceilings.
+3. **Monitoring and alerting:** Ensure logs are shipped to your observability stack.
+4. **Going to pubnet:** Follow key custody best practices when `ENABLE_PUBNET=true`.
+5. **Runbooks:** Refer to [OPERATIONS.md](./OPERATIONS.md) for more details.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,11 @@
+# X402 Facilitator Documentation Hub
+
+Welcome to the X402 Facilitator documentation. Please choose the path that best matches your role:
+
+- [Seller Guide](./SELLER.md): "I have an API and I want to charge agents for it"
+- [Buyer / Agent Guide](./BUYER.md): "I want my agent to find and pay for services"
+- [Operator Guide](./OPERATOR.md): "I want to run my own facilitator"
+
+**Reference:**
+- [Architecture](./ARCHITECTURE.md): System design, components, and the discovery path
+- [Glossary](./GLOSSARY.md): Terminology (Stellar, X402, and Facilitator concepts)

--- a/docs/SELLER.md
+++ b/docs/SELLER.md
@@ -1,0 +1,9 @@
+# Seller Guide
+
+1. **Add X402 to an existing Express API:** Add the `@x402/core` middleware to intercept requests.
+2. **Choose an asset and price:** Setup a trustline for USDC receipt. (See our demo-merchant example).
+3. **Declare discovery metadata:** Provide metadata on your endpoints.
+4. **Verify listing:** Check the Bazaar endpoint to ensure you are listed.
+5. **Troubleshooting:**
+   - *Error: Trustline missing.* Ensure you have an active trustline for the asset.
+   - *Error: Invalid signature.* Ensure the agent signs with the correct private key.


### PR DESCRIPTION
Resolves #30

This PR restructures the documentation to be role-based:
- Extracted the main documentation entry point to `docs/README.md`
- Added specific guides for `SELLER.md`, `BUYER.md`, and `OPERATOR.md`
- Extracted terminology to `GLOSSARY.md`
- Extracted system components to `ARCHITECTURE.md`
- Slimmed down the root `README.md` to act as an overview and routing page