### PR TITLE
feat(bazaar): `GET /discovery/resources` with the full upstream filter set

### DIFF
--- a/docs/BAZAAR.md
+++ b/docs/BAZAAR.md
@@ -7,3 +7,36 @@ Identity is the crucial decision for the catalog:
 
 ## Upstream Type
 Derived from `@x402/extensions` (v2.21.0) `DiscoveryResource`.
+
+## API: `GET /discovery/resources`
+
+Allows agents and clients to list discovered resources with optional filtering and pagination.
+Pagination uses `limit` (max 100, default 20) and `offset`. The results are ordered by discovery time (newest first).
+
+### Example
+```bash
+curl "https://facilitator.example.com/discovery/resources?type=mcp&limit=10"
+```
+```json
+{
+  "x402Version": 2,
+  "items": [
+    {
+      "type": "mcp",
+      "url": "http://mcp.ex",
+      "toolName": "search_docs",
+      "serviceName": "Documentation Search",
+      "scheme": "exact",
+      "network": "stellar:testnet"
+    }
+  ],
+  "pagination": {
+    "limit": 10,
+    "offset": 0,
+    "total": 1
+  }
+}
+```
+
+### Performance Target
+The p95 latency target for this endpoint is **<50ms**, ensuring it does not block agent interactive paths.

--- a/src/catalog/memory.js
+++ b/src/catalog/memory.js
@@ -30,4 +30,43 @@ export class MemoryCatalogStore {
         const key = toolName ? `${url}::${toolName}` : `${url}::`;
         return this.resources.get(key) || null;
     }
+    async listResources(params = {}) {
+        let items = Array.from(this.resources.values());
+
+        if (params.type) items = items.filter(r => r.type === params.type);
+        if (params.payTo) items = items.filter(r => r.payTo === params.payTo);
+        if (params.scheme) items = items.filter(r => r.scheme === params.scheme);
+        if (params.network) items = items.filter(r => r.network === params.network);
+        if (params.extensions && Array.isArray(params.extensions)) {
+            items = items.filter(r => {
+                const resourceExts = Object.keys(r.extensions || {});
+                return params.extensions.every(ext => resourceExts.includes(ext));
+            });
+        }
+
+        // Sort by first_seen_at desc, then key asc to ensure deterministic order
+        items.sort((a, b) => {
+            const timeDiff = b.first_seen_at.getTime() - a.first_seen_at.getTime();
+            if (timeDiff !== 0) return timeDiff;
+            const keyA = this._key(a);
+            const keyB = this._key(b);
+            return keyA.localeCompare(keyB);
+        });
+
+        const total = items.length;
+        
+        let parsedLimit = parseInt(params.limit, 10);
+        if (isNaN(parsedLimit)) parsedLimit = 20;
+        
+        let parsedOffset = parseInt(params.offset, 10);
+        if (isNaN(parsedOffset)) parsedOffset = 0;
+
+        const limit = Math.min(Math.max(1, parsedLimit), 100);
+        const offset = Math.max(0, parsedOffset);
+
+        return {
+            items: items.slice(offset, offset + limit),
+            total
+        };
+    }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -204,14 +204,14 @@ app.get('/discovery/resources', async (req, res) => {
     network: req.query.network,
     extensions,
     limit: req.query.limit,
-    offset: req.query.offset
+    offset: req.query.offset,
   };
 
   try {
     const result = await catalog.listResources(params);
     let parsedLimit = parseInt(params.limit, 10);
     if (isNaN(parsedLimit)) parsedLimit = 20;
-    
+
     let parsedOffset = parseInt(params.offset, 10);
     if (isNaN(parsedOffset)) parsedOffset = 0;
 
@@ -221,8 +221,8 @@ app.get('/discovery/resources', async (req, res) => {
       pagination: {
         limit: Math.min(Math.max(1, parsedLimit), 100),
         offset: Math.max(0, parsedOffset),
-        total: result.total
-      }
+        total: result.total,
+      },
     });
   } catch (err) {
     res.status(500).json({ error: 'internal_error', message: err.message });

--- a/src/server.js
+++ b/src/server.js
@@ -21,6 +21,7 @@ import { resolveConfig } from './config.js';
 import { buildFacilitator } from './facilitator.js';
 import { installRpcRetry } from './rpc-retry.js';
 import { RateLimiter } from './rate-limit.js';
+import { MemoryCatalogStore } from './catalog/memory.js';
 
 // Must run before the scheme makes any RPC call. Retries connection-level
 // failures only; see rpc-retry.js for what that deliberately excludes.
@@ -180,6 +181,48 @@ app.post('/settle', requireApiKey, async (req, res) => {
       transaction: '',
       network: req.body?.paymentRequirements?.network,
     });
+  }
+});
+
+const catalog = new MemoryCatalogStore();
+
+app.get('/discovery/resources', async (req, res) => {
+  let extensions;
+  if (req.query.extensions) {
+    extensions = Array.isArray(req.query.extensions)
+      ? req.query.extensions
+      : req.query.extensions.split(',');
+  }
+
+  const params = {
+    type: req.query.type,
+    payTo: req.query.payTo,
+    scheme: req.query.scheme,
+    network: req.query.network,
+    extensions,
+    limit: req.query.limit,
+    offset: req.query.offset
+  };
+
+  try {
+    const result = await catalog.listResources(params);
+    let parsedLimit = parseInt(params.limit, 10);
+    if (isNaN(parsedLimit)) parsedLimit = 20;
+    
+    let parsedOffset = parseInt(params.offset, 10);
+    if (isNaN(parsedOffset)) parsedOffset = 0;
+
+    res.json({
+      x402Version: 2,
+      items: result.items,
+      pagination: {
+        limit: Math.min(Math.max(1, parsedLimit), 100),
+        offset: Math.max(0, parsedOffset),
+        total: result.total
+      }
+    });
+  } catch (err) {
+    res.status(500).json({ error: 'internal_error', message: err.message });
   }
 });
 

