### PR TITLE
ci: lint, format, test matrix, audit and an enforced licence policy

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Revisions to skip when running git blame. Configure once with:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# style: apply prettier across the tree
+e9c5cbc59b367d368fa3f58c5dc3557354c9c9ac

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,3 +3,6 @@
 
 # style: apply prettier across the tree
 e9c5cbc59b367d368fa3f58c5dc3557354c9c9ac
+
+# style: format the catalog and sdk files that landed in the meantime
+d04cff5643c02f5c1ec54202e56ad4d1654bc74c

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Something is broken that is not a wire-format conformance failure
+title: ''
+labels: 'bug'
+---
+
+## What happened
+
+## What you expected instead
+
+## Reproducing it
+
+1.
+2.
+
+## Environment
+
+| | |
+|---|---|
+| Node version | |
+| Commit or version | |
+| Network | <!-- stellar:testnet / stellar:pubnet --> |
+| Deployment | <!-- local, docker, hosted --> |
+
+## Logs
+
+<!-- Redact FACILITATOR_SECRET and any API key before pasting. -->
+
+```
+```

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: x402 specification
+    url: https://github.com/x402-foundation/x402
+    about: Questions about the protocol itself, rather than this facilitator, belong upstream.

--- a/.github/ISSUE_TEMPLATE/conformance_failure.md
+++ b/.github/ISSUE_TEMPLATE/conformance_failure.md
@@ -1,0 +1,43 @@
+---
+name: Conformance failure
+about: A canonical x402 client did something this facilitator did not handle correctly
+title: 'conformance: '
+labels: 'area: facilitator'
+---
+
+<!--
+This is the most useful issue you can file here. The whole point of the service
+is that stock SDK code works against it unmodified, so a case where it does not
+is worth more than a feature request.
+-->
+
+## What you pointed at it
+
+| | |
+|---|---|
+| Client | <!-- e.g. @x402/core 2.21.0 --> |
+| Scheme / network | <!-- e.g. exact / stellar:testnet --> |
+| Facilitator URL or commit | |
+
+## What you expected
+
+<!-- Quote the spec or the package if you can. -->
+
+## What happened
+
+<!-- The actual request and response. Redact secrets, but do not paraphrase the
+     wire format — the exact field names are usually the whole issue. -->
+
+```http
+```
+
+## Reproducing it
+
+<!-- Ideally the smallest stock-SDK snippet that shows it. -->
+
+```js
+```
+
+## Anything else
+
+<!-- Settled transaction hash, ledger, timing — whatever you have. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+## What changed
+
+<!-- One or two sentences. What does this do that the tree did not do before? -->
+
+## Why
+
+<!-- The problem, not the patch. If it fixes an issue, link it: Closes #N -->
+
+## How it was verified
+
+<!-- Commands run and their result. "npm test passes" is fine; "should work" is not. -->
+
+- [ ] `npm test`
+- [ ] `npx eslint .`
+- [ ] `npx prettier --check .`
+
+## Wire format
+
+Does this change anything a client can observe — a route, a status code, a
+field name, a reason code, or the shape of a response?
+
+- [ ] No
+- [ ] Yes, and it is described below
+
+<!--
+Conformance here is judged at the wire level: reviewers point stock SDK code at
+the service rather than read a claim. A field renamed by accident is a
+conformance failure that passes every local test, so it needs saying out loud.
+-->
+
+## Anything a reviewer should push back on
+
+<!-- Shortcuts taken, assumptions made, things you were unsure about. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,87 @@
+name: CI
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+
+# A second push to a PR cancels the first: the older run's result is about code
+# nobody will merge.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          # ESLint 9 requires Node >= 22, so lint runs on 22 only. The test
+          # matrix below is what covers the >= 20 engines claim.
+          node-version: '22'
+          cache: npm
+      - run: npm ci
+      - run: npx eslint .
+
+  format:
+    name: format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+      - run: npm ci
+      # --check, never --write. CI reports; it does not silently rewrite the
+      # code under review.
+      - run: npx prettier --check .
+
+  test:
+    name: test (node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # package.json says engines >= 20. A claim nothing tests is a guess.
+        node: ['20', '22']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+      - run: npm ci
+      # No network, no funded account, no .env. The end-to-end conformance run
+      # needs testnet and lives in its own workflow.
+      - run: npm test
+
+  audit:
+    name: audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+      - run: npm ci
+      - run: npm audit --audit-level=high
+
+  licenses:
+    name: licenses
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+      - run: npm ci
+      # This project commits to a permissive OSI licence with no AGPL in the
+      # dependency path. That commitment is enforced here rather than asserted
+      # in a README.
+      - run: node scripts/check-licenses.mjs --list

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+node_modules
+package-lock.json
+
+# Prose is hand-tuned — centred HTML, tables, mermaid blocks. Reflowing it
+# produces large diffs that hide the change being reviewed, and formatting
+# markdown is not what this check is for.
+*.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "printWidth": 100,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "arrowParens": "avoid",
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
   <h1>x402-facilitator-stellar</h1>
   <p><strong>An x402 facilitator for Stellar — verify, settle, supported</strong></p>
   <p>
+    <img src="https://img.shields.io/github/actions/workflow/status/accensa/x402-facilitator-stellar/ci.yml?branch=main" alt="CI Status" />
     <img src="https://img.shields.io/badge/status-conformance%20spike-orange.svg" alt="Status: conformance spike" />
     <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License Apache 2.0" />
     <img src="https://img.shields.io/badge/stellar-testnet-success.svg" alt="Stellar testnet" />
@@ -147,6 +148,25 @@ curl -s localhost:3402/supported | jq
   "extensions": [],
   "signers": { "stellar:*": ["G..."] }
 }
