### PR TITLE
feat(bazaar): search evaluation harness and judgement set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,16 @@ jobs:
       # dependency path. That commitment is enforced here rather than asserted
       # in a README.
       - run: node scripts/check-licenses.mjs --list
+
+  eval:
+    name: eval
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+      - run: npm ci
+      # Search evaluation gate
+      - run: npm run eval

--- a/docs/BAZAAR.md
+++ b/docs/BAZAAR.md
@@ -81,3 +81,14 @@ The validation rules for resources submitted to the catalog are as follows:
 - **Rate Limit:** Catalog operations are limited per payer IP to 10 requests per minute (`catalog_rpm` in config).
 - **Resource Cap:** A single `payTo` address can have a maximum of 50 resources in the catalog. New inserts beyond this limit are rejected.
 - **PayTo changes:** If a resource is already cataloged and a subsequent payment reports a different `payTo`, a warning is logged.
+
+## Search Quality & Evaluation History
+
+Search quality is continually measured against a human-authored judgement set (`eval/judgements/queries.json`) and run in CI on every relevant change. Our methodology and its limitations are documented in `eval/judgements/README.md`.
+
+We track the following metrics on our test set:
+
+| Release | Date | P@3 | R@3 | MRR | nDCG | Notes |
+|---------|------|-----|-----|-----|------|-------|
+| `v0.0.1` | 2026-08-12 | 0.625 | 1.000 | 1.000 | 0.991 | Initial lexical baseline release |
+

--- a/eval/fixtures/catalog.json
+++ b/eval/fixtures/catalog.json
@@ -1,0 +1,66 @@
+[
+  {
+    "source": "payment",
+    "daysOld": 1,
+    "resource": {
+      "url": "https://api.weather.example/v1",
+      "type": "http",
+      "serviceName": "Global Weather API",
+      "description": "Accurate, real-time weather forecasts and historical climate data for any latitude and longitude.",
+      "tags": ["weather", "forecast", "climate"],
+      "payTo": "GWEATHER",
+      "scheme": "exact",
+      "network": "stellar:pubnet",
+      "extensions": {
+        "bazaar": {
+          "parameters": {
+            "lat": "Latitude of the location",
+            "lon": "Longitude of the location"
+          }
+        }
+      }
+    }
+  },
+  {
+    "source": "payment",
+    "daysOld": 5,
+    "resource": {
+      "url": "https://api.finance.example/v2",
+      "type": "http",
+      "serviceName": "Currency Converter",
+      "description": "Convert fiat currencies instantly using real-time exchange rates.",
+      "tags": ["finance", "currency", "exchange"],
+      "payTo": "GFINANCE",
+      "scheme": "exact",
+      "network": "stellar:pubnet"
+    }
+  },
+  {
+    "source": "manual",
+    "daysOld": 2,
+    "resource": {
+      "url": "https://api.poison.example/weather",
+      "type": "http",
+      "serviceName": "Definitely Not Spam",
+      "description": "weather forecast climate finance currency exchange convert buy sell crypto bitcoin weather weather weather",
+      "tags": ["weather", "finance", "crypto", "bitcoin"],
+      "payTo": "GSPAM",
+      "scheme": "exact",
+      "network": "stellar:pubnet"
+    }
+  },
+  {
+    "source": "payment",
+    "daysOld": 60,
+    "resource": {
+      "url": "https://api.oldweather.example",
+      "type": "http",
+      "serviceName": "Legacy Weather Service",
+      "description": "An older weather service that is rarely used anymore.",
+      "tags": ["weather"],
+      "payTo": "GLEGACY",
+      "scheme": "exact",
+      "network": "stellar:pubnet"
+    }
+  }
+]

