### PR TITLE
test: extract createApp and cover the HTTP surface (#2)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,200 @@
+/**
+ * The HTTP surface: /verify, /settle, /supported, /usage.
+ *
+ * @x402/core ships no facilitator router — it gives you x402Facilitator with
+ * verify(), settle() and getSupported(), and the transport is yours. This file
+ * is that transport and nothing else.
+ *
+ * Conformance is judged at the wire level (RFP §3.6): reviewers point stock SDK
+ * code at the deliverable rather than read a conformance claim. So the rules
+ * here are narrow and deliberate:
+ *
+ *   - the spec's `payload: {transaction}` shape is accepted verbatim, unwrapped
+ *     and un-renamed;
+ *   - every rejection carries a non-null reason code, including transport-level
+ *     ones, so an agent can branch on a code instead of parsing prose;
+ *   - responses are passed through from the scheme untouched.
+ *
+ * Separated from server.js so the surface can be built and exercised without
+ * binding a port, holding a real signer, or spawning a subprocess. server.js is
+ * the process entrypoint and does nothing this file does.
+ */
+import crypto from 'node:crypto';
+import express from 'express';
+
+/**
+ * Builds the Express app.
+ *
+ * Takes its three collaborators rather than reaching for module state, which is
+ * what makes the surface testable: a test can supply a facilitator that throws,
+ * or a rate limiter already at its ceiling, without a network or a keypair.
+ *
+ * `signers` is deliberately not a parameter — no route reads it. The addresses
+ * reach the wire through facilitator.getSupported(); server.js keeps them only
+ * to print the boot banner.
+ *
+ * @param {object} config - resolved config from resolveConfig()
+ * @param {{verify: Function, settle: Function, getSupported: Function}} facilitator
+ * @param {{checkVerify: Function, recordVerify: Function, checkSettle: Function,
+ *          recordSettle: Function, getUsage: Function}} rateLimiter
+ * @returns {import('express').Express}
+ */
+export function createApp(config, facilitator, rateLimiter) {
+  const app = express();
+  app.use(express.json({ limit: '256kb' }));
+
+  /**
+   * Caller authentication.
+   *
+   * Unset means open. That is the correct default for a free testnet instance —
+   * the RFP requires testnet be usable without friction — and it is documented
+   * rather than silent: the server logs at boot when it is running open.
+   */
+  function requireApiKey(req, res, next) {
+    if (config.apiKeys.length === 0) return next();
+
+    const authHeader = req.get('authorization');
+    if (!authHeader) {
+      return res.status(401).json({ error: 'unauthorized', reason: 'missing_auth_header' });
+    }
+
+    let presentedKey = '';
+    if (authHeader.startsWith('Bearer ')) {
+      presentedKey = authHeader.substring(7);
+    } else if (!authHeader.includes(' ')) {
+      presentedKey = authHeader;
+    } else {
+      return res.status(401).json({ error: 'unauthorized', reason: 'malformed_auth_header' });
+    }
+
+    if (!presentedKey || presentedKey.includes(' ')) {
+      return res.status(401).json({ error: 'unauthorized', reason: 'malformed_auth_header' });
+    }
+
+    const presentedHash = crypto.createHash('sha256').update(presentedKey).digest();
+
+    for (const apiKey of config.apiKeys) {
+      if (
+        presentedHash.length === apiKey.hash.length &&
+        crypto.timingSafeEqual(presentedHash, apiKey.hash)
+      ) {
+        req.keyId = apiKey.id;
+        return next();
+      }
+    }
+
+    return res.status(401).json({ error: 'unauthorized', reason: 'invalid_api_key' });
+  }
+
+  /**
+   * Require API key for usage (no open mode allowed for this).
+   */
+  function requireApiKeyStrict(req, res, next) {
+    if (config.apiKeys.length === 0) {
+      return res.status(401).json({ error: 'unauthorized', reason: 'open_mode_usage_forbidden' });
+    }
+    requireApiKey(req, res, next);
+  }
+
+  function handleRateLimit(res, checkResult) {
+    if (checkResult) {
+      res.set('RateLimit-Limit', checkResult.limit);
+      res.set('RateLimit-Remaining', checkResult.remaining);
+      res.set('RateLimit-Reset', checkResult.resetAt);
+      if (!checkResult.allowed) {
+        res.set('Retry-After', Math.max(1, checkResult.resetAt - Math.floor(Date.now() / 1000)));
+        return res.status(429).json({ error: 'rate_limited', reason: checkResult.reason });
+      }
+    }
+  }
+
+  /**
+   * Both /verify and /settle take {paymentPayload, paymentRequirements}.
+   * Returning a non-null reason on a malformed body matters as much as on a
+   * failed verification — a null reason anywhere is an acceptance failure.
+   */
+  function readPaymentBody(req, res) {
+    const { paymentPayload, paymentRequirements } = req.body ?? {};
+    if (!paymentPayload || !paymentRequirements) {
+      res.status(400).json({
+        isValid: false,
+        invalidReason: 'invalid_request',
+        invalidMessage: 'body must contain paymentPayload and paymentRequirements',
+      });
+      return null;
+    }
+    return { paymentPayload, paymentRequirements };
+  }
+
+  app.get('/healthz', (_req, res) => res.json({ ok: true }));
+
+  /**
+   * GET /supported
+   *
+   * Must emit the Stellar `extra` block including areFeesSponsored — an explicit
+   * acceptance item. getSupported() assembles it from the registered schemes, so
+   * it is passed through rather than hand-built.
+   */
+  app.get('/supported', (_req, res) => {
+    res.json(facilitator.getSupported());
+  });
+
+  app.get('/usage', requireApiKeyStrict, (req, res) => {
+    res.json(rateLimiter.getUsage(req.keyId));
+  });
+
+  app.post('/verify', requireApiKey, async (req, res) => {
+    const check = rateLimiter.checkVerify(req);
+    if (!check.allowed) return handleRateLimit(res, check);
+
+    const body = readPaymentBody(req, res);
+    if (!body) return;
+    try {
+      rateLimiter.recordVerify(req);
+      handleRateLimit(res, check);
+      const result = await facilitator.verify(body.paymentPayload, body.paymentRequirements);
+      res.json(result);
+    } catch (err) {
+      // An exception must not become a 500 with an empty body: to a client that
+      // is indistinguishable from the service being down, and it carries no
+      // reason code. Shape it like a verification failure instead.
+      //
+      // Note ExactStellarScheme already absorbs its own internal exceptions and
+      // returns invalidReason "unexpected_verify_error" rather than throwing, so
+      // this path only catches failures above the scheme — an unregistered
+      // scheme/network pair, for instance. A distinct code keeps the two
+      // distinguishable to a client.
+      res.status(200).json({
+        isValid: false,
+        invalidReason: 'facilitator_error',
+        invalidMessage: err instanceof Error ? err.message : String(err),
+      });
+    }
+  });
+
+  app.post('/settle', requireApiKey, async (req, res) => {
+    const check = rateLimiter.checkSettle(req);
+    if (!check.allowed) return handleRateLimit(res, check);
+
+    const body = readPaymentBody(req, res);
+    if (!body) return;
+    try {
+      const result = await facilitator.settle(body.paymentPayload, body.paymentRequirements);
+      rateLimiter.recordSettle(req, result.success ? result.transactionFeeStroops || 0 : 0);
+      handleRateLimit(res, check);
+      res.json(result);
+    } catch (err) {
+      // SettleResponse requires `transaction` and `network` even on failure, so
+      // a client can attribute the failure without correlating out of band.
+      res.status(200).json({
+        success: false,
+        errorReason: 'facilitator_error',
+        errorMessage: err instanceof Error ? err.message : String(err),
+        transaction: '',
+        network: req.body?.paymentRequirements?.network,
+      });
+    }
+  });
+
+  return app;
+}

--- a/src/server.js
+++ b/src/server.js
@@ -1,26 +1,16 @@
 /**
- * The HTTP surface: /verify, /settle, /supported.
+ * Process entrypoint.
  *
- * @x402/core ships no facilitator router — it gives you x402Facilitator with
- * verify(), settle() and getSupported(), and the transport is yours. This file
- * is that transport and nothing else.
- *
- * Conformance is judged at the wire level (RFP §3.6): reviewers point stock SDK
- * code at the deliverable rather than read a conformance claim. So the rules
- * here are narrow and deliberate:
- *
- *   - the spec's `payload: {transaction}` shape is accepted verbatim, unwrapped
- *     and un-renamed;
- *   - every rejection carries a non-null `reason`, including transport-level
- *     ones, so an agent can branch on a code instead of parsing prose;
- *   - responses are passed through from the scheme untouched.
+ * Resolves configuration, builds the facilitator, the rate limiter and the HTTP
+ * app, then binds a port. The routes live in app.js so they can be exercised in
+ * a test without a listener, a real signer or a subprocess — this file is only
+ * the wiring a test has no use for.
  */
-import crypto from 'node:crypto';
-import express from 'express';
 import { resolveConfig } from './config.js';
 import { buildFacilitator } from './facilitator.js';
 import { installRpcRetry } from './rpc-retry.js';
 import { RateLimiter } from './rate-limit.js';
+import { createApp } from './app.js';
 
 // Must run before the scheme makes any RPC call. Retries connection-level
 // failures only; see rpc-retry.js for what that deliberately excludes.
@@ -29,162 +19,7 @@ installRpcRetry({ log: msg => console.warn(`  ${msg}`) });
 const config = resolveConfig();
 const { facilitator, signers } = buildFacilitator(config);
 const rateLimiter = new RateLimiter(config.rateLimits);
-
-const app = express();
-app.use(express.json({ limit: '256kb' }));
-
-/**
- * Caller authentication.
- *
- * Unset means open. That is the correct default for a free testnet instance —
- * the RFP requires testnet be usable without friction — and it is documented
- * rather than silent: the server logs at boot when it is running open.
- */
-function requireApiKey(req, res, next) {
-  if (config.apiKeys.length === 0) return next();
-
-  const authHeader = req.get('authorization');
-  if (!authHeader) {
-    return res.status(401).json({ error: 'unauthorized', reason: 'missing_auth_header' });
-  }
-
-  let presentedKey = '';
-  if (authHeader.startsWith('Bearer ')) {
-    presentedKey = authHeader.substring(7);
-  } else if (!authHeader.includes(' ')) {
-    presentedKey = authHeader;
-  } else {
-    return res.status(401).json({ error: 'unauthorized', reason: 'malformed_auth_header' });
-  }
-
-  if (!presentedKey || presentedKey.includes(' ')) {
-    return res.status(401).json({ error: 'unauthorized', reason: 'malformed_auth_header' });
-  }
-
-  const presentedHash = crypto.createHash('sha256').update(presentedKey).digest();
-
-  for (const apiKey of config.apiKeys) {
-    if (
-      presentedHash.length === apiKey.hash.length &&
-      crypto.timingSafeEqual(presentedHash, apiKey.hash)
-    ) {
-      req.keyId = apiKey.id;
-      return next();
-    }
-  }
-
-  return res.status(401).json({ error: 'unauthorized', reason: 'invalid_api_key' });
-}
-
-/**
- * Require API key for usage (no open mode allowed for this).
- */
-function requireApiKeyStrict(req, res, next) {
-  if (config.apiKeys.length === 0) {
-    return res.status(401).json({ error: 'unauthorized', reason: 'open_mode_usage_forbidden' });
-  }
-  requireApiKey(req, res, next);
-}
-
-function handleRateLimit(res, checkResult) {
-  if (checkResult) {
-    res.set('RateLimit-Limit', checkResult.limit);
-    res.set('RateLimit-Remaining', checkResult.remaining);
-    res.set('RateLimit-Reset', checkResult.resetAt);
-    if (!checkResult.allowed) {
-      res.set('Retry-After', Math.max(1, checkResult.resetAt - Math.floor(Date.now() / 1000)));
-      return res.status(429).json({ error: 'rate_limited', reason: checkResult.reason });
-    }
-  }
-}
-
-/**
- * Both /verify and /settle take {paymentPayload, paymentRequirements}.
- * Returning a non-null reason on a malformed body matters as much as on a
- * failed verification — a null reason anywhere is an acceptance failure.
- */
-function readPaymentBody(req, res) {
-  const { paymentPayload, paymentRequirements } = req.body ?? {};
-  if (!paymentPayload || !paymentRequirements) {
-    res.status(400).json({
-      isValid: false,
-      invalidReason: 'invalid_request',
-      invalidMessage: 'body must contain paymentPayload and paymentRequirements',
-    });
-    return null;
-  }
-  return { paymentPayload, paymentRequirements };
-}
-
-app.get('/healthz', (_req, res) => res.json({ ok: true }));
-
-/**
- * GET /supported
- *
- * Must emit the Stellar `extra` block including areFeesSponsored — an explicit
- * acceptance item. getSupported() assembles it from the registered schemes, so
- * it is passed through rather than hand-built.
- */
-app.get('/supported', (_req, res) => {
-  res.json(facilitator.getSupported());
-});
-
-app.get('/usage', requireApiKeyStrict, (req, res) => {
-  res.json(rateLimiter.getUsage(req.keyId));
-});
-
-app.post('/verify', requireApiKey, async (req, res) => {
-  const check = rateLimiter.checkVerify(req);
-  if (!check.allowed) return handleRateLimit(res, check);
-
-  const body = readPaymentBody(req, res);
-  if (!body) return;
-  try {
-    rateLimiter.recordVerify(req);
-    handleRateLimit(res, check);
-    const result = await facilitator.verify(body.paymentPayload, body.paymentRequirements);
-    res.json(result);
-  } catch (err) {
-    // An exception must not become a 500 with an empty body: to a client that
-    // is indistinguishable from the service being down, and it carries no
-    // reason code. Shape it like a verification failure instead.
-    //
-    // Note ExactStellarScheme already absorbs its own internal exceptions and
-    // returns invalidReason "unexpected_verify_error" rather than throwing, so
-    // this path only catches failures above the scheme — an unregistered
-    // scheme/network pair, for instance. A distinct code keeps the two
-    // distinguishable to a client.
-    res.status(200).json({
-      isValid: false,
-      invalidReason: 'facilitator_error',
-      invalidMessage: err instanceof Error ? err.message : String(err),
-    });
-  }
-});
-
-app.post('/settle', requireApiKey, async (req, res) => {
-  const check = rateLimiter.checkSettle(req);
-  if (!check.allowed) return handleRateLimit(res, check);
-
-  const body = readPaymentBody(req, res);
-  if (!body) return;
-  try {
-    const result = await facilitator.settle(body.paymentPayload, body.paymentRequirements);
-    rateLimiter.recordSettle(req, result.success ? result.transactionFeeStroops || 0 : 0);
-    handleRateLimit(res, check);
-    res.json(result);
-  } catch (err) {
-    // SettleResponse requires `transaction` and `network` even on failure, so
-    // a client can attribute the failure without correlating out of band.
-    res.status(200).json({
-      success: false,
-      errorReason: 'facilitator_error',
-      errorMessage: err instanceof Error ? err.message : String(err),
-      transaction: '',
-      network: req.body?.paymentRequirements?.network,
-    });
-  }
-});
+const app = createApp(config, facilitator, rateLimiter);
 
 app.listen(config.port, () => {
   console.log(`x402 Stellar facilitator listening on :${config.port}`);

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -1,0 +1,357 @@
+/**
+ * The HTTP surface.
+ *
+ * What is under test is the transport — status codes, reason codes, pass-through
+ * fidelity, auth and rate-limit wiring. ExactStellarScheme is upstream's and is
+ * stubbed throughout: reimplementing or re-verifying it is what this repo exists
+ * not to do.
+ *
+ * Nothing here touches the network or needs a funded account.
+ */
+import { test, describe, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { serve, testConfig, stubFacilitator, stubRateLimiter, VALID_BODY } from './helpers/app.js';
+
+describe('GET /healthz', () => {
+  let app;
+  before(async () => {
+    app = await serve();
+  });
+  after(() => app.close());
+
+  test('reports liveness', async () => {
+    const res = await app.get('/healthz');
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { ok: true });
+  });
+});
+
+describe('GET /supported', () => {
+  test('passes getSupported() through untouched, extra block and all', async () => {
+    // The Stellar extra block carrying areFeesSponsored is an explicit
+    // acceptance item, so the transport must not reshape it on the way out.
+    const supported = {
+      kinds: [
+        {
+          x402Version: 2,
+          scheme: 'exact',
+          network: 'stellar:testnet',
+          extra: { areFeesSponsored: true },
+        },
+      ],
+      extensions: [],
+      signers: { 'stellar:*': ['GABC'] },
+    };
+    const app = await serve({ facilitator: stubFacilitator({ getSupported: () => supported }) });
+    try {
+      const res = await app.get('/supported');
+      assert.equal(res.status, 200);
+      assert.deepEqual(await res.json(), supported);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('stays open when API keys are configured', async () => {
+    // A client has to read /supported before it has any relationship with us.
+    // Putting it behind auth breaks discovery.
+    const app = await serve({ config: testConfig({ apiKeys: ['admin:s3cret'] }) });
+    try {
+      assert.equal((await app.get('/supported')).status, 200);
+      assert.equal((await app.get('/healthz')).status, 200);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('malformed bodies always carry a reason', () => {
+  let app;
+  before(async () => {
+    app = await serve();
+  });
+  after(() => app.close());
+
+  for (const route of ['/verify', '/settle']) {
+    for (const [label, body] of [
+      ['an empty object', {}],
+      ['paymentPayload only', { paymentPayload: VALID_BODY.paymentPayload }],
+      ['paymentRequirements only', { paymentRequirements: VALID_BODY.paymentRequirements }],
+      ['a null payload', { paymentPayload: null, paymentRequirements: {} }],
+    ]) {
+      test(`POST ${route} with ${label} → 400 and a non-null invalidReason`, async () => {
+        const res = await app.post(route, body);
+        assert.equal(res.status, 400);
+        const json = await res.json();
+        assert.equal(json.isValid, false);
+        // A null reason anywhere is an acceptance failure — an agent has to
+        // branch on a code rather than parse prose.
+        assert.equal(json.invalidReason, 'invalid_request');
+        assert.ok(json.invalidMessage, 'invalidMessage must not be empty');
+      });
+    }
+  }
+});
+
+describe('POST /verify', () => {
+  test('passes the payload and requirements through unmodified', async () => {
+    const facilitator = stubFacilitator();
+    const app = await serve({ facilitator });
+    try {
+      const res = await app.post('/verify', VALID_BODY);
+      assert.equal(res.status, 200);
+      assert.deepEqual(await res.json(), { isValid: true });
+
+      const call = facilitator.calls[0];
+      assert.equal(call.name, 'verify');
+      // Unwrapped, un-renamed, verbatim — including payload.transaction, which
+      // is the shape the spec defines and the one easiest to mangle in transit.
+      assert.deepEqual(call.payload, VALID_BODY.paymentPayload);
+      assert.equal(call.payload.payload.transaction, 'AAAAAgAAAA...');
+      assert.deepEqual(call.requirements, VALID_BODY.paymentRequirements);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('a thrown facilitator becomes a 200 verification failure, not a 500', async () => {
+    // A 500 with an empty body is indistinguishable from the service being down
+    // and carries no reason code.
+    const app = await serve({
+      facilitator: stubFacilitator({
+        verify: async () => {
+          throw new Error('no scheme registered for stellar:pubnet');
+        },
+      }),
+    });
+    try {
+      const res = await app.post('/verify', VALID_BODY);
+      assert.equal(res.status, 200);
+      const json = await res.json();
+      assert.equal(json.isValid, false);
+      assert.equal(json.invalidReason, 'facilitator_error');
+      assert.match(json.invalidMessage, /no scheme registered/);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('a non-Error throw still produces a reason and a message', async () => {
+    const app = await serve({
+      facilitator: stubFacilitator({
+        verify: async () => {
+          throw 'a bare string';
+        },
+      }),
+    });
+    try {
+      const json = await (await app.post('/verify', VALID_BODY)).json();
+      assert.equal(json.invalidReason, 'facilitator_error');
+      assert.equal(json.invalidMessage, 'a bare string');
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('a scheme rejection is passed through, not rewritten', async () => {
+    // The scheme owns its vocabulary. The transport must not translate
+    // invalid_exact_stellar_payload into something of its own invention.
+    const app = await serve({
+      facilitator: stubFacilitator({
+        verify: async () => ({
+          isValid: false,
+          invalidReason: 'invalid_exact_stellar_payload_authorization_not_signed',
+          invalidMessage: 'payer signature missing',
+          payer: 'GPAYER',
+        }),
+      }),
+    });
+    try {
+      const res = await app.post('/verify', VALID_BODY);
+      assert.equal(res.status, 200);
+      assert.deepEqual(await res.json(), {
+        isValid: false,
+        invalidReason: 'invalid_exact_stellar_payload_authorization_not_signed',
+        invalidMessage: 'payer signature missing',
+        payer: 'GPAYER',
+      });
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('POST /settle', () => {
+  test('passes the scheme result through untouched', async () => {
+    const app = await serve();
+    try {
+      const res = await app.post('/settle', VALID_BODY);
+      assert.equal(res.status, 200);
+      assert.deepEqual(await res.json(), {
+        success: true,
+        transaction: 'abc123',
+        network: 'stellar:testnet',
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('a thrown facilitator still returns transaction and network', async () => {
+    // SettleResponse requires both even on failure, so a client can attribute
+    // the failure without correlating out of band.
+    const app = await serve({
+      facilitator: stubFacilitator({
+        settle: async () => {
+          throw new Error('rpc unreachable');
+        },
+      }),
+    });
+    try {
+      const res = await app.post('/settle', VALID_BODY);
+      assert.equal(res.status, 200);
+      const json = await res.json();
+      assert.equal(json.success, false);
+      assert.equal(json.errorReason, 'facilitator_error');
+      assert.match(json.errorMessage, /rpc unreachable/);
+      assert.equal(json.transaction, '');
+      assert.equal(json.network, 'stellar:testnet');
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('the sponsored fee is reported to the rate limiter', async () => {
+    // The daily fee ceiling is what actually bounds the loss on pubnet, and it
+    // is only as good as the number the settle path hands it.
+    const rateLimiter = stubRateLimiter();
+    const app = await serve({
+      rateLimiter,
+      facilitator: stubFacilitator({
+        settle: async () => ({
+          success: true,
+          transaction: 'tx',
+          network: 'stellar:testnet',
+          transactionFeeStroops: 4200,
+        }),
+      }),
+    });
+    try {
+      await app.post('/settle', VALID_BODY);
+      const recorded = rateLimiter.recorded.find(r => r.name === 'recordSettle');
+      assert.equal(recorded.fee, 4200);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('a failed settlement records no fee', async () => {
+    const rateLimiter = stubRateLimiter();
+    const app = await serve({
+      rateLimiter,
+      facilitator: stubFacilitator({
+        settle: async () => ({ success: false, errorReason: 'insufficient_funds' }),
+      }),
+    });
+    try {
+      await app.post('/settle', VALID_BODY);
+      const recorded = rateLimiter.recorded.find(r => r.name === 'recordSettle');
+      assert.equal(recorded.fee, 0);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('rate limiting', () => {
+  test('an allowed request carries the RateLimit headers', async () => {
+    const app = await serve();
+    try {
+      const res = await app.post('/verify', VALID_BODY);
+      assert.equal(res.status, 200);
+      assert.equal(res.headers.get('ratelimit-limit'), '60');
+      assert.equal(res.headers.get('ratelimit-remaining'), '59');
+      assert.ok(res.headers.get('ratelimit-reset'), 'reset must be present');
+    } finally {
+      await app.close();
+    }
+  });
+
+  for (const route of ['/verify', '/settle']) {
+    test(`a refused ${route} returns 429 with Retry-After and a reason`, async () => {
+      const app = await serve({ rateLimiter: stubRateLimiter({ allow: false }) });
+      try {
+        const res = await app.post(route, VALID_BODY);
+        assert.equal(res.status, 429);
+        const retryAfter = Number(res.headers.get('retry-after'));
+        assert.ok(retryAfter >= 1, 'Retry-After must be a positive number of seconds');
+        const json = await res.json();
+        assert.equal(json.error, 'rate_limited');
+        // An agent has to be able to back off on a code rather than parse prose.
+        assert.ok(json.reason, 'a 429 must carry a reason');
+      } finally {
+        await app.close();
+      }
+    });
+  }
+
+  test('a refused request never reaches the facilitator', async () => {
+    // Otherwise the limit bounds the response, not the work or the fee.
+    const facilitator = stubFacilitator();
+    const app = await serve({ facilitator, rateLimiter: stubRateLimiter({ allow: false }) });
+    try {
+      await app.post('/settle', VALID_BODY);
+      assert.deepEqual(facilitator.calls, [], 'settle must not be called when rate limited');
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('a malformed body does not consume verify budget', async () => {
+    // A caller sending junk should get a 400, not be pushed toward their limit.
+    const rateLimiter = stubRateLimiter();
+    const app = await serve({ rateLimiter });
+    try {
+      await app.post('/verify', {});
+      assert.deepEqual(rateLimiter.recorded, []);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('GET /usage', () => {
+  test('is refused in open mode with a distinct reason', async () => {
+    // With no keys there is no caller identity, so there is no usage to scope.
+    const app = await serve();
+    try {
+      const res = await app.get('/usage');
+      assert.equal(res.status, 401);
+      assert.equal((await res.json()).reason, 'open_mode_usage_forbidden');
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('returns the calling key own usage', async () => {
+    const app = await serve({ config: testConfig({ apiKeys: ['admin:s3cret'] }) });
+    try {
+      const res = await app.get('/usage', { authorization: 'Bearer s3cret' });
+      assert.equal(res.status, 200);
+      const json = await res.json();
+      // Scoped to the presented key, not to the whole instance.
+      assert.equal(json.keyId, 'admin');
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('is refused without a key when keys are configured', async () => {
+    const app = await serve({ config: testConfig({ apiKeys: ['admin:s3cret'] }) });
+    try {
+      assert.equal((await app.get('/usage')).status, 401);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/test/auth-http.test.js
+++ b/test/auth-http.test.js
@@ -1,132 +1,119 @@
-import test from 'node:test';
+/**
+ * Caller authentication over HTTP.
+ *
+ * Every assertion here is carried over from the original subprocess version.
+ * What changed is how the server is obtained: this builds the app in-process
+ * via createApp rather than spawning `node src/server.js` and polling stdout
+ * for "listening on".
+ *
+ * That mattered in practice. The spawn version had no timeout, so when
+ * src/config.js was merged in a state that did not parse, the child died on
+ * startup, the "listening on" line never arrived, and the promise never
+ * settled — the suite reported `Promise resolution is still pending but the
+ * event loop has already resolved` instead of the syntax error. It also bound
+ * fixed ports (3409, 3410) and needed a real keypair to get past boot.
+ */
+import { test, describe, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { spawn } from 'node:child_process';
-import { join } from 'node:path';
-import { Keypair } from '@stellar/stellar-sdk';
+import { serve, testConfig, VALID_BODY } from './helpers/app.js';
 
-function startServer(env) {
-  return new Promise((resolve, reject) => {
-    const serverProcess = spawn('node', ['src/server.js'], {
-      env: { ...process.env, ...env },
-      cwd: join(import.meta.dirname, '..'),
-    });
-
-    serverProcess.stdout.on('data', data => {
-      if (data.toString().includes('listening on')) {
-        resolve(serverProcess);
-      }
-    });
-
-    serverProcess.stderr.on('data', data => {
-      console.error(`server error: ${data}`);
-    });
-
-    serverProcess.on('error', err => reject(err));
+describe('with API keys configured', () => {
+  let app;
+  before(async () => {
+    app = await serve({ config: testConfig({ apiKeys: ['admin:supersecret'] }) });
   });
-}
+  after(() => app.close());
 
-test('auth middleware tests', async t => {
-  const PORT = 3409;
-  const env = {
-    PORT: PORT.toString(),
-    FACILITATOR_SECRET: Keypair.random().secret(),
-    FACILITATOR_API_KEYS: 'admin:supersecret',
-  };
-
-  const server = await startServer(env);
-
-  t.after(() => {
-    server.kill();
-  });
-
-  const baseUrl = `http://localhost:${PORT}`;
-
-  await t.test('missing header', async () => {
-    const res = await fetch(`${baseUrl}/verify`, {
-      method: 'POST',
-      body: '{}',
-      headers: { 'content-type': 'application/json' },
-    });
+  test('missing header', async () => {
+    const res = await app.post('/verify', {});
     assert.equal(res.status, 401);
-    const json = await res.json();
-    assert.equal(json.reason, 'missing_auth_header');
+    assert.equal((await res.json()).reason, 'missing_auth_header');
   });
 
-  await t.test('malformed header', async () => {
-    const res = await fetch(`${baseUrl}/verify`, {
-      method: 'POST',
-      body: '{}',
-      headers: {
-        'content-type': 'application/json',
-        authorization: 'Bearer token extra',
-      },
-    });
+  test('malformed header', async () => {
+    const res = await app.post('/verify', {}, { authorization: 'Bearer token extra' });
     assert.equal(res.status, 401);
-    const json = await res.json();
-    assert.equal(json.reason, 'malformed_auth_header');
+    assert.equal((await res.json()).reason, 'malformed_auth_header');
   });
 
-  await t.test('invalid key', async () => {
-    const res = await fetch(`${baseUrl}/verify`, {
-      method: 'POST',
-      body: '{}',
-      headers: {
-        'content-type': 'application/json',
-        authorization: 'Bearer wrongsecret',
-      },
-    });
+  test('invalid key', async () => {
+    const res = await app.post('/verify', {}, { authorization: 'Bearer wrongsecret' });
     assert.equal(res.status, 401);
-    const json = await res.json();
-    assert.equal(json.reason, 'invalid_api_key');
+    assert.equal((await res.json()).reason, 'invalid_api_key');
   });
 
-  await t.test('valid key (Bearer)', async () => {
-    const res = await fetch(`${baseUrl}/verify`, {
-      method: 'POST',
-      body: '{}',
-      headers: {
-        'content-type': 'application/json',
-        authorization: 'Bearer supersecret',
-      },
-    });
-    // It should pass auth and return 400 bad request from readPaymentBody
+  test('valid key (Bearer) passes auth and reaches body validation', async () => {
+    // 400, not 401: the empty body is rejected by readPaymentBody, which only
+    // runs once the key has been accepted.
+    const res = await app.post('/verify', {}, { authorization: 'Bearer supersecret' });
     assert.equal(res.status, 400);
   });
 
-  await t.test('valid key (plain)', async () => {
-    const res = await fetch(`${baseUrl}/verify`, {
-      method: 'POST',
-      body: '{}',
-      headers: {
-        'content-type': 'application/json',
-        authorization: 'supersecret',
-      },
-    });
+  test('valid key (plain, no Bearer prefix)', async () => {
+    const res = await app.post('/verify', {}, { authorization: 'supersecret' });
     assert.equal(res.status, 400);
+  });
+
+  test('a wrong key of a different length is rejected, not crashed on', async () => {
+    // timingSafeEqual throws on length mismatch, which is why the comparison is
+    // over fixed-width SHA-256 digests rather than the raw keys.
+    const res = await app.post('/verify', {}, { authorization: 'Bearer x' });
+    assert.equal(res.status, 401);
+    assert.equal((await res.json()).reason, 'invalid_api_key');
+  });
+
+  test('the key id is attached to the request, not the key', async () => {
+    // /usage echoes req.keyId, which is how a caller is identified in metering
+    // and logs without the secret travelling with it.
+    const res = await app.get('/usage', { authorization: 'Bearer supersecret' });
+    assert.equal(res.status, 200);
+    assert.equal((await res.json()).keyId, 'admin');
+  });
+
+  test('both /verify and /settle are protected', async () => {
+    for (const route of ['/verify', '/settle']) {
+      const res = await app.post(route, VALID_BODY);
+      assert.equal(res.status, 401, `${route} must require a key`);
+    }
   });
 });
 
-test('open mode tests', async t => {
-  const PORT = 3410;
-  const env = {
-    PORT: PORT.toString(),
-    FACILITATOR_SECRET: Keypair.random().secret(),
-  };
+describe('with several keys configured', () => {
+  let app;
+  before(async () => {
+    app = await serve({ config: testConfig({ apiKeys: ['first:aaa', 'second:bbb'] }) });
+  });
+  after(() => app.close());
 
-  const server = await startServer(env);
+  test('every key works, not just the first', async () => {
+    for (const [key, id] of [
+      ['aaa', 'first'],
+      ['bbb', 'second'],
+    ]) {
+      const res = await app.get('/usage', { authorization: `Bearer ${key}` });
+      assert.equal(res.status, 200);
+      assert.equal((await res.json()).keyId, id);
+    }
+  });
+});
 
-  t.after(() => {
-    server.kill();
+describe('open mode', () => {
+  let app;
+  before(async () => {
+    app = await serve();
+  });
+  after(() => app.close());
+
+  test('passes without a header', async () => {
+    // 400 because the body is empty, but auth passed — which is the point.
+    const res = await app.post('/verify', {});
+    assert.equal(res.status, 400);
   });
 
-  const baseUrl = `http://localhost:${PORT}`;
-
-  await t.test('passes without header', async () => {
-    const res = await fetch(`${baseUrl}/verify`, {
-      method: 'POST',
-      body: '{}',
-      headers: { 'content-type': 'application/json' },
-    });
-    assert.equal(res.status, 400); // Bad request because body is empty, but auth passed
+  test('an Authorization header is ignored rather than rejected', async () => {
+    // With no keys configured there is nothing to check it against, and
+    // refusing a caller who volunteered one would be surprising.
+    const res = await app.post('/verify', {}, { authorization: 'Bearer anything' });
+    assert.equal(res.status, 400);
   });
 });

--- a/test/helpers/app.js
+++ b/test/helpers/app.js
@@ -1,0 +1,111 @@
+/**
+ * Shared harness for the HTTP surface tests.
+ *
+ * Builds the real app from src/app.js with stubbed collaborators. No subprocess,
+ * no fixed port, no keypair, no network — a test can make the facilitator throw
+ * or the rate limiter refuse, which is not reachable when the server is spawned
+ * as a child process and talks to a real scheme.
+ */
+import { createHash } from 'node:crypto';
+import { createApp } from '../../src/app.js';
+
+/**
+ * Builds the config shape createApp expects.
+ *
+ * API keys are given as `id:secret` and hashed here the way resolveConfig does,
+ * so a test states the secret it will present rather than a digest.
+ */
+export function testConfig({ apiKeys = [] } = {}) {
+  return {
+    apiKeys: apiKeys.map(entry => {
+      const idx = entry.indexOf(':');
+      const [id, secret] = idx > 0 ? [entry.slice(0, idx), entry.slice(idx + 1)] : ['key_0', entry];
+      return { id, hash: createHash('sha256').update(secret).digest() };
+    }),
+  };
+}
+
+/** A facilitator that records its calls and returns fixed, inspectable results. */
+export function stubFacilitator(overrides = {}) {
+  const calls = [];
+  return {
+    calls,
+    getSupported: () => ({ kinds: [], extensions: [], signers: {} }),
+    verify: async (payload, requirements) => {
+      calls.push({ name: 'verify', payload, requirements });
+      return { isValid: true };
+    },
+    settle: async (payload, requirements) => {
+      calls.push({ name: 'settle', payload, requirements });
+      return { success: true, transaction: 'abc123', network: requirements.network };
+    },
+    ...overrides,
+  };
+}
+
+/**
+ * A rate limiter that allows everything and records what it was told.
+ *
+ * `allow: false` flips it to refusing, which is how the 429 path and its
+ * headers get exercised without waiting out a real window.
+ */
+export function stubRateLimiter({ allow = true, reason = 'verify_rpm_exceeded' } = {}) {
+  const resetAt = Math.floor(Date.now() / 1000) + 60;
+  const result = () => ({ allowed: allow, limit: 60, remaining: allow ? 59 : 0, resetAt, reason });
+  const recorded = [];
+  return {
+    recorded,
+    checkVerify: () => result(),
+    checkSettle: () => result(),
+    recordVerify: req => recorded.push({ name: 'recordVerify', keyId: req.keyId }),
+    recordSettle: (req, fee) => recorded.push({ name: 'recordSettle', keyId: req.keyId, fee }),
+    getUsage: keyId => ({ keyId, verify: 1, settle: 2, feeStroops: 3000 }),
+  };
+}
+
+/**
+ * Boots the app on an ephemeral port and returns a client bound to it.
+ *
+ * Port 0 rather than a fixed one: tests must not collide with each other, nor
+ * with a facilitator the developer happens to have running.
+ */
+export async function serve({ config, facilitator, rateLimiter } = {}) {
+  const app = createApp(
+    config ?? testConfig(),
+    facilitator ?? stubFacilitator(),
+    rateLimiter ?? stubRateLimiter(),
+  );
+
+  const server = app.listen(0);
+  await new Promise(resolve => server.once('listening', resolve));
+  const base = `http://127.0.0.1:${server.address().port}`;
+
+  return {
+    base,
+    close: () => new Promise(resolve => server.close(resolve)),
+    get: (path, headers = {}) => fetch(`${base}${path}`, { headers }),
+    post: (path, body, headers = {}) =>
+      fetch(`${base}${path}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', ...headers },
+        body: typeof body === 'string' ? body : JSON.stringify(body),
+      }),
+  };
+}
+
+/** A payment body that satisfies readPaymentBody. Contents are never inspected. */
+export const VALID_BODY = {
+  paymentPayload: {
+    x402Version: 2,
+    scheme: 'exact',
+    network: 'stellar:testnet',
+    payload: { transaction: 'AAAAAgAAAA...' },
+  },
+  paymentRequirements: {
+    scheme: 'exact',
+    network: 'stellar:testnet',
+    asset: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
+    maxAmountRequired: '1000',
+    payTo: 'GCALKSGAZRJLSUEJT3M5W6LN4R7XQOLIRCOS6ZA6EDZVTZDBIIPPFKJ6',
+  },
+};

--- a/test/rpc-retry.test.js
+++ b/test/rpc-retry.test.js
@@ -1,0 +1,188 @@
+/**
+ * installRpcRetry.
+ *
+ * The distinction this module exists to hold is the one worth pinning: failures
+ * raised *before* a response is received are retried; anything the server
+ * actually said stands. Retrying a rejected simulation or a failed settlement
+ * would convert a real failure into a flaky success, which is the class of bug
+ * this repo exists to avoid.
+ *
+ * forceIpv4 is off throughout — the IPv4 connector is about reaching a real
+ * host, and these tests never leave the process.
+ */
+import { test, describe, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { installRpcRetry } from '../src/rpc-retry.js';
+
+/** The real fetch, restored after every test so the wrapper cannot leak. */
+const REAL_FETCH = globalThis.fetch;
+
+/** Builds an error shaped like the ones undici raises. */
+function transportError(code, { onCause = false } = {}) {
+  const err = new Error(`simulated ${code}`);
+  if (onCause) err.cause = { code };
+  else err.code = code;
+  return err;
+}
+
+/** A fetch stub that plays a scripted sequence and counts its calls. */
+function scriptedFetch(...outcomes) {
+  const stub = async () => {
+    stub.calls++;
+    const next = outcomes.shift();
+    if (next instanceof Error) throw next;
+    return next ?? new Response('ok');
+  };
+  stub.calls = 0;
+  return stub;
+}
+
+beforeEach(() => {
+  globalThis.fetch = REAL_FETCH;
+});
+
+afterEach(() => {
+  globalThis.fetch = REAL_FETCH;
+});
+
+describe('what is retried', () => {
+  for (const code of [
+    'ETIMEDOUT',
+    'ECONNRESET',
+    'ECONNREFUSED',
+    'EAI_AGAIN',
+    'UND_ERR_CONNECT_TIMEOUT',
+    'UND_ERR_SOCKET',
+  ]) {
+    test(`${code} is retried and can succeed`, async () => {
+      const stub = scriptedFetch(transportError(code), new Response('recovered'));
+      globalThis.fetch = stub;
+      installRpcRetry({ attempts: 3, baseDelayMs: 1, forceIpv4: false });
+
+      const res = await globalThis.fetch('http://rpc.invalid');
+      assert.equal(await res.text(), 'recovered');
+      assert.equal(stub.calls, 2);
+    });
+  }
+
+  test('the code is read from err.cause too, not only err.code', async () => {
+    // undici wraps the real cause, and reading only the top-level code is how
+    // a retryable failure gets misclassified as fatal.
+    const stub = scriptedFetch(
+      transportError('UND_ERR_CONNECT_TIMEOUT', { onCause: true }),
+      new Response('recovered'),
+    );
+    globalThis.fetch = stub;
+    installRpcRetry({ attempts: 3, baseDelayMs: 1, forceIpv4: false });
+
+    assert.equal(await (await globalThis.fetch('http://rpc.invalid')).text(), 'recovered');
+    assert.equal(stub.calls, 2);
+  });
+});
+
+describe('what is deliberately not retried', () => {
+  test('an HTTP error response is returned as-is, never retried', async () => {
+    // This is the important one. A 500 from the RPC is the server answering.
+    // Retrying it would turn a real failure into an intermittent success.
+    const stub = scriptedFetch(new Response('boom', { status: 500 }));
+    globalThis.fetch = stub;
+    installRpcRetry({ attempts: 5, baseDelayMs: 1, forceIpv4: false });
+
+    const res = await globalThis.fetch('http://rpc.invalid');
+    assert.equal(res.status, 500);
+    assert.equal(stub.calls, 1, 'an answered request must not be retried');
+  });
+
+  test('a non-transport error is rethrown on the first attempt', async () => {
+    const stub = scriptedFetch(transportError('ERR_INVALID_URL'));
+    globalThis.fetch = stub;
+    installRpcRetry({ attempts: 5, baseDelayMs: 1, forceIpv4: false });
+
+    await assert.rejects(() => globalThis.fetch('not a url'), /simulated ERR_INVALID_URL/);
+    assert.equal(stub.calls, 1);
+  });
+
+  test('an error with no code at all is not retried', async () => {
+    const stub = scriptedFetch(new Error('something else entirely'));
+    globalThis.fetch = stub;
+    installRpcRetry({ attempts: 5, baseDelayMs: 1, forceIpv4: false });
+
+    await assert.rejects(() => globalThis.fetch('http://rpc.invalid'), /something else entirely/);
+    assert.equal(stub.calls, 1);
+  });
+});
+
+describe('attempt bounds', () => {
+  test('attempts is a total, including the first call', async () => {
+    const stub = scriptedFetch(
+      transportError('ETIMEDOUT'),
+      transportError('ETIMEDOUT'),
+      transportError('ETIMEDOUT'),
+    );
+    globalThis.fetch = stub;
+    installRpcRetry({ attempts: 2, baseDelayMs: 1, forceIpv4: false });
+
+    await assert.rejects(() => globalThis.fetch('http://rpc.invalid'), /simulated ETIMEDOUT/);
+    assert.equal(stub.calls, 2, 'attempts: 2 means two calls, not two retries');
+  });
+
+  test('the last error is what surfaces after exhausting attempts', async () => {
+    const stub = scriptedFetch(transportError('ETIMEDOUT'), transportError('ECONNRESET'));
+    globalThis.fetch = stub;
+    installRpcRetry({ attempts: 2, baseDelayMs: 1, forceIpv4: false });
+
+    await assert.rejects(() => globalThis.fetch('http://rpc.invalid'), /simulated ECONNRESET/);
+  });
+
+  test('attempts: 1 disables retrying entirely', async () => {
+    const stub = scriptedFetch(transportError('ETIMEDOUT'), new Response('never reached'));
+    globalThis.fetch = stub;
+    installRpcRetry({ attempts: 1, baseDelayMs: 1, forceIpv4: false });
+
+    await assert.rejects(() => globalThis.fetch('http://rpc.invalid'));
+    assert.equal(stub.calls, 1);
+  });
+});
+
+describe('logging', () => {
+  test('each retry is logged once, with the code and the attempt', async () => {
+    const lines = [];
+    const stub = scriptedFetch(
+      transportError('ETIMEDOUT'),
+      transportError('ETIMEDOUT'),
+      new Response('ok'),
+    );
+    globalThis.fetch = stub;
+    installRpcRetry({ attempts: 4, baseDelayMs: 1, forceIpv4: false, log: l => lines.push(l) });
+
+    await globalThis.fetch('http://rpc.invalid/soroban');
+    assert.equal(lines.length, 2);
+    assert.match(lines[0], /ETIMEDOUT/);
+    assert.match(lines[0], /rpc\.invalid/);
+    assert.match(lines[0], /retry 1/);
+    assert.match(lines[1], /retry 2/);
+  });
+
+  test('a successful first attempt logs nothing', async () => {
+    const lines = [];
+    globalThis.fetch = scriptedFetch(new Response('ok'));
+    installRpcRetry({ attempts: 3, baseDelayMs: 1, forceIpv4: false, log: l => lines.push(l) });
+
+    await globalThis.fetch('http://rpc.invalid');
+    assert.deepEqual(lines, []);
+  });
+});
+
+describe('the wrapper does not leak', () => {
+  test('installing replaces globalThis.fetch, and the harness restores it', async () => {
+    assert.equal(globalThis.fetch, REAL_FETCH, 'beforeEach must hand back the real fetch');
+    globalThis.fetch = scriptedFetch(new Response('ok'));
+    installRpcRetry({ attempts: 1, baseDelayMs: 1, forceIpv4: false });
+    assert.notEqual(globalThis.fetch, REAL_FETCH);
+    // afterEach restores it; the assertion above in the next test proves it.
+  });
+
+  test('the previous test left the real fetch behind', () => {
+    assert.equal(globalThis.fetch, REAL_FETCH);
+  });
+});


### PR DESCRIPTION
Closes #2.

## Why this PR exists

#49 carried this work and was merged — into `ci/tooling`, not `main`. `ci/tooling` was the base because #49 needed the Prettier and lint checks from #47 to exist before its new files landed. #47 then merged to `main` first (correctly, closing #3 and #12), but `ci/tooling` was not deleted, so GitHub did not retarget #49, and merging it moved the work no closer to `main`.

So `src/app.js` and the 70-test suite are still not on `main`, and #2 is still open. This takes them there.

## What is in it

| Commit | |
|---|---|
| `e7e3d48` | `test: extract createApp and cover the HTTP surface` — the whole of #49 |
| merge | `main` merged in, resolving one conflict |

Full description is on #49; the short version is that the routes were defined at module scope in `server.js`, so the only way to exercise them was to spawn `node src/server.js` on a fixed port. That spawn helper had no timeout, which is why #44 surfaced as `Promise resolution is still pending` instead of the `SyntaxError` that actually happened. `createApp(config, facilitator, rateLimiter)` fixes that; **77 tests, no network, no subprocess, no fixed port**.

## The conflict, and how it was resolved

#48 added `/discovery/resources` directly to `src/server.js` while this branch moved the payment routes out of it. Both are kept: `createApp` builds the app, and the discovery route is registered on the returned instance. That works unchanged, and both surfaces were checked against a running server:

```
$ curl 'localhost:3495/discovery/resources?limit=5'
{"x402Version":2,"items":[],"pagination":{"limit":5,"offset":0,"total":0}}

$ curl localhost:3495/supported
{"kinds":[{"x402Version":2,"scheme":"exact","network":"stellar:testnet","extra":{"areFeesSponsored":true}}],...}
```

**One thing deliberately not fixed here.** `/discovery/resources` now sits outside `createApp`, so it cannot be exercised without binding a port — precisely what the extraction exists to avoid, and the next route added to `server.js` will follow it. Moving it in means `createApp` takes a catalog store as a fourth collaborator, which is a change to someone else's feature and does not belong in a merge resolution. Worth a follow-up issue.

## Verification

- `npm test` — 77 pass, 0 fail
- `npm run lint`, `npx prettier --check .` — clean
- Both route surfaces verified against a real booted server, as above

## Process note

This is the third time work has merged into an intermediate branch and failed to close its issue. The mechanical fix is the repo setting **"Automatically delete head branches"**: GitHub retargets open PRs to the parent's base when the base branch is merged *and deleted*, so a stack collapses onto `main` by itself. Without it, every stacked PR has to be retargeted by hand, and forgetting is silent.