+```
+
+### Tests
+
+```bash
+npm test              # unit tests — no network, no funded account, no .env
+npm run lint          # eslint
+npm run format:check  # prettier, check only
+npm run licenses      # fails on any AGPL in the dependency path
+```
+
+All four run in CI on every push and pull request, across Node 20 and 22.
+
+The end-to-end conformance run is separate, because it needs testnet and two
+funded accounts:
+
+```bash
+FACILITATOR_SECRET=$(stellar keys show facilitator) npm start &
+ALICE_SECRET=$(stellar keys show alice) npm run e2e
 ```
 
 ### Privacy and Data Minimisation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   facilitator:
     build: .
     ports:
-      - "${PORT:-3402}:3402"
+      - '${PORT:-3402}:3402'
     environment:
       - FACILITATOR_SECRET=${FACILITATOR_SECRET}
       - DATABASE_URL=postgres://postgres:postgres@db:5432/x402_facilitator
@@ -20,11 +20,11 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=x402_facilitator
     ports:
-      - "5432:5432"
+      - '5432:5432'
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
       interval: 5s
       timeout: 5s
       retries: 5

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,60 @@
+/**
+ * Deliberately small.
+ *
+ * This is a five-file service whose job is to be a thin, readable transport
+ * over @x402/stellar. Importing a forty-rule preset into it would generate
+ * churn that has nothing to do with correctness, and would make the diff on a
+ * conformance fix harder to read. The rules here are the ones that catch real
+ * mistakes in this codebase: unused bindings left behind by a refactor, and
+ * accidental globals.
+ *
+ * Formatting is Prettier's job and is checked separately, so nothing here
+ * concerns itself with whitespace.
+ */
+export default [
+  {
+    files: ['**/*.js', '**/*.mjs'],
+    languageOptions: {
+      ecmaVersion: 2023,
+      sourceType: 'module',
+      globals: {
+        // Node globals used across src/, scripts/ and test/.
+        process: 'readonly',
+        console: 'readonly',
+        globalThis: 'readonly',
+        fetch: 'readonly',
+        Response: 'readonly',
+        Request: 'readonly',
+        AbortController: 'readonly',
+        setTimeout: 'readonly',
+        clearTimeout: 'readonly',
+        Buffer: 'readonly',
+        URL: 'readonly',
+      },
+    },
+    linterOptions: {
+      reportUnusedDisableDirectives: 'error',
+    },
+    rules: {
+      // An import left behind by a refactor is the failure mode this catches:
+      // it reads as a dependency that is no longer one.
+      'no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+      'no-undef': 'error',
+      'no-var': 'error',
+      'prefer-const': 'error',
+      eqeqeq: ['error', 'smart'],
+
+      // Silent failure is the thing this repo is most trying to avoid, and an
+      // empty catch is how it usually arrives. `catch {}` with a comment
+      // explaining why is still allowed.
+      'no-empty': ['error', { allowEmptyCatch: false }],
+
+      // await inside a loop is correct in the settle path and in the retry
+      // wrapper; flagging it would be noise.
+      'no-await-in-loop': 'off',
+    },
+  },
+  {
+    ignores: ['node_modules/**', 'coverage/**'],
+  },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,9 @@
         "undici": "^7.29.0"
       },
       "devDependencies": {
-        "@x402/express": "^2.21.0"
+        "@x402/express": "^2.21.0",
+        "eslint": "^9.39.5",
+        "prettier": "^3.9.6"
       },
       "engines": {
         "node": ">=20"
@@ -28,6 +30,240 @@
       "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
     },
     "node_modules/@noble/ciphers": {
       "version": "1.3.0",
@@ -239,6 +475,20 @@
         "node": ">=22.0.0"
       }
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@x402/core": {
       "version": "2.21.0",
       "resolved": "https://registry.npmjs.org/@x402/core/-/core-2.21.0.tgz",
@@ -334,6 +584,29 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -363,12 +636,35 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/apg-js": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/apg-js/-/apg-js-4.4.0.tgz",
       "integrity": "sha512-fefmXFknJmtgtNEXfPwZKYkMFX4Fyeyz+fNF6JWp87biGOPslJbCBVU158zvKRZfHBKnJDy8CMM40oLFGkXT8Q==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -387,6 +683,13 @@
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/base32.js": {
       "version": "0.1.0",
@@ -460,6 +763,17 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -522,6 +836,53 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -542,6 +903,13 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
@@ -583,6 +951,21 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -599,6 +982,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -698,6 +1088,197 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -785,6 +1366,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
@@ -811,6 +1406,19 @@
         "is-retry-allowed": "^3.0.0"
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -831,6 +1439,44 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -953,6 +1599,32 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -963,6 +1635,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-symbols": {
@@ -1073,6 +1755,43 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1086,6 +1805,29 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-promise": {
@@ -1105,6 +1847,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/isows": {
       "version": "1.0.7",
@@ -1132,10 +1881,94 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1198,10 +2031,30 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -1244,6 +2097,24 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/ox": {
@@ -1306,6 +2177,51 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1313,6 +2229,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-to-regexp": {
@@ -1323,6 +2259,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/proxy-addr": {
@@ -1345,6 +2307,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -1399,6 +2371,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/router": {
@@ -1473,6 +2455,29 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.1",
@@ -1567,6 +2572,32 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1582,6 +2613,19 @@
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
       "dev": true,
       "license": "Unlicense"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/type-is": {
       "version": "2.1.0",
@@ -1642,6 +2686,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/vary": {
@@ -1713,6 +2767,32 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -1739,6 +2819,19 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,13 @@
   "scripts": {
     "start": "node src/server.js",
     "dev": "node --watch src/server.js",
-    "smoke": "node scripts/smoke.mjs",
-    "test": "node --test"
+    "test": "node --test",
+    "test:watch": "node --test --watch",
+    "e2e": "node scripts/e2e.mjs",
+    "lint": "eslint .",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "licenses": "node scripts/check-licenses.mjs"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^16.2.0",
@@ -22,6 +27,8 @@
     "undici": "^7.29.0"
   },
   "devDependencies": {
-    "@x402/express": "^2.21.0"
+    "@x402/express": "^2.21.0",
+    "eslint": "^9.39.5",
+    "prettier": "^3.9.6"
   }
 }

--- a/scripts/check-licenses.mjs
+++ b/scripts/check-licenses.mjs
@@ -1,0 +1,138 @@
+/**
+ * Fails the build if a copyleft licence appears anywhere in the dependency
+ * tree.
+ *
+ * A permissive OSI licence with no AGPL in the dependency path is a hard
+ * requirement for this project, not a preference — an AGPL dependency would
+ * make the service undistributable on the terms it promises. That requirement
+ * is currently a sentence in a README, and a sentence is not a check. This is
+ * the check.
+ *
+ * Deliberately dependency-free. Pulling in a licence-scanning package to
+ * enforce a licence policy adds another package to the tree the policy is
+ * about, and the whole job is reading `license` out of every package.json.
+ *
+ * Usage:
+ *   node scripts/check-licenses.mjs           # fail on a forbidden licence
+ *   node scripts/check-licenses.mjs --list    # print the full inventory
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * Licences that must never appear.
+ *
+ * AGPL is the named one. SSPL, BUSL and CC-BY-NC are here because they are
+ * likewise not permissive OSI licences and would fail the same requirement for
+ * the same reason — better to catch them now than to discover the rule was
+ * written too narrowly.
+ */
+const FORBIDDEN = [/\bAGPL/i, /\bSSPL/i, /\bBUSL/i, /\bCC-BY-NC/i];
+
+/** Matched only when a package declares nothing else — see classify(). */
+const WEAK_COPYLEFT = [/\bGPL-/i, /\bLGPL/i, /\bMPL-/i, /\bEPL-/i];
+
+/**
+ * Reads the licence of one package, tolerating every shape npm has ever used:
+ * a string, an SPDX expression, a {type} object, or a legacy `licenses` array.
+ */
+function licenseOf(pkg) {
+  if (typeof pkg.license === 'string') return pkg.license;
+  if (pkg.license && typeof pkg.license.type === 'string') return pkg.license.type;
+  if (Array.isArray(pkg.licenses)) {
+    return pkg.licenses.map(l => (typeof l === 'string' ? l : l.type)).join(' OR ');
+  }
+  return 'UNKNOWN';
+}
+
+/** Walks node_modules, including scoped and nested trees. */
+function* packages(dir) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    // No node_modules at this level. Not an error: a package with no
+    // dependencies of its own simply has none.
+    return;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+    if (entry.name === '.bin' || entry.name === '.cache') continue;
+
+    const full = join(dir, entry.name);
+
+    if (entry.name.startsWith('@')) {
+      yield* packages(full);
+      continue;
+    }
+
+    try {
+      const manifest = JSON.parse(readFileSync(join(full, 'package.json'), 'utf8'));
+      if (manifest.name) {
+        yield { name: manifest.name, version: manifest.version, license: licenseOf(manifest) };
+      }
+    } catch {
+      // Not a package directory, or an unreadable manifest. Skipping is right:
+      // this walks a directory tree, not a resolved dependency graph.
+    }
+
+    const nested = join(full, 'node_modules');
+    try {
+      if (statSync(nested).isDirectory()) yield* packages(nested);
+    } catch {
+      // No nested tree.
+    }
+  }
+}
+
+function classify(license) {
+  if (FORBIDDEN.some(re => re.test(license))) return 'forbidden';
+  // A dual licence offering a permissive option is fine — we take that option.
+  if (WEAK_COPYLEFT.some(re => re.test(license)) && !/\bOR\b/i.test(license)) return 'review';
+  if (license === 'UNKNOWN') return 'review';
+  return 'ok';
+}
+
+const found = [...packages(join(ROOT, 'node_modules'))];
+if (found.length === 0) {
+  console.error('No packages found. Run npm ci first.');
+  process.exit(2);
+}
+
+const forbidden = [];
+const review = [];
+for (const pkg of found) {
+  const verdict = classify(pkg.license);
+  if (verdict === 'forbidden') forbidden.push(pkg);
+  else if (verdict === 'review') review.push(pkg);
+}
+
+if (process.argv.includes('--list')) {
+  const counts = new Map();
+  for (const pkg of found) counts.set(pkg.license, (counts.get(pkg.license) ?? 0) + 1);
+  for (const [license, n] of [...counts].sort((a, b) => b[1] - a[1])) {
+    console.log(`${String(n).padStart(4)}  ${license}`);
+  }
+  console.log(`\n${found.length} packages`);
+}
+
+if (review.length > 0) {
+  console.log(`\n${review.length} package(s) need a human look (not a failure):`);
+  for (const pkg of review) console.log(`  ${pkg.name}@${pkg.version} — ${pkg.license}`);
+}
+
+if (forbidden.length > 0) {
+  console.error(`\nFORBIDDEN LICENCE in the dependency path:`);
+  for (const pkg of forbidden) console.error(`  ${pkg.name}@${pkg.version} — ${pkg.license}`);
+  console.error(
+    '\nThis project commits to a permissive OSI licence with no AGPL in the ' +
+      'dependency path. Remove the dependency or find a permissive alternative.',
+  );
+  process.exit(1);
+}
+
+console.log(`\nLicence check passed — ${found.length} packages, none forbidden.`);

--- a/scripts/data_retention_job.js
+++ b/scripts/data_retention_job.js
@@ -1,40 +1,35 @@
 #!/usr/bin/env node
 
 /**
- * X402 Facilitator Data Retention Job
- * 
- * Enforces the data minimisation and retention policy:
- * - Request Logs: 7 days
- * - Search Queries: 30 days
- * - Settlement Records: 90 days
+ * Data retention job — NOT YET IMPLEMENTED.
+ *
+ * Intended to enforce the retention policy in docs/PRIVACY.md:
+ *   request logs        7 days
+ *   search queries     30 days
+ *   settlement records 90 days
+ *
+ * There is no datastore to purge from yet, so this deletes nothing. It exits
+ * non-zero so that scheduling it is impossible to mistake for enforcing the
+ * policy: a stub that prints "[OK] Purged ..." and returns success is worse
+ * than no job at all, because it makes an unenforced policy look enforced.
+ *
+ * See the tracking issue for what has to land before this can do its job.
  */
 
-// This is a stub implementation representing the deletion job.
-// Once a database connection (e.g. Postgres or SQLite) is fully integrated, 
-// this script should execute DELETE queries.
+const RETENTION_DAYS = {
+  'request logs': 7,
+  'search queries': 30,
+  'settlement records': 90,
+};
 
-const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
-const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
-const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
-
-async function purgeExpiredData() {
-    console.log("Starting data retention purge job...");
-    const now = Date.now();
-    
-    // Example: pseudo-SQL logic
-    // await db.query('DELETE FROM request_logs WHERE timestamp < ?', [new Date(now - SEVEN_DAYS_MS)]);
-    console.log(`[OK] Purged request logs older than 7 days`);
-    
-    // await db.query('DELETE FROM search_queries WHERE timestamp < ?', [new Date(now - THIRTY_DAYS_MS)]);
-    console.log(`[OK] Purged search queries older than 30 days`);
-
-    // await db.query('DELETE FROM settlement_records WHERE timestamp < ?', [new Date(now - NINETY_DAYS_MS)]);
-    console.log(`[OK] Purged settlement records older than 90 days`);
-
-    console.log("Data retention purge job completed successfully.");
+console.error('data-retention: NOT IMPLEMENTED — nothing was purged.\n');
+console.error('The policy this job is supposed to enforce:');
+for (const [what, days] of Object.entries(RETENTION_DAYS)) {
+  console.error(`  ${what.padEnd(20)} ${days} days`);
 }
+console.error(
+  '\nBlocked on a datastore: the service holds no persistent records to purge.\n' +
+    'Until then docs/PRIVACY.md must not claim these periods are enforced.',
+);
 
-purgeExpiredData().catch(err => {
-    console.error("Failed to run data retention job:", err);
-    process.exit(1);
-});
+process.exit(1);

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -43,8 +43,8 @@ installRpcRetry({ log: msg => console.log(`    ${msg}`) });
 
 const NETWORK = 'stellar:testnet';
 const XLM_SAC = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC';
-const MERCHANT = process.env.MERCHANT_ADDRESS
-  ?? 'GCALKSGAZRJLSUEJT3M5W6LN4R7XQOLIRCOS6ZA6EDZVTZDBIIPPFKJ6';
+const MERCHANT =
+  process.env.MERCHANT_ADDRESS ?? 'GCALKSGAZRJLSUEJT3M5W6LN4R7XQOLIRCOS6ZA6EDZVTZDBIIPPFKJ6';
 const FACILITATOR_URL = process.env.FACILITATOR_URL ?? 'http://localhost:3402';
 const RESOURCE_PORT = Number(process.env.RESOURCE_PORT ?? 3401);
 
@@ -155,11 +155,11 @@ try {
   console.log(`    status=${unpaid.status}`);
   if (unpaid.status !== 402) throw new Error(`expected 402, got ${unpaid.status}`);
 
-  const body = await unpaid.clone().json().catch(() => undefined);
-  const paymentRequired = http.getPaymentRequiredResponse(
-    name => unpaid.headers.get(name),
-    body,
-  );
+  const body = await unpaid
+    .clone()
+    .json()
+    .catch(() => undefined);
+  const paymentRequired = http.getPaymentRequiredResponse(name => unpaid.headers.get(name), body);
   const req0 = paymentRequired.accepts?.[0];
   console.log(`    asset=${req0?.asset}`);
   console.log(`    amount=${req0?.maxAmountRequired}  payTo=${req0?.payTo}`);

--- a/src/catalog/memory.js
+++ b/src/catalog/memory.js
@@ -1,33 +1,31 @@
 export class MemoryCatalogStore {
-    constructor() {
-        this.resources = new Map();
-    }
-    
-    _key(resource) {
-        return resource.type === 'mcp' 
-            ? `${resource.url}::${resource.toolName}` 
-            : `${resource.url}::`;
-    }
+  constructor() {
+    this.resources = new Map();
+  }
 
-    async upsertResource(resource, source = 'manual') {
-        const key = this._key(resource);
-        const existing = this.resources.get(key);
-        
-        const now = new Date();
-        const entry = {
-            ...existing,
-            ...resource,
-            source,
-            last_seen_at: now,
-            first_seen_at: existing ? existing.first_seen_at : now
-        };
-        
-        this.resources.set(key, entry);
-        return entry;
-    }
-    
-    async getResource(url, toolName = null) {
-        const key = toolName ? `${url}::${toolName}` : `${url}::`;
-        return this.resources.get(key) || null;
-    }
+  _key(resource) {
+    return resource.type === 'mcp' ? `${resource.url}::${resource.toolName}` : `${resource.url}::`;
+  }
+
+  async upsertResource(resource, source = 'manual') {
+    const key = this._key(resource);
+    const existing = this.resources.get(key);
+
+    const now = new Date();
+    const entry = {
+      ...existing,
+      ...resource,
+      source,
+      last_seen_at: now,
+      first_seen_at: existing ? existing.first_seen_at : now,
+    };
+
+    this.resources.set(key, entry);
+    return entry;
+  }
+
+  async getResource(url, toolName = null) {
+    const key = toolName ? `${url}::${toolName}` : `${url}::`;
+    return this.resources.get(key) || null;
+  }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -60,13 +60,19 @@ export function resolveConfig(env = process.env) {
     }
     return {
       id,
-      hash: crypto.createHash('sha256').update(secretPart).digest()
+      hash: crypto.createHash('sha256').update(secretPart).digest(),
     };
   });
 
   // Parse Rate Limits
-  const parseLimits = (str) => {
-    const limits = { verifyRpm: 60, settleRpm: 10, settleRph: 100, settleRpd: 1000, feeSpd: 5000000 };
+  const parseLimits = str => {
+    const limits = {
+      verifyRpm: 60,
+      settleRpm: 10,
+      settleRph: 100,
+      settleRpd: 1000,
+      feeSpd: 5000000,
+    };
     if (!str) return limits;
     str.split(',').forEach(pair => {
       const [k, v] = pair.split('=');
@@ -81,7 +87,7 @@ export function resolveConfig(env = process.env) {
 
   const rateLimits = {
     global: parseLimits(env.RATE_LIMIT_GLOBAL),
-    keys: {}
+    keys: {},
   };
 
   for (const k of Object.keys(env)) {

--- a/src/rate-limit.js
+++ b/src/rate-limit.js
@@ -38,11 +38,19 @@ export class RateLimiter {
 
   _check(ownerId, type, windowSec, limit, amount = 1) {
     const bucketId = this._getBucketId(ownerId, type, windowSec);
-    const bucket = this.store.get(bucketId) || { count: 0, resetAt: Math.floor(Date.now() / 1000) + windowSec };
+    const bucket = this.store.get(bucketId) || {
+      count: 0,
+      resetAt: Math.floor(Date.now() / 1000) + windowSec,
+    };
     if (bucket.count + amount > limit) {
       return { allowed: false, limit, remaining: 0, resetAt: bucket.resetAt };
     }
-    return { allowed: true, limit, remaining: limit - bucket.count - amount, resetAt: bucket.resetAt };
+    return {
+      allowed: true,
+      limit,
+      remaining: limit - bucket.count - amount,
+      resetAt: bucket.resetAt,
+    };
   }
 
   _sweep(now) {
@@ -69,18 +77,18 @@ export class RateLimiter {
   checkSettle(req) {
     const ownerId = req.keyId || req.ip;
     const limits = this._getKeyConfig(req.keyId);
-    
+
     // Check all three limits for settle
     const checks = [
       this._check(ownerId, 'settle', 60, limits.settleRpm),
       this._check(ownerId, 'settle', 3600, limits.settleRph),
       this._check(ownerId, 'settle', 86400, limits.settleRpd),
     ];
-    
+
     for (const c of checks) {
       if (!c.allowed) return { ...c, reason: 'rate_limit_exceeded' };
     }
-    
+
     // Check fee limit
     // We can't strictly check fee before settlement unless we assume maxTransactionFeeStroops.
     // We will check if the current consumed + 0 is > limits.feeSpd (or maxTransactionFeeStroops).
@@ -88,8 +96,8 @@ export class RateLimiter {
     if (!feeCheck.allowed) return { ...feeCheck, reason: 'fee_ceiling_exceeded' };
 
     // Return the tightest limit for headers
-    return checks.reduce((tightest, current) => 
-      (current.remaining < tightest.remaining ? current : tightest)
+    return checks.reduce((tightest, current) =>
+      current.remaining < tightest.remaining ? current : tightest,
     );
   }
 

--- a/src/sdk/cli.js
+++ b/src/sdk/cli.js
@@ -4,20 +4,20 @@ import { validateDiscoveryDeclaration } from './validation.js';
 
 const file = process.argv[2];
 if (!file) {
-    console.error("Usage: validate-discovery <path-to-json>");
-    process.exit(1);
+  console.error('Usage: validate-discovery <path-to-json>');
+  process.exit(1);
 }
 
 try {
-    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
-    const errors = validateDiscoveryDeclaration(data);
-    if (errors.length > 0) {
-        console.error("Validation failed:");
-        errors.forEach(err => console.error(" - " + err));
-        process.exit(1);
-    }
-    console.log("Validation passed.");
-} catch (err) {
-    console.error("Error reading or parsing file:", err.message);
+  const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+  const errors = validateDiscoveryDeclaration(data);
+  if (errors.length > 0) {
+    console.error('Validation failed:');
+    errors.forEach(err => console.error(' - ' + err));
     process.exit(1);
+  }
+  console.log('Validation passed.');
+} catch (err) {
+  console.error('Error reading or parsing file:', err.message);
+  process.exit(1);
 }

--- a/src/sdk/index.js
+++ b/src/sdk/index.js
@@ -4,10 +4,10 @@ export { validateDiscoveryDeclaration };
 const STELLAR_DECIMALS = 7;
 
 export function toStroops(amount) {
-    if (!amount) return '0';
-    const [intPart = '0', fracPart = ''] = String(amount).split('.');
-    const paddedFrac = fracPart.padEnd(STELLAR_DECIMALS, '0').slice(0, STELLAR_DECIMALS);
-    return BigInt(intPart + paddedFrac).toString();
+  if (!amount) return '0';
+  const [intPart = '0', fracPart = ''] = String(amount).split('.');
+  const paddedFrac = fracPart.padEnd(STELLAR_DECIMALS, '0').slice(0, STELLAR_DECIMALS);
+  return BigInt(intPart + paddedFrac).toString();
 }
 
 /**
@@ -15,18 +15,18 @@ export function toStroops(amount) {
  * Validates the input and converts human-readable amounts to stroops.
  */
 export function createStellarDiscoveryResource(params) {
-    const errors = validateDiscoveryDeclaration(params);
-    if (errors.length > 0) {
-        throw new Error("Invalid discovery declaration:\n - " + errors.join('\n - '));
-    }
-    
-    return {
-        ...params,
-        network: params.network || 'stellar:testnet',
-        scheme: params.scheme || 'exact',
-        pricing: {
-            ...params.pricing,
-            amount: toStroops(params.pricing.amount)
-        }
-    };
+  const errors = validateDiscoveryDeclaration(params);
+  if (errors.length > 0) {
+    throw new Error('Invalid discovery declaration:\n - ' + errors.join('\n - '));
+  }
+
+  return {
+    ...params,
+    network: params.network || 'stellar:testnet',
+    scheme: params.scheme || 'exact',
+    pricing: {
+      ...params.pricing,
+      amount: toStroops(params.pricing.amount),
+    },
+  };
 }

--- a/src/sdk/validation.js
+++ b/src/sdk/validation.js
@@ -1,29 +1,29 @@
 export function validateDiscoveryDeclaration(decl) {
-    const errors = [];
-    if (!decl || typeof decl !== 'object') {
-        return ['Declaration must be an object'];
-    }
-    if (!decl.routeTemplate) errors.push('routeTemplate is required');
-    
-    // Check for parameter descriptions if parameters exist in template
-    if (decl.routeTemplate) {
-        const matches = decl.routeTemplate.match(/\{([^}]+)\}/g);
-        if (matches) {
-            const params = matches.map(m => m.slice(1, -1));
-            params.forEach(p => {
-                if (!decl.parameters || !decl.parameters[p]) {
-                    errors.push(`Missing description for parameter: ${p}`);
-                }
-            });
+  const errors = [];
+  if (!decl || typeof decl !== 'object') {
+    return ['Declaration must be an object'];
+  }
+  if (!decl.routeTemplate) errors.push('routeTemplate is required');
+
+  // Check for parameter descriptions if parameters exist in template
+  if (decl.routeTemplate) {
+    const matches = decl.routeTemplate.match(/\{([^}]+)\}/g);
+    if (matches) {
+      const params = matches.map(m => m.slice(1, -1));
+      params.forEach(p => {
+        if (!decl.parameters || !decl.parameters[p]) {
+          errors.push(`Missing description for parameter: ${p}`);
         }
+      });
     }
-    
-    if (!decl.pricing || typeof decl.pricing !== 'object') {
-        errors.push('pricing object is required');
-    } else {
-        if (!decl.pricing.amount) errors.push('pricing.amount is required');
-        if (!decl.pricing.asset) errors.push('pricing.asset is required');
-    }
-    
-    return errors;
+  }
+
+  if (!decl.pricing || typeof decl.pricing !== 'object') {
+    errors.push('pricing object is required');
+  } else {
+    if (!decl.pricing.amount) errors.push('pricing.amount is required');
+    if (!decl.pricing.asset) errors.push('pricing.asset is required');
+  }
+
+  return errors;
 }

--- a/src/server.js
+++ b/src/server.js
@@ -42,7 +42,7 @@ app.use(express.json({ limit: '256kb' }));
  */
 function requireApiKey(req, res, next) {
   if (config.apiKeys.length === 0) return next();
-  
+
   const authHeader = req.get('authorization');
   if (!authHeader) {
     return res.status(401).json({ error: 'unauthorized', reason: 'missing_auth_header' });
@@ -64,7 +64,10 @@ function requireApiKey(req, res, next) {
   const presentedHash = crypto.createHash('sha256').update(presentedKey).digest();
 
   for (const apiKey of config.apiKeys) {
-    if (presentedHash.length === apiKey.hash.length && crypto.timingSafeEqual(presentedHash, apiKey.hash)) {
+    if (
+      presentedHash.length === apiKey.hash.length &&
+      crypto.timingSafeEqual(presentedHash, apiKey.hash)
+    ) {
       req.keyId = apiKey.id;
       return next();
     }

--- a/test/auth-http.test.js
+++ b/test/auth-http.test.js
@@ -8,7 +8,7 @@ function startServer(env) {
   return new Promise((resolve, reject) => {
     const serverProcess = spawn('node', ['src/server.js'], {
       env: { ...process.env, ...env },
-      cwd: join(import.meta.dirname, '..')
+      cwd: join(import.meta.dirname, '..'),
     });
 
     serverProcess.stdout.on('data', data => {
@@ -20,21 +20,21 @@ function startServer(env) {
     serverProcess.stderr.on('data', data => {
       console.error(`server error: ${data}`);
     });
-    
+
     serverProcess.on('error', err => reject(err));
   });
 }
 
-test('auth middleware tests', async (t) => {
+test('auth middleware tests', async t => {
   const PORT = 3409;
-  const env = { 
+  const env = {
     PORT: PORT.toString(),
     FACILITATOR_SECRET: Keypair.random().secret(),
-    FACILITATOR_API_KEYS: 'admin:supersecret'
+    FACILITATOR_API_KEYS: 'admin:supersecret',
   };
-  
+
   const server = await startServer(env);
-  
+
   t.after(() => {
     server.kill();
   });
@@ -42,20 +42,24 @@ test('auth middleware tests', async (t) => {
   const baseUrl = `http://localhost:${PORT}`;
 
   await t.test('missing header', async () => {
-    const res = await fetch(`${baseUrl}/verify`, { method: 'POST', body: '{}', headers: {'content-type': 'application/json'} });
+    const res = await fetch(`${baseUrl}/verify`, {
+      method: 'POST',
+      body: '{}',
+      headers: { 'content-type': 'application/json' },
+    });
     assert.equal(res.status, 401);
     const json = await res.json();
     assert.equal(json.reason, 'missing_auth_header');
   });
 
   await t.test('malformed header', async () => {
-    const res = await fetch(`${baseUrl}/verify`, { 
-      method: 'POST', 
-      body: '{}', 
+    const res = await fetch(`${baseUrl}/verify`, {
+      method: 'POST',
+      body: '{}',
       headers: {
         'content-type': 'application/json',
-        'authorization': 'Bearer token extra'
-      } 
+        authorization: 'Bearer token extra',
+      },
     });
     assert.equal(res.status, 401);
     const json = await res.json();
@@ -63,13 +67,13 @@ test('auth middleware tests', async (t) => {
   });
 
   await t.test('invalid key', async () => {
-    const res = await fetch(`${baseUrl}/verify`, { 
-      method: 'POST', 
-      body: '{}', 
+    const res = await fetch(`${baseUrl}/verify`, {
+      method: 'POST',
+      body: '{}',
       headers: {
         'content-type': 'application/json',
-        'authorization': 'Bearer wrongsecret'
-      } 
+        authorization: 'Bearer wrongsecret',
+      },
     });
     assert.equal(res.status, 401);
     const json = await res.json();
@@ -77,40 +81,40 @@ test('auth middleware tests', async (t) => {
   });
 
   await t.test('valid key (Bearer)', async () => {
-    const res = await fetch(`${baseUrl}/verify`, { 
-      method: 'POST', 
-      body: '{}', 
+    const res = await fetch(`${baseUrl}/verify`, {
+      method: 'POST',
+      body: '{}',
       headers: {
         'content-type': 'application/json',
-        'authorization': 'Bearer supersecret'
-      } 
+        authorization: 'Bearer supersecret',
+      },
     });
     // It should pass auth and return 400 bad request from readPaymentBody
-    assert.equal(res.status, 400); 
+    assert.equal(res.status, 400);
   });
 
   await t.test('valid key (plain)', async () => {
-    const res = await fetch(`${baseUrl}/verify`, { 
-      method: 'POST', 
-      body: '{}', 
+    const res = await fetch(`${baseUrl}/verify`, {
+      method: 'POST',
+      body: '{}',
       headers: {
         'content-type': 'application/json',
-        'authorization': 'supersecret'
-      } 
+        authorization: 'supersecret',
+      },
     });
-    assert.equal(res.status, 400); 
+    assert.equal(res.status, 400);
   });
 });
 
-test('open mode tests', async (t) => {
+test('open mode tests', async t => {
   const PORT = 3410;
-  const env = { 
+  const env = {
     PORT: PORT.toString(),
     FACILITATOR_SECRET: Keypair.random().secret(),
   };
-  
+
   const server = await startServer(env);
-  
+
   t.after(() => {
     server.kill();
   });
@@ -118,7 +122,11 @@ test('open mode tests', async (t) => {
   const baseUrl = `http://localhost:${PORT}`;
 
   await t.test('passes without header', async () => {
-    const res = await fetch(`${baseUrl}/verify`, { method: 'POST', body: '{}', headers: {'content-type': 'application/json'} });
+    const res = await fetch(`${baseUrl}/verify`, {
+      method: 'POST',
+      body: '{}',
+      headers: { 'content-type': 'application/json' },
+    });
     assert.equal(res.status, 400); // Bad request because body is empty, but auth passed
   });
 });

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -10,9 +10,9 @@ test('auth config resolution handles open mode', () => {
 });
 
 test('auth config resolves plain keys to hashes with auto-generated ids', () => {
-  const env = { 
+  const env = {
     FACILITATOR_SECRET: Keypair.random().secret(),
-    FACILITATOR_API_KEYS: 'secret1, secret2'
+    FACILITATOR_API_KEYS: 'secret1, secret2',
   };
   const config = resolveConfig(env);
   assert.equal(config.apiKeys.length, 2);
@@ -22,9 +22,9 @@ test('auth config resolves plain keys to hashes with auto-generated ids', () => 
 });
 
 test('auth config resolves named keys', () => {
-  const env = { 
+  const env = {
     FACILITATOR_SECRET: Keypair.random().secret(),
-    FACILITATOR_API_KEYS: 'admin:supersecret,agent:agentsecret'
+    FACILITATOR_API_KEYS: 'admin:supersecret,agent:agentsecret',
   };
   const config = resolveConfig(env);
   assert.equal(config.apiKeys.length, 2);

--- a/test/catalog.test.js
+++ b/test/catalog.test.js
@@ -2,24 +2,34 @@ import assert from 'assert';
 import { MemoryCatalogStore } from '../src/catalog/memory.js';
 
 async function testIdentity() {
-    const store = new MemoryCatalogStore();
-    
-    // HTTP resource
-    await store.upsertResource({ type: 'http', url: 'http://api.ex/1', serviceName: 'A' });
-    
-    // MCP resources (same url, different tools)
-    await store.upsertResource({ type: 'mcp', url: 'http://mcp.ex', toolName: 'tool1', serviceName: 'B' });
-    await store.upsertResource({ type: 'mcp', url: 'http://mcp.ex', toolName: 'tool2', serviceName: 'C' });
-    
-    assert.strictEqual(store.resources.size, 3);
-    
-    const mcp1 = await store.getResource('http://mcp.ex', 'tool1');
-    assert.strictEqual(mcp1.serviceName, 'B');
-    
-    console.log("✅ Catalog identity tests passed.");
+  const store = new MemoryCatalogStore();
+
+  // HTTP resource
+  await store.upsertResource({ type: 'http', url: 'http://api.ex/1', serviceName: 'A' });
+
+  // MCP resources (same url, different tools)
+  await store.upsertResource({
+    type: 'mcp',
+    url: 'http://mcp.ex',
+    toolName: 'tool1',
+    serviceName: 'B',
+  });
+  await store.upsertResource({
+    type: 'mcp',
+    url: 'http://mcp.ex',
+    toolName: 'tool2',
+    serviceName: 'C',
+  });
+
+  assert.strictEqual(store.resources.size, 3);
+
+  const mcp1 = await store.getResource('http://mcp.ex', 'tool1');
+  assert.strictEqual(mcp1.serviceName, 'B');
+
+  console.log('✅ Catalog identity tests passed.');
 }
 
 testIdentity().catch(err => {
-    console.error(err);
-    process.exit(1);
+  console.error(err);
+  process.exit(1);
 });

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -42,11 +42,11 @@ test('resolveConfig: pubnet sets per-network values correctly', () => {
   };
   const config = resolveConfig(env);
   assert.deepStrictEqual(config.networks, [TESTNET, PUBNET]);
-  
+
   assert.strictEqual(config.perNetwork[TESTNET].secret, 'S123');
   assert.strictEqual(config.perNetwork[TESTNET].rpcUrl, 'https://testnet.local');
   assert.strictEqual(config.perNetwork[TESTNET].maxTransactionFeeStroops, 10000);
-  
+
   assert.strictEqual(config.perNetwork[PUBNET].secret, 'S456');
   assert.strictEqual(config.perNetwork[PUBNET].rpcUrl, 'https://pubnet.local');
   assert.strictEqual(config.perNetwork[PUBNET].maxTransactionFeeStroops, 20000);

--- a/test/rate-limit.test.js
+++ b/test/rate-limit.test.js
@@ -5,7 +5,7 @@ import { RateLimiter } from '../src/rate-limit.js';
 test('rate limiter honors global limits', () => {
   const config = {
     global: { verifyRpm: 2, settleRpm: 1, settleRph: 10, settleRpd: 100, feeSpd: 1000 },
-    keys: {}
+    keys: {},
   };
   const limiter = new RateLimiter(config);
   const req = { keyId: 'test_key' };
@@ -33,8 +33,8 @@ test('rate limiter honors per-key overrides', () => {
   const config = {
     global: { verifyRpm: 1, settleRpm: 1, settleRph: 10, settleRpd: 100, feeSpd: 1000 },
     keys: {
-      'test_key': { verifyRpm: 5, settleRpm: 1, settleRph: 10, settleRpd: 100, feeSpd: 1000 }
-    }
+      test_key: { verifyRpm: 5, settleRpm: 1, settleRph: 10, settleRpd: 100, feeSpd: 1000 },
+    },
   };
   const limiter = new RateLimiter(config);
   const req = { keyId: 'test_key' };
@@ -47,7 +47,7 @@ test('rate limiter honors per-key overrides', () => {
 test('rate limiter halts on fee ceiling', () => {
   const config = {
     global: { verifyRpm: 10, settleRpm: 10, settleRph: 10, settleRpd: 10, feeSpd: 500 },
-    keys: {}
+    keys: {},
   };
   const limiter = new RateLimiter(config);
   const req = { keyId: 'test_key' };
@@ -55,13 +55,13 @@ test('rate limiter halts on fee ceiling', () => {
   assert.equal(limiter.checkSettle(req).allowed, true);
   limiter.recordSettle(req, 400);
   assert.equal(limiter.checkSettle(req).allowed, true);
-  
+
   // Checking doesn't increment, but if we assume the next transaction could be up to max fee?
   // Our implementation checks if current consumed > limit.
   // Wait, current consumed is 400. limit is 500. So allowed = true.
   // Next settlement consumes 200.
   limiter.recordSettle(req, 200);
-  
+
   // Now consumed is 600. Next check should fail.
   const res = limiter.checkSettle(req);
   assert.equal(res.allowed, false);
@@ -71,7 +71,7 @@ test('rate limiter halts on fee ceiling', () => {
 test('rate limiter falls back to IP in open mode', () => {
   const config = {
     global: { verifyRpm: 1, settleRpm: 1, settleRph: 10, settleRpd: 100, feeSpd: 1000 },
-    keys: {}
+    keys: {},
   };
   const limiter = new RateLimiter(config);
   const req1 = { ip: '192.168.1.1' };

--- a/test/sdk.test.js
+++ b/test/sdk.test.js
@@ -1,49 +1,53 @@
 import assert from 'assert';
-import { toStroops, validateDiscoveryDeclaration, createStellarDiscoveryResource } from '../src/sdk/index.js';
+import {
+  toStroops,
+  validateDiscoveryDeclaration,
+  createStellarDiscoveryResource,
+} from '../src/sdk/index.js';
 
 function testToStroops() {
-    assert.strictEqual(toStroops('1'), '10000000');
-    assert.strictEqual(toStroops('0.5'), '5000000');
-    assert.strictEqual(toStroops('10.1234567'), '101234567');
-    assert.strictEqual(toStroops('0.0000001'), '1');
-    assert.strictEqual(toStroops('123.456'), '1234560000');
-    console.log("✅ testToStroops passed");
+  assert.strictEqual(toStroops('1'), '10000000');
+  assert.strictEqual(toStroops('0.5'), '5000000');
+  assert.strictEqual(toStroops('10.1234567'), '101234567');
+  assert.strictEqual(toStroops('0.0000001'), '1');
+  assert.strictEqual(toStroops('123.456'), '1234560000');
+  console.log('✅ testToStroops passed');
 }
 
 function testValidation() {
-    const valid = {
-        routeTemplate: '/api/data/{id}',
-        parameters: { id: "The data ID" },
-        pricing: { amount: '1', asset: 'USDC' }
-    };
-    assert.strictEqual(validateDiscoveryDeclaration(valid).length, 0);
+  const valid = {
+    routeTemplate: '/api/data/{id}',
+    parameters: { id: 'The data ID' },
+    pricing: { amount: '1', asset: 'USDC' },
+  };
+  assert.strictEqual(validateDiscoveryDeclaration(valid).length, 0);
 
-    const invalid = {
-        routeTemplate: '/api/data/{id}',
-        pricing: { amount: '1', asset: 'USDC' }
-    };
-    const errors = validateDiscoveryDeclaration(invalid);
-    assert.strictEqual(errors.length, 1);
-    assert.ok(errors[0].includes('Missing description for parameter: id'));
-    console.log("✅ testValidation passed");
+  const invalid = {
+    routeTemplate: '/api/data/{id}',
+    pricing: { amount: '1', asset: 'USDC' },
+  };
+  const errors = validateDiscoveryDeclaration(invalid);
+  assert.strictEqual(errors.length, 1);
+  assert.ok(errors[0].includes('Missing description for parameter: id'));
+  console.log('✅ testValidation passed');
 }
 
 function testCreateResource() {
-    const res = createStellarDiscoveryResource({
-        routeTemplate: '/api/ping',
-        pricing: { amount: '2.5', asset: 'XLM' }
-    });
-    assert.strictEqual(res.pricing.amount, '25000000');
-    assert.strictEqual(res.network, 'stellar:testnet');
-    assert.strictEqual(res.scheme, 'exact');
-    console.log("✅ testCreateResource passed");
+  const res = createStellarDiscoveryResource({
+    routeTemplate: '/api/ping',
+    pricing: { amount: '2.5', asset: 'XLM' },
+  });
+  assert.strictEqual(res.pricing.amount, '25000000');
+  assert.strictEqual(res.network, 'stellar:testnet');
+  assert.strictEqual(res.scheme, 'exact');
+  console.log('✅ testCreateResource passed');
 }
 
 try {
-    testToStroops();
-    testValidation();
-    testCreateResource();
+  testToStroops();
+  testValidation();
+  testCreateResource();
 } catch (err) {
-    console.error("Tests failed:", err);
-    process.exit(1);
+  console.error('Tests failed:', err);
+  process.exit(1);
 }


### PR DESCRIPTION
Closes #12. Closes #3.

Rebuilt against current `main`. The earlier attempt (#39) was merged into an intermediate branch and never reached `main`, and by then #4, #5, #11 and #16 had rewritten `src/server.js` underneath it — so this is the same content reconciled against the tree as it stands today.

## Why this matters more than it did last week

#44 happened because of this gap. `src/config.js` was merged in a state that **did not parse** — `npm start` failed, the service could not boot, and two of four test files could not load. It went in green because there was no green to lose: nothing ran `npm test`, nothing ran `node --check`, nothing ran at all on #34, #35, #36 or #37.

The `test` job below would have caught it on the PR that introduced it.

## The five jobs

| Job | Runs | Note |
|---|---|---|
| `lint` | `eslint .` | Deliberately small — see below |
| `format` | `prettier --check .` | `--check`, never `--write` |
| `test` | `npm test` on Node **20 and 22** | `engines` says `>=20`; an untested claim is a guess |
| `audit` | `npm audit --audit-level=high` | |
| `licenses` | `node scripts/check-licenses.mjs --list` | Enforces the AGPL-free commitment |

**Lint is intentionally minimal.** This is a thin transport whose value is being readable. A forty-rule preset would generate churn unrelated to correctness and make the diff on a conformance fix harder to read. The rules kept catch real mistakes here: bindings left behind by a refactor, accidental globals, empty catch blocks — silent failure being what this repo most wants to avoid.

**Markdown is excluded from Prettier**, with the reason written into `.prettierignore`. The README has centred HTML, tables and a mermaid block; reflowing it is 36 lines of prose churn that hides whatever is actually being reviewed.

## The licence job

A permissive OSI licence with no AGPL in the dependency path is a hard requirement. Until now it was a sentence in a README; it is now a check.

`scripts/check-licenses.mjs` is **dependency-free on purpose** — importing a licence scanner to enforce a licence policy adds a package to the tree the policy is about, and the whole job is reading `license` out of every manifest. It handles all four shapes npm has used for that field, walks scoped and nested trees, and separates *forbidden* (AGPL, SSPL, BUSL, CC-BY-NC) from *needs a human look* (bare GPL/LGPL/MPL/EPL, or `UNKNOWN`). The second is reported, not failed: a dual licence offering a permissive option is fine and we take that option.

Verified both directions:

```
$ node scripts/check-licenses.mjs        # with a planted AGPL-3.0 package
FORBIDDEN LICENCE in the dependency path:
  fake-agpl-probe@1.0.0 — AGPL-3.0
exit 1

$ node scripts/check-licenses.mjs        # real tree
Licence check passed — 218 packages, none forbidden.
exit 0
```

Inventory, now a citable result rather than a claim: 175 MIT · 20 Apache-2.0 · 9 ISC · 7 BSD-2-Clause · 5 BSD-3-Clause · 1 Python-2.0 · 1 Unlicense.

## Two things found while making CI green

**`npm run smoke` pointed at `scripts/smoke.mjs`, which does not exist** (#3). Replaced with `npm run e2e`, pointing at the harness that does.

**`scripts/data_retention_job.js` is a stub that reports success.** Four unused bindings tripped the linter, which is what surfaced it. The job logs `[OK] Purged request logs older than 7 days` and deletes nothing; `docs/PRIVACY.md:61` states the retention periods *"are enforced by an automated deletion job … that runs daily"*; and nothing schedules it — no cron, no workflow.

I have made the minimum change to stop it claiming success: it now exits non-zero and states that it is unimplemented, so scheduling it cannot be mistaken for enforcing the policy. **I have deliberately not touched `docs/PRIVACY.md` or implemented the job** — that is the privacy work's owner's call, and it needs a datastore that does not exist yet. Filed separately.

## Commits

Three, deliberately separable:

1. `ci:` — the workflow, tooling configs, licence checker, templates, script fixes
2. `style:` — the repo-wide Prettier pass, mechanical, no behaviour change
3. `chore:` — `.git-blame-ignore-revs` listing that reformat, so it does not sit between a line and its real author forever

Enable it once locally with `git config blame.ignoreRevsFile .git-blame-ignore-revs`.

## Templates

The PR template asks one question the others do not: **does this change anything a client can observe?** A field renamed by accident is a conformance failure that passes every local test.

The conformance-failure issue template exists because the README already says the most useful contribution here is a conformance failure, and gave it nowhere to go.

## Verification

Every job run locally before pushing: lint OK · format OK · 20 tests pass · 218 packages none forbidden · 0 vulnerabilities.