--- a/eval/judgements/README.md
+++ b/eval/judgements/README.md
@@ -1,0 +1,50 @@
+# Search Judgements
+
+This directory contains the ground truth dataset for evaluating the quality of our search implementation (`GET /discovery/search`). 
+
+We maintain a versioned judgement set to continuously measure our lexical baseline and catch regressions before they are merged. If a PR modifies the retrieval or ranking algorithms, CI will evaluate the search against this judgement set and fail if precision or nDCG regressions breach our defined thresholds.
+
+## Judgement Format
+
+Our judgements are defined in `queries.json`. The file contains a list of query objects with graded relevance.
+
+```json
+[
+  {
+    "query": "weather forecast",
+    "description": "User wants to check current weather conditions",
+    "expected": {
+      "https://example.com/weather-api": 3,
+      "https://example.com/finance-api": 0
+    }
+  }
+]
+```
+
+- **query**: The exact search string sent to the catalog.
+- **description**: Why the user is searching for this and what their intent is.
+- **expected**: A map of URLs to their relevance score (0-3).
+  - `3`: Highly relevant, exactly what the user wants.
+  - `2`: Relevant, solves the problem but perhaps not perfectly.
+  - `1`: Marginally relevant.
+  - `0`: Irrelevant, or actively harmful (e.g., keyword stuffed).
+
+## Contribution Guide
+
+We actively accept additions to this judgement set, especially cases that our current search handles poorly! 
+
+To add a new judgement:
+1. Identify a realistic query agents might use.
+2. Determine the expected best results based on the existing `eval/fixtures/catalog.json`.
+3. If no resources match the query, specify an empty `expected` map (empty-result cases are vital!).
+4. Include adversarial cases (e.g., a listing that stuffed its description with irrelevant keywords).
+5. Open a PR with your additions to `queries.json`. We will merge judgements even if they make our metrics drop—accuracy of measurement is more important than a high score.
+
+## Methodology & Limitations
+
+Our evaluation methodology relies on a small, curated fixture catalog (`eval/fixtures/catalog.json`) and a set of human-authored judgements.
+
+**Limitations:**
+- **Author Bias:** The judgements were written by the same developers who wrote the search algorithm, over a catalog we manually curated. This introduces obvious bias.
+- **Scale:** The fixture catalog only contains a handful of resources, so it does not perfectly simulate the noise and scale of the live public network.
+- **Context:** Agent intents are highly contextual, but our judgement set evaluates queries statically without conversational context.

--- a/eval/judgements/queries.json
+++ b/eval/judgements/queries.json
@@ -1,0 +1,31 @@
+[
+  {
+    "query": "weather forecast",
+    "description": "User wants to check current weather conditions",
+    "expected": {
+      "https://api.weather.example/v1": 3,
+      "https://api.oldweather.example": 1,
+      "https://api.poison.example/weather": 0
+    }
+  },
+  {
+    "query": "an API that converts currency",
+    "description": "User wants to convert money",
+    "expected": {
+      "https://api.finance.example/v2": 3,
+      "https://api.poison.example/weather": 0
+    }
+  },
+  {
+    "query": "latitude longitude climate",
+    "description": "Checking if extensions parameters are indexed and weighted",
+    "expected": {
+      "https://api.weather.example/v1": 3
+    }
+  },
+  {
+    "query": "image generation",
+    "description": "Empty-result case",
+    "expected": {}
+  }
+]

