### PR TITLE
feat(bazaar): catalog datastore, schema and migrations

### DIFF
--- a/docs/BAZAAR.md
+++ b/docs/BAZAAR.md
@@ -1,0 +1,9 @@
+# Bazaar Data Model
+
+## Identity Decision
+Identity is the crucial decision for the catalog:
+- **HTTP resources** are keyed uniquely by their `url`.
+- **MCP resources** are keyed by the tuple `(url, toolName)` because a single MCP server URL can expose multiple tools, and each tool is considered a distinct catalog entry.
+
+## Upstream Type
+Derived from `@x402/extensions` (v2.21.0) `DiscoveryResource`.

--- a/migrations/001_bazaar_catalog.sql
+++ b/migrations/001_bazaar_catalog.sql
@@ -1,0 +1,30 @@
+-- migrations/001_bazaar_catalog.sql
+CREATE TABLE IF NOT EXISTS discovery_resources (
+    id SERIAL PRIMARY KEY,
+    type VARCHAR(50) NOT NULL, -- 'http' or 'mcp'
+    url TEXT NOT NULL,
+    tool_name VARCHAR(255), -- NULL for http, populated for mcp
+    service_name VARCHAR(255),
+    description TEXT,
+    tags JSONB DEFAULT '[]',
+    mime_type VARCHAR(100),
+    pay_to TEXT,
+    network VARCHAR(50),
+    scheme VARCHAR(50),
+    pricing JSONB,
+    extensions JSONB DEFAULT '{}',
+    route_template TEXT,
+    icon_url TEXT,
+    first_seen_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    last_seen_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    last_payment_at TIMESTAMP,
+    source VARCHAR(50),
+    
+    -- Identity decision: Unique across type, url, and tool_name
+    UNIQUE NULLS NOT DISTINCT (url, tool_name)
+);
+
+-- Indexes for ListDiscoveryResourcesParams
+CREATE INDEX idx_discovery_resources_type ON discovery_resources(type);
+CREATE INDEX idx_discovery_resources_tags ON discovery_resources USING GIN (tags);
+CREATE INDEX idx_discovery_resources_last_seen ON discovery_resources(last_seen_at);

--- a/src/catalog/memory.js
+++ b/src/catalog/memory.js
@@ -1,0 +1,33 @@
+export class MemoryCatalogStore {
+    constructor() {
+        this.resources = new Map();
+    }
+    
+    _key(resource) {
+        return resource.type === 'mcp' 
+            ? `${resource.url}::${resource.toolName}` 
+            : `${resource.url}::`;
+    }
+
+    async upsertResource(resource, source = 'manual') {
+        const key = this._key(resource);
+        const existing = this.resources.get(key);
+        
+        const now = new Date();
+        const entry = {
+            ...existing,
+            ...resource,
+            source,
+            last_seen_at: now,
+            first_seen_at: existing ? existing.first_seen_at : now
+        };
+        
+        this.resources.set(key, entry);
+        return entry;
+    }
+    
+    async getResource(url, toolName = null) {
+        const key = toolName ? `${url}::${toolName}` : `${url}::`;
+        return this.resources.get(key) || null;
+    }
+}

--- a/test/catalog.test.js
+++ b/test/catalog.test.js
@@ -1,0 +1,25 @@
+import assert from 'assert';
+import { MemoryCatalogStore } from '../src/catalog/memory.js';
+
+async function testIdentity() {
+    const store = new MemoryCatalogStore();
+    
+    // HTTP resource
+    await store.upsertResource({ type: 'http', url: 'http://api.ex/1', serviceName: 'A' });
+    
+    // MCP resources (same url, different tools)
+    await store.upsertResource({ type: 'mcp', url: 'http://mcp.ex', toolName: 'tool1', serviceName: 'B' });
+    await store.upsertResource({ type: 'mcp', url: 'http://mcp.ex', toolName: 'tool2', serviceName: 'C' });
+    
+    assert.strictEqual(store.resources.size, 3);
+    
+    const mcp1 = await store.getResource('http://mcp.ex', 'tool1');
+    assert.strictEqual(mcp1.serviceName, 'B');
+    
+    console.log("✅ Catalog identity tests passed.");
+}
+
+testIdentity().catch(err => {
+    console.error(err);
+    process.exit(1);
+});


### PR DESCRIPTION
Resolves #20

This PR establishes the persistence layer for the Bazaar:
- Defined the `MemoryCatalogStore` interface with `upsertResource` and `getResource` methods.
- Documented identity decision (HTTP vs MCP) in `docs/BAZAAR.md`.
- Tested the identity mapping `(url, toolName)` for MCP vs `(url)` for HTTP.
- Created SQL migration for Postgres implementation `migrations/001_bazaar_catalog.sql` defining unique constraints and indexes.