--- a/test/api.discovery.test.js
+++ b/test/api.discovery.test.js
@@ -8,7 +8,7 @@ function startServer(env) {
   return new Promise((resolve, reject) => {
     const serverProcess = spawn('node', ['src/server.js'], {
       env: { ...process.env, ...env },
-      cwd: join(import.meta.dirname, '..')
+      cwd: join(import.meta.dirname, '..'),
     });
 
     serverProcess.stdout.on('data', data => {
@@ -20,20 +20,20 @@ function startServer(env) {
     serverProcess.stderr.on('data', data => {
       console.error(`server error: ${data}`);
     });
-    
+
     serverProcess.on('error', err => reject(err));
   });
 }
 
-test('GET /discovery/resources tests', async (t) => {
+test('GET /discovery/resources tests', async t => {
   const PORT = 3411;
-  const env = { 
+  const env = {
     PORT: PORT.toString(),
     FACILITATOR_SECRET: Keypair.random().secret(),
   };
-  
+
   const server = await startServer(env);
-  
+
   t.after(() => {
     server.kill();
   });
@@ -44,54 +44,54 @@ test('GET /discovery/resources tests', async (t) => {
     const res = await fetch(`${baseUrl}/discovery/resources?type=mcp&limit=50&offset=10`);
     assert.equal(res.status, 200);
     const json = await res.json();
-    
+
     // Check field-for-field match with DiscoveryResourcesResponse
     assert.equal(json.x402Version, 2);
     assert.ok(Array.isArray(json.items));
     assert.equal(json.items.length, 0); // Empty because we haven't inserted anything
-    
+
     assert.ok(json.pagination);
     assert.equal(json.pagination.limit, 50);
     assert.equal(json.pagination.offset, 10);
     assert.equal(json.pagination.total, 0);
   });
-  
+
   await t.test('unknown filter values return empty page rather than error', async () => {
     const res = await fetch(`${baseUrl}/discovery/resources?payTo=UNKNOWN_PAY_TO_ADDRESS`);
     assert.equal(res.status, 200);
     const json = await res.json();
     assert.equal(json.items.length, 0);
   });
-  
+
   await t.test('limit bounds are enforced', async () => {
     // 0 is clamped to 1
     let res = await fetch(`${baseUrl}/discovery/resources?limit=0`);
     let json = await res.json();
     assert.equal(json.pagination.limit, 1);
-    
+
     // Default is 20
     res = await fetch(`${baseUrl}/discovery/resources`);
     json = await res.json();
     assert.equal(json.pagination.limit, 20);
-    
+
     // Max is 100
     res = await fetch(`${baseUrl}/discovery/resources?limit=500`);
     json = await res.json();
     assert.equal(json.pagination.limit, 100);
   });
-  
+
   await t.test('offset bounds are enforced', async () => {
     // Negative is clamped to 0
     let res = await fetch(`${baseUrl}/discovery/resources?offset=-5`);
     let json = await res.json();
     assert.equal(json.pagination.offset, 0);
-    
+
     // Default is 0
     res = await fetch(`${baseUrl}/discovery/resources`);
     json = await res.json();
     assert.equal(json.pagination.offset, 0);
   });
-  
+
   await t.test('multiple extensions parsed properly', async () => {
     const res = await fetch(`${baseUrl}/discovery/resources?extensions=ext1&extensions=ext2`);
     assert.equal(res.status, 200);

--- a/test/api.discovery.test.js
+++ b/test/api.discovery.test.js
@@ -1,0 +1,101 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { join } from 'node:path';
+import { Keypair } from '@stellar/stellar-sdk';
+
+function startServer(env) {
+  return new Promise((resolve, reject) => {
+    const serverProcess = spawn('node', ['src/server.js'], {
+      env: { ...process.env, ...env },
+      cwd: join(import.meta.dirname, '..')
+    });
+
+    serverProcess.stdout.on('data', data => {
+      if (data.toString().includes('listening on')) {
+        resolve(serverProcess);
+      }
+    });
+
+    serverProcess.stderr.on('data', data => {
+      console.error(`server error: ${data}`);
+    });
+    
+    serverProcess.on('error', err => reject(err));
+  });
+}
+
+test('GET /discovery/resources tests', async (t) => {
+  const PORT = 3411;
+  const env = { 
+    PORT: PORT.toString(),
+    FACILITATOR_SECRET: Keypair.random().secret(),
+  };
+  
+  const server = await startServer(env);
+  
+  t.after(() => {
+    server.kill();
+  });
+
+  const baseUrl = `http://localhost:${PORT}`;
+
+  await t.test('returns correctly shaped response', async () => {
+    const res = await fetch(`${baseUrl}/discovery/resources?type=mcp&limit=50&offset=10`);
+    assert.equal(res.status, 200);
+    const json = await res.json();
+    
+    // Check field-for-field match with DiscoveryResourcesResponse
+    assert.equal(json.x402Version, 2);
+    assert.ok(Array.isArray(json.items));
+    assert.equal(json.items.length, 0); // Empty because we haven't inserted anything
+    
+    assert.ok(json.pagination);
+    assert.equal(json.pagination.limit, 50);
+    assert.equal(json.pagination.offset, 10);
+    assert.equal(json.pagination.total, 0);
+  });
+  
+  await t.test('unknown filter values return empty page rather than error', async () => {
+    const res = await fetch(`${baseUrl}/discovery/resources?payTo=UNKNOWN_PAY_TO_ADDRESS`);
+    assert.equal(res.status, 200);
+    const json = await res.json();
+    assert.equal(json.items.length, 0);
+  });
+  
+  await t.test('limit bounds are enforced', async () => {
+    // 0 is clamped to 1
+    let res = await fetch(`${baseUrl}/discovery/resources?limit=0`);
+    let json = await res.json();
+    assert.equal(json.pagination.limit, 1);
+    
+    // Default is 20
+    res = await fetch(`${baseUrl}/discovery/resources`);
+    json = await res.json();
+    assert.equal(json.pagination.limit, 20);
+    
+    // Max is 100
+    res = await fetch(`${baseUrl}/discovery/resources?limit=500`);
+    json = await res.json();
+    assert.equal(json.pagination.limit, 100);
+  });
+  
+  await t.test('offset bounds are enforced', async () => {
+    // Negative is clamped to 0
+    let res = await fetch(`${baseUrl}/discovery/resources?offset=-5`);
+    let json = await res.json();
+    assert.equal(json.pagination.offset, 0);
+    
+    // Default is 0
+    res = await fetch(`${baseUrl}/discovery/resources`);
+    json = await res.json();
+    assert.equal(json.pagination.offset, 0);
+  });
+  
+  await t.test('multiple extensions parsed properly', async () => {
+    const res = await fetch(`${baseUrl}/discovery/resources?extensions=ext1&extensions=ext2`);
+    assert.equal(res.status, 200);
+    const json = await res.json();
+    assert.equal(json.items.length, 0);
+  });
+});

--- a/test/catalog.list.test.js
+++ b/test/catalog.list.test.js
@@ -1,0 +1,63 @@
+import assert from 'assert';
+import { MemoryCatalogStore } from '../src/catalog/memory.js';
+
+async function run() {
+    const store = new MemoryCatalogStore();
+    
+    await store.upsertResource({ type: 'http', url: 'http://a', payTo: 'G1', scheme: 'exact', network: 'testnet', extensions: { 'ext1': true } });
+    // Add small delay to ensure deterministic ordering by first_seen_at
+    await new Promise(r => setTimeout(r, 10));
+    await store.upsertResource({ type: 'mcp', url: 'http://b', toolName: 't1', payTo: 'G2', scheme: 'upto', network: 'pubnet' });
+    await new Promise(r => setTimeout(r, 10));
+    await store.upsertResource({ type: 'http', url: 'http://c', payTo: 'G1', scheme: 'exact', network: 'pubnet', extensions: { 'ext1': true, 'ext2': true } });
+    
+    // Test no filters
+    let res = await store.listResources({});
+    assert.strictEqual(res.total, 3);
+    assert.strictEqual(res.items.length, 3);
+    assert.strictEqual(res.items[0].url, 'http://c'); // most recent first
+    
+    // Test filter type
+    res = await store.listResources({ type: 'mcp' });
+    assert.strictEqual(res.total, 1);
+    assert.strictEqual(res.items[0].url, 'http://b');
+    
+    // Test filter payTo
+    res = await store.listResources({ payTo: 'G1' });
+    assert.strictEqual(res.total, 2);
+    
+    // Test filter scheme and network composability
+    res = await store.listResources({ scheme: 'exact', network: 'testnet' });
+    assert.strictEqual(res.total, 1);
+    assert.strictEqual(res.items[0].url, 'http://a');
+    
+    // Test extensions (must include all)
+    res = await store.listResources({ extensions: ['ext1'] });
+    assert.strictEqual(res.total, 2);
+    
+    res = await store.listResources({ extensions: ['ext1', 'ext2'] });
+    assert.strictEqual(res.total, 1);
+    assert.strictEqual(res.items[0].url, 'http://c');
+    
+    // Test pagination limit/offset
+    res = await store.listResources({ limit: 1 });
+    assert.strictEqual(res.total, 3); // total matches count before pagination
+    assert.strictEqual(res.items.length, 1);
+    assert.strictEqual(res.items[0].url, 'http://c');
+    
+    res = await store.listResources({ limit: 1, offset: 1 });
+    assert.strictEqual(res.items.length, 1);
+    assert.strictEqual(res.items[0].url, 'http://b');
+    
+    // Test unknown filter value
+    res = await store.listResources({ payTo: 'UNKNOWN' });
+    assert.strictEqual(res.total, 0);
+    assert.strictEqual(res.items.length, 0);
+    
+    console.log("✅ Catalog list tests passed");
+}
+
+run().catch(err => {
+    console.error(err);
+    process.exit(1);
+});

--- a/test/catalog.list.test.js
+++ b/test/catalog.list.test.js
@@ -2,62 +2,83 @@ import assert from 'assert';
 import { MemoryCatalogStore } from '../src/catalog/memory.js';
 
 async function run() {
-    const store = new MemoryCatalogStore();
-    
-    await store.upsertResource({ type: 'http', url: 'http://a', payTo: 'G1', scheme: 'exact', network: 'testnet', extensions: { 'ext1': true } });
-    // Add small delay to ensure deterministic ordering by first_seen_at
-    await new Promise(r => setTimeout(r, 10));
-    await store.upsertResource({ type: 'mcp', url: 'http://b', toolName: 't1', payTo: 'G2', scheme: 'upto', network: 'pubnet' });
-    await new Promise(r => setTimeout(r, 10));
-    await store.upsertResource({ type: 'http', url: 'http://c', payTo: 'G1', scheme: 'exact', network: 'pubnet', extensions: { 'ext1': true, 'ext2': true } });
-    
-    // Test no filters
-    let res = await store.listResources({});
-    assert.strictEqual(res.total, 3);
-    assert.strictEqual(res.items.length, 3);
-    assert.strictEqual(res.items[0].url, 'http://c'); // most recent first
-    
-    // Test filter type
-    res = await store.listResources({ type: 'mcp' });
-    assert.strictEqual(res.total, 1);
-    assert.strictEqual(res.items[0].url, 'http://b');
-    
-    // Test filter payTo
-    res = await store.listResources({ payTo: 'G1' });
-    assert.strictEqual(res.total, 2);
-    
-    // Test filter scheme and network composability
-    res = await store.listResources({ scheme: 'exact', network: 'testnet' });
-    assert.strictEqual(res.total, 1);
-    assert.strictEqual(res.items[0].url, 'http://a');
-    
-    // Test extensions (must include all)
-    res = await store.listResources({ extensions: ['ext1'] });
-    assert.strictEqual(res.total, 2);
-    
-    res = await store.listResources({ extensions: ['ext1', 'ext2'] });
-    assert.strictEqual(res.total, 1);
-    assert.strictEqual(res.items[0].url, 'http://c');
-    
-    // Test pagination limit/offset
-    res = await store.listResources({ limit: 1 });
-    assert.strictEqual(res.total, 3); // total matches count before pagination
-    assert.strictEqual(res.items.length, 1);
-    assert.strictEqual(res.items[0].url, 'http://c');
-    
-    res = await store.listResources({ limit: 1, offset: 1 });
-    assert.strictEqual(res.items.length, 1);
-    assert.strictEqual(res.items[0].url, 'http://b');
-    
-    // Test unknown filter value
-    res = await store.listResources({ payTo: 'UNKNOWN' });
-    assert.strictEqual(res.total, 0);
-    assert.strictEqual(res.items.length, 0);
-    
-    console.log("✅ Catalog list tests passed");
+  const store = new MemoryCatalogStore();
+
+  await store.upsertResource({
+    type: 'http',
+    url: 'http://a',
+    payTo: 'G1',
+    scheme: 'exact',
+    network: 'testnet',
+    extensions: { ext1: true },
+  });
+  // Add small delay to ensure deterministic ordering by first_seen_at
+  await new Promise(r => setTimeout(r, 10));
+  await store.upsertResource({
+    type: 'mcp',
+    url: 'http://b',
+    toolName: 't1',
+    payTo: 'G2',
+    scheme: 'upto',
+    network: 'pubnet',
+  });
+  await new Promise(r => setTimeout(r, 10));
+  await store.upsertResource({
+    type: 'http',
+    url: 'http://c',
+    payTo: 'G1',
+    scheme: 'exact',
+    network: 'pubnet',
+    extensions: { ext1: true, ext2: true },
+  });
+
+  // Test no filters
+  let res = await store.listResources({});
+  assert.strictEqual(res.total, 3);
+  assert.strictEqual(res.items.length, 3);
+  assert.strictEqual(res.items[0].url, 'http://c'); // most recent first
+
+  // Test filter type
+  res = await store.listResources({ type: 'mcp' });
+  assert.strictEqual(res.total, 1);
+  assert.strictEqual(res.items[0].url, 'http://b');
+
+  // Test filter payTo
+  res = await store.listResources({ payTo: 'G1' });
+  assert.strictEqual(res.total, 2);
+
+  // Test filter scheme and network composability
+  res = await store.listResources({ scheme: 'exact', network: 'testnet' });
+  assert.strictEqual(res.total, 1);
+  assert.strictEqual(res.items[0].url, 'http://a');
+
+  // Test extensions (must include all)
+  res = await store.listResources({ extensions: ['ext1'] });
+  assert.strictEqual(res.total, 2);
+
+  res = await store.listResources({ extensions: ['ext1', 'ext2'] });
+  assert.strictEqual(res.total, 1);
+  assert.strictEqual(res.items[0].url, 'http://c');
+
+  // Test pagination limit/offset
+  res = await store.listResources({ limit: 1 });
+  assert.strictEqual(res.total, 3); // total matches count before pagination
+  assert.strictEqual(res.items.length, 1);
+  assert.strictEqual(res.items[0].url, 'http://c');
+
+  res = await store.listResources({ limit: 1, offset: 1 });
+  assert.strictEqual(res.items.length, 1);
+  assert.strictEqual(res.items[0].url, 'http://b');
+
+  // Test unknown filter value
+  res = await store.listResources({ payTo: 'UNKNOWN' });
+  assert.strictEqual(res.total, 0);
+  assert.strictEqual(res.items.length, 0);
+
+  console.log('✅ Catalog list tests passed');
 }
 
 run().catch(err => {
-    console.error(err);
-    process.exit(1);
+  console.error(err);
+  process.exit(1);
 });


### PR DESCRIPTION
Resolves #21

Adds the `/discovery/resources` endpoint to the Bazaar. 
- Implements the exact `ListDiscoveryResourcesParams` filter set including `type`, `payTo`, `scheme`, `network`, `extensions`.
- Response shape exactly matches `DiscoveryResourcesResponse`.
- Filters compose with AND logic, and unknown values yield an empty page.
- Limit and offset bounds are enforced.
- Tested pagination boundaries, composing filters, and edge cases.
- P95 latency target documented in `docs/BAZAAR.md`.

*Note: this branch builds on top of issue-20.*