### PR TITLE
fix(config): repair a merge that left resolveConfig unparseable

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -28,6 +28,23 @@ export function resolveConfig(env = process.env) {
     throw new Error('FACILITATOR_SECRET must be a Stellar secret key (starts with S).');
   }
 
+  /**
+   * Per-network configuration.
+   *
+   * Signer, RPC endpoint and fee ceiling are all network-specific and are kept
+   * that way deliberately: sharing any of them is how a testnet key ends up
+   * submitting to pubnet, or how a pubnet scheme ends up simulating against a
+   * testnet endpoint.
+   */
+  const networks = [TESTNET];
+  const perNetwork = {
+    [TESTNET]: {
+      secret,
+      rpcUrl: env.STELLAR_RPC_URL,
+      maxTransactionFeeStroops: Number(env.MAX_TX_FEE_STROOPS ?? 50_000),
+    },
+  };
+
   const rawApiKeys = (env.FACILITATOR_API_KEYS ?? '')
     .split(',')
     .map(k => k.trim())
@@ -73,12 +90,6 @@ export function resolveConfig(env = process.env) {
       rateLimits.keys[keyId] = parseLimits(env[k]);
     }
   }
-
-  return {
-    port: Number(env.PORT ?? 3402),
-    secret,
-    secretPubnet: env.FACILITATOR_SECRET_PUBNET,
-    networks: resolveNetworks(env),
 
   if (env.ENABLE_PUBNET === 'true') {
     if (!env.FACILITATOR_SECRET_PUBNET) {


### PR DESCRIPTION
> **`main` is currently broken.** `src/config.js` does not parse, so `npm start` fails and the service cannot boot. This should go in ahead of anything else.

## The breakage

```
$ node --check src/config.js
src/config.js:83
  if (env.ENABLE_PUBNET === 'true') {
         ^
SyntaxError: Unexpected token '.'
```

A merge left a `return {` opened mid-function with an `if` block spliced into the object literal:

```js
  return {
    port: Number(env.PORT ?? 3402),
    secret,
    secretPubnet: env.FACILITATOR_SECRET_PUBNET,
    networks: resolveNetworks(env),

  if (env.ENABLE_PUBNET === 'true') {
```

That dead `return` has two further problems beyond not parsing: it calls `resolveNetworks()`, which no longer exists in the file, and it returns the pre-#4 flat config shape (`secret`, `secretPubnet`) that every consumer has since stopped expecting.

The `ENABLE_PUBNET` block immediately below it pushes to `networks` and assigns into `perNetwork` — neither of which is ever declared. So the function was missing its initialisation as well as containing a stray return.

## The fix

1. Declare `networks` and `perNetwork` after the secret validation, which is where the `ENABLE_PUBNET` block below already assumed they were.
2. Delete the stray `return`.

**Nothing downstream changes.** `src/facilitator.js:35` and `src/server.js:190` already read `config.perNetwork[network].{secret, rpcUrl, maxTransactionFeeStroops}`, and `test/config.test.js` already asserts exactly that shape. Those tests were failing only because the module could not be loaded.

## Verification

| | Before | After |
|---|---|---|
| `node --check src/config.js` | SyntaxError | passes |
| `npm test` | 8 tests, 4 pass, **2 files fail to load** | **20 tests, 20 pass** |
| `npm start` | fails to boot | boots |
| `GET /supported` | unreachable | `{"extra":{"areFeesSponsored":true}}` |

```
x402 Stellar facilitator listening on :3497
  networks : stellar:testnet
  [stellar:testnet]
    signer : GDCQAKXRE7USA7MTFC64QAVMLE7O2SEIBCBJUJLIKEB7WKXNZDSDYTB6
    rpc    : (package default)
    max fee: 50000 stroops
  auth     : OPEN — no API keys configured (fine for free testnet)
```

## How this reached `main`

There is no CI on this repo — no `.github` directory at all. Nothing ran `npm test`, `node --check`, or so much as a build on #34, #35, #36 or #37, so a merge that broke the entrypoint went in green because there was no green to lose.

That is #12, and it is the next PR. Worth noting that the failure this fix repairs is precisely the one the `test` job would have caught on the PR that introduced it.