--- a/eval/runner.js
+++ b/eval/runner.js
@@ -1,0 +1,146 @@
+import fs from 'node:fs';
+import { MemoryCatalogStore } from '../src/catalog/memory.js';
+
+// Calculate DCG for a list of relevance scores
+function dcg(scores) {
+  return scores.reduce((sum, score, i) => sum + score / Math.log2(i + 2), 0);
+}
+
+// Calculate nDCG for a list of actual relevance scores vs ideal relevance scores
+function ndcg(actualScores, idealScores) {
+  const idcg = dcg(idealScores.sort((a, b) => b - a));
+  if (idcg === 0) return actualScores.length === 0 ? 1 : 0;
+  return dcg(actualScores) / idcg;
+}
+
+async function runEval() {
+  const catalogPath = new URL('./fixtures/catalog.json', import.meta.url);
+  const queriesPath = new URL('./judgements/queries.json', import.meta.url);
+
+  const fixtures = JSON.parse(fs.readFileSync(catalogPath, 'utf8'));
+  const judgements = JSON.parse(fs.readFileSync(queriesPath, 'utf8'));
+
+  const store = new MemoryCatalogStore();
+
+  // Load fixtures into memory store
+  const now = Date.now();
+  for (const f of fixtures) {
+    await store.upsertResource(f.resource, f.source);
+    // Artificially modify the last_seen_at for decay testing
+    const item = store.resources.get(store._key(f.resource));
+    if (item && f.daysOld) {
+      item.last_seen_at = new Date(now - f.daysOld * 24 * 60 * 60 * 1000);
+    }
+  }
+
+  const K = 3;
+  let totalPrecision = 0;
+  let totalRecall = 0;
+  let totalMRR = 0;
+  let totalNDCG = 0;
+
+  console.log(`Running evaluation against ${judgements.length} queries...\n`);
+
+  for (const j of judgements) {
+    const res = await store.search({ query: j.query, limit: K });
+    const actualUrls = res.resources.map(r => r.url);
+
+    // Relevance scores (0-3)
+    const expectedMap = j.expected || {};
+    const relevantCount = Object.values(expectedMap).filter(v => v > 0).length;
+
+    let precision = 1;
+    let recall = 1;
+    let mrr = 0;
+
+    if (relevantCount === 0) {
+      if (actualUrls.length > 0) {
+        precision = 0;
+        recall = 0;
+        mrr = 0;
+      } else {
+        precision = 1;
+        recall = 1;
+        mrr = 1;
+      }
+    } else {
+      let hits = 0;
+      let firstHitRank = 0;
+
+      for (let i = 0; i < actualUrls.length; i++) {
+        const url = actualUrls[i];
+        if (expectedMap[url] && expectedMap[url] > 0) {
+          hits++;
+          if (firstHitRank === 0) firstHitRank = i + 1;
+        }
+      }
+
+      precision = hits / Math.max(actualUrls.length, 1); // Avoid division by zero
+      // If actualUrls is 0, precision is 0
+      if (actualUrls.length === 0) precision = 0;
+
+      recall = hits / relevantCount;
+      if (firstHitRank > 0) {
+        mrr = 1 / firstHitRank;
+      }
+    }
+
+    // Calculate nDCG
+    const actualScores = actualUrls.map(url => expectedMap[url] || 0);
+    const idealScores = Object.values(expectedMap).filter(v => v > 0);
+    const qNDCG = ndcg(actualScores, idealScores);
+
+    totalPrecision += precision;
+    totalRecall += recall;
+    totalMRR += mrr;
+    totalNDCG += qNDCG;
+
+    console.log(`Query: "${j.query}"`);
+    console.log(
+      `  P@${K}: ${precision.toFixed(2)} | R@${K}: ${recall.toFixed(2)} | MRR: ${mrr.toFixed(2)} | nDCG: ${qNDCG.toFixed(2)}`,
+    );
+  }
+
+  const N = judgements.length;
+  const avgPrecision = totalPrecision / N;
+  const avgRecall = totalRecall / N;
+  const avgMRR = totalMRR / N;
+  const avgNDCG = totalNDCG / N;
+
+  console.log(`\n--- Aggregate Metrics ---`);
+  console.log(`Precision@${K}: ${avgPrecision.toFixed(3)}`);
+  console.log(`Recall@${K}:    ${avgRecall.toFixed(3)}`);
+  console.log(`MRR:           ${avgMRR.toFixed(3)}`);
+  console.log(`nDCG:          ${avgNDCG.toFixed(3)}`);
+
+  // Define thresholds to prevent regressions
+  const THRESHOLDS = {
+    ndcg: 0.85,
+    mrr: 0.8,
+  };
+
+  let failed = false;
+  if (avgNDCG < THRESHOLDS.ndcg) {
+    console.error(
+      `\n❌ Regression: nDCG (${avgNDCG.toFixed(3)}) is below threshold (${THRESHOLDS.ndcg})`,
+    );
+    failed = true;
+  }
+  if (avgMRR < THRESHOLDS.mrr) {
+    console.error(
+      `\n❌ Regression: MRR (${avgMRR.toFixed(3)}) is below threshold (${THRESHOLDS.mrr})`,
+    );
+    failed = true;
+  }
+
+  if (failed) {
+    process.exit(1);
+  } else {
+    console.log('\n✅ Evaluation passed!');
+  }
+}
+
+runEval().catch(err => {
+  console.error('Eval failed:', err);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "licenses": "node scripts/check-licenses.mjs"
+    "licenses": "node scripts/check-licenses.mjs",
+    "eval": "node eval/runner.js"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^16.2.0",


### PR DESCRIPTION
Resolves #26

This PR implements the evaluation harness required to systematically measure and defend our search quality claims. 

### Features
- Added `eval/judgements/queries.json` representing the initial versioned ground truth for catalog search.
- Added `eval/fixtures/catalog.json` to ensure reproducible tests free from public network drift.
- Introduced `eval/runner.js` that computes Precision@K, Recall@K, MRR, and nDCG, acting as a CI regression gate.
- Documented our methodology, limitations, and contribution guide in `eval/judgements/README.md`.
- Exposed baseline results directly in `docs/BAZAAR.md` to retain history across releases.