### PR TITLE
feat(mcp): agent-facing MCP server — resource search and a paid-call proxy

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,0 +1,65 @@
+# x402 Agent MCP Server
+
+This repository includes a standalone Model Context Protocol (MCP) server that empowers any MCP-compatible agent to discover, verify, and call paid x402 endpoints natively. It transforms paid API integration from a manual coding task into a simple tool call.
+
+## Features
+
+- **Agent-facing Discovery**: Exposes the facilitator catalog directly to the agent's context.
+- **Automated Payment Negotiation**: Handles HTTP 402 responses, `x402` payload signing, and payment injection transparently.
+- **Hard Spending Controls**: Enforces strict per-call and per-session max spending limits, rejecting any over-budget calls before money is moved.
+- **Secure Key Custody**: Key is provided at startup via environment variable and is never logged or exposed to the model.
+
+## Installation & Configuration
+
+The MCP server is implemented as a standard Node.js stdio script.
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `AGENT_PAYER_SECRET_KEY` | **(Required for `call_paid_resource`)** Stellar Ed25519 Secret Key to pay for API calls. | *none* |
+| `MAX_FEE_PER_CALL_STROOPS` | Max amount willing to pay for a single API call (in stroops). | `1000` (0.0001 XLM) |
+| `MAX_SESSION_SPEND_STROOPS`| Max amount willing to pay per session (in stroops). | `10000` (0.001 XLM) |
+| `FACILITATOR_URL` | Facilitator endpoint for catalog discovery. | `http://localhost:3402` |
+| `NETWORK` | Stellar network to use. | `stellar:testnet` |
+
+### Adding to Claude Desktop
+
+Add the following to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "x402-stellar": {
+      "command": "node",
+      "args": ["/path/to/x402-facilitator-stellar/src/mcp/cli.js"],
+      "env": {
+        "AGENT_PAYER_SECRET_KEY": "S...YOUR_TESTNET_KEY...",
+        "MAX_FEE_PER_CALL_STROOPS": "1000",
+        "MAX_SESSION_SPEND_STROOPS": "50000",
+        "FACILITATOR_URL": "http://localhost:3402"
+      }
+    }
+  }
+}
+```
+
+## Available Tools
+
+The MCP server exposes three tools to the agent:
+
+1. **`search_resources` (Free)**: Search the facilitator's catalog using natural language and filters. Returns resource metadata including parameter descriptions.
+2. **`get_resource` (Free)**: Get full metadata and pricing information for a specific resource URL.
+3. **`call_paid_resource` (Paid)**: Call a paid endpoint. The tool handles the 402 negotiation and payment automatically. **This tool will spend money.**
+
+## Worked Example
+
+Agent prompt:
+> "Find a weather API in the x402 catalog, get the forecast for London, and tell me if it will rain."
+
+What the agent does:
+1. Calls `search_resources` with `{"query": "weather forecast"}`.
+2. Reads the returned parameters and pricing.
+3. Calls `call_paid_resource` with `{"url": "...", "method": "GET"}`.
+4. The MCP proxy intercepts the 402 response, signs the payment payload using `AGENT_PAYER_SECRET_KEY`, resubmits the request, and returns the weather data to the agent.
+5. The agent responds to the user: "It will not rain in London today."

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "node": ">=20"
   },
   "bin": {
-    "validate-discovery": "./src/sdk/cli.js"
+    "validate-discovery": "./src/sdk/cli.js",
+    "x402-mcp": "./src/mcp/cli.js"
   },
   "scripts": {
     "start": "node src/server.js",

--- a/src/mcp/cli.js
+++ b/src/mcp/cli.js
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+
+import { McpServer } from './server.js';
+import { x402Client, x402HTTPClient } from '@x402/core/client';
+import { ExactStellarScheme as ExactStellarClient } from '@x402/stellar/exact/client';
+import { createEd25519Signer } from '@x402/stellar';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+const FACILITATOR_URL = process.env.FACILITATOR_URL || 'http://localhost:3402';
+const AGENT_PAYER_SECRET_KEY = process.env.AGENT_PAYER_SECRET_KEY;
+const NETWORK = process.env.NETWORK || 'stellar:testnet';
+
+// Conservative defaults (in stroops: 1 XLM = 10_000_000 stroops).
+// Default max per-call: 1000 stroops = 0.0001 XLM
+// Default max per-session: 10000 stroops = 0.001 XLM
+const MAX_FEE_PER_CALL_STROOPS = BigInt(process.env.MAX_FEE_PER_CALL_STROOPS || '1000');
+const MAX_SESSION_SPEND_STROOPS = BigInt(process.env.MAX_SESSION_SPEND_STROOPS || '10000');
+
+let sessionSpendStroops = 0n;
+
+// Setup x402 client if key is provided
+let x402HttpClient = null;
+if (AGENT_PAYER_SECRET_KEY) {
+  try {
+    const payer = createEd25519Signer(AGENT_PAYER_SECRET_KEY, NETWORK);
+    const client = new x402Client().register(NETWORK, new ExactStellarClient(payer));
+    x402HttpClient = new x402HTTPClient(client);
+  } catch (err) {
+    console.error(`Failed to initialize payer signer: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+async function fetchDiscovery(path, params) {
+  const url = new URL(`${FACILITATOR_URL}${path}`);
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      if (v !== undefined && v !== null) {
+        if (Array.isArray(v)) {
+          v.forEach(val => url.searchParams.append(k, val));
+        } else {
+          url.searchParams.append(k, String(v));
+        }
+      }
+    }
+  }
+
+  const res = await fetch(url);
+  if (!res.ok) {
+    let msg = `HTTP ${res.status}`;
+    try {
+      const errBody = await res.json();
+      if (errBody.invalidReason) msg = errBody.invalidReason;
+    } catch {
+      // Ignore parse errors from the error body
+    }
+    throw new Error(`Facilitator request failed: ${msg}`);
+  }
+  return res.json();
+}
+
+function assertCanSpend(amountStroops) {
+  const amount = BigInt(amountStroops);
+  if (amount > MAX_FEE_PER_CALL_STROOPS) {
+    throw new Error(
+      `Spending refused: Request amount (${amount} stroops) exceeds per-call limit (${MAX_FEE_PER_CALL_STROOPS} stroops).`,
+    );
+  }
+  if (sessionSpendStroops + amount > MAX_SESSION_SPEND_STROOPS) {
+    throw new Error(
+      `Spending refused: Request amount (${amount} stroops) exceeds remaining session budget (spent ${sessionSpendStroops}/${MAX_SESSION_SPEND_STROOPS} stroops).`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// MCP Server Initialization
+// ---------------------------------------------------------------------------
+const server = new McpServer({
+  name: 'x402-facilitator-stellar-mcp',
+  version: '0.0.1',
+});
+
+// Tool 1: search_resources
+server.tool(
+  'search_resources',
+  {
+    description:
+      'Search for x402 paid and free resources in the facilitator catalog. Does NOT spend money.',
+    properties: {
+      query: { type: 'string', description: 'Natural language search query' },
+      limit: { type: 'number', description: 'Number of results to return (max 100)' },
+      type: { type: 'string', description: 'Filter by resource type (e.g. "http", "mcp")' },
+      extensions: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Required extensions (e.g. "bazaar")',
+      },
+      payTo: { type: 'string', description: 'Filter by payee Stellar account ID' },
+      scheme: { type: 'string', description: 'Payment scheme (e.g. "exact")' },
+      network: { type: 'string', description: 'Network identifier (e.g. "stellar:testnet")' },
+    },
+  },
+  async args => {
+    return await fetchDiscovery('/discovery/search', args);
+  },
+);
+
+// Tool 2: get_resource
+server.tool(
+  'get_resource',
+  {
+    description:
+      'Get full metadata and pricing information for a specific x402 resource. Does NOT spend money.',
+    properties: {
+      url: { type: 'string', description: 'Resource URL to fetch metadata for' },
+      toolName: {
+        type: 'string',
+        description: 'Optional MCP tool name, required if the resource is an MCP tool',
+      },
+    },
+    required: ['url'],
+  },
+  async args => {
+    const res = await fetchDiscovery('/discovery/resources', {
+      url: args.url,
+      toolName: args.toolName,
+    });
+    if (!res.resources || res.resources.length === 0) {
+      throw new Error(`Resource not found in catalog.`);
+    }
+    return res.resources[0];
+  },
+);
+
+// Tool 3: call_paid_resource
+server.tool(
+  'call_paid_resource',
+  {
+    description:
+      'Proxy tool that handles discovery, HTTP 402 negotiation, payment via x402, and retrieves the resource. This tool WILL SPEND MONEY up to your configured caps.',
+    properties: {
+      url: { type: 'string', description: 'The endpoint URL to call' },
+      method: { type: 'string', description: 'HTTP method (default: GET)' },
+      body: { type: 'string', description: 'JSON stringified body payload for POST/PUT requests' },
+      maxFeeStroops: {
+        type: 'string',
+        description:
+          'Maximum willing to pay in stroops for this specific call (optional). Still bounded by the global per-call cap.',
+      },
+    },
+    required: ['url'],
+  },
+  async args => {
+    if (!x402HttpClient) {
+      throw new Error('call_paid_resource requires AGENT_PAYER_SECRET_KEY to be configured.');
+    }
+
+    const { url, method = 'GET', body, maxFeeStroops } = args;
+
+    // 1. Initial Unpaid Request
+    const options = { method };
+    if (body) {
+      options.body = body;
+      options.headers = { 'Content-Type': 'application/json' };
+    }
+
+    const unpaidRes = await fetch(url, options);
+
+    if (unpaidRes.status !== 402) {
+      // Endpoint is not gated or we somehow bypassed it
+      const text = await unpaidRes.text();
+      return {
+        success: true,
+        status: unpaidRes.status,
+        response: text,
+      };
+    }
+
+    // 2. Parse 402 Payment Requirements
+    const errBody = await unpaidRes
+      .clone()
+      .json()
+      .catch(() => undefined);
+    let paymentRequired;
+    try {
+      paymentRequired = x402HttpClient.getPaymentRequiredResponse(
+        name => unpaidRes.headers.get(name),
+        errBody,
+      );
+    } catch (err) {
+      throw new Error(`Failed to parse payment requirements: ${err.message}`);
+    }
+
+    const req0 = paymentRequired.accepts?.[0];
+    if (!req0) {
+      throw new Error('Resource returned 402 but provided no payment accepts requirements.');
+    }
+
+    const amountStr = req0.maxAmountRequired || req0.price?.amount || '0';
+    const amount = BigInt(amountStr);
+
+    // 3. Spending Controls
+    assertCanSpend(amount);
+    if (maxFeeStroops && amount > BigInt(maxFeeStroops)) {
+      throw new Error(
+        `Spending refused: Request amount (${amount} stroops) exceeds requested maxFeeStroops (${maxFeeStroops}).`,
+      );
+    }
+
+    // 4. Create Payment Payload & Sign
+    let paymentPayload;
+    try {
+      paymentPayload = await x402HttpClient.createPaymentPayload(paymentRequired);
+    } catch (err) {
+      throw new Error(`Failed to create payment payload: ${err.message}`);
+    }
+
+    // 5. Send Paid Request
+    const paidHeaders = {
+      ...options.headers,
+      ...x402HttpClient.encodePaymentSignatureHeader(paymentPayload),
+    };
+
+    const paidRes = await fetch(url, { ...options, headers: paidHeaders });
+    const responseText = await paidRes.text();
+
+    const settle = x402HttpClient.getPaymentSettleResponse(name => paidRes.headers.get(name));
+
+    if (paidRes.status !== 200) {
+      throw new Error(
+        `Paid request failed (${paidRes.status}): ${settle?.errorReason || 'unknown'}. ${responseText.slice(0, 200)}`,
+      );
+    }
+
+    // 6. Record Spend
+    sessionSpendStroops += amount;
+
+    return {
+      success: true,
+      settlement: settle,
+      response: responseText,
+    };
+  },
+);
+
+// Start server
+server.start();

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -1,0 +1,112 @@
+import { createInterface } from 'readline';
+
+/**
+ * Minimal MCP Stdio Server
+ */
+export class McpServer {
+  constructor({ name, version }) {
+    this.name = name;
+    this.version = version;
+    this.tools = new Map();
+  }
+
+  tool(name, schema, handler) {
+    this.tools.set(name, { schema, handler });
+  }
+
+  async start() {
+    const rl = createInterface({
+      input: process.stdin,
+      output: process.stdout,
+      terminal: false,
+    });
+
+    rl.on('line', async line => {
+      if (!line.trim()) return;
+      let req;
+      try {
+        req = JSON.parse(line);
+      } catch {
+        this._sendError(null, -32700, 'Parse error');
+        return;
+      }
+
+      try {
+        await this._handleRequest(req);
+      } catch (err) {
+        this._sendError(req.id, -32603, 'Internal error', err.message);
+      }
+    });
+  }
+
+  async _handleRequest(req) {
+    if (req.method === 'initialize') {
+      this._sendResult(req.id, {
+        protocolVersion: '2024-11-05',
+        serverInfo: { name: this.name, version: this.version },
+        capabilities: { tools: {} },
+      });
+    } else if (req.method === 'tools/list') {
+      const tools = Array.from(this.tools.entries()).map(([name, { schema }]) => ({
+        name,
+        description: schema.description || '',
+        inputSchema: {
+          type: 'object',
+          properties: schema.properties || {},
+          required: schema.required || [],
+        },
+      }));
+      this._sendResult(req.id, { tools });
+    } else if (req.method === 'tools/call') {
+      const toolName = req.params?.name;
+      const toolArgs = req.params?.arguments || {};
+      const tool = this.tools.get(toolName);
+
+      if (!tool) {
+        this._sendError(req.id, -32601, 'Method not found');
+        return;
+      }
+
+      try {
+        const result = await tool.handler(toolArgs);
+        this._sendResult(req.id, {
+          content: [
+            {
+              type: 'text',
+              text: typeof result === 'string' ? result : JSON.stringify(result, null, 2),
+            },
+          ],
+          isError: false,
+        });
+      } catch (err) {
+        // Return structured errors inside the MCP tool result where possible
+        if (err.isToolError) {
+          this._sendResult(req.id, {
+            content: [{ type: 'text', text: JSON.stringify(err.payload || err.message, null, 2) }],
+            isError: true,
+          });
+        } else {
+          this._sendError(req.id, -32603, err.message);
+        }
+      }
+    } else if (req.method === 'ping') {
+      this._sendResult(req.id, {});
+    } else if (req.method === 'notifications/initialized') {
+      // no response needed
+    } else {
+      if (req.id !== undefined) {
+        this._sendError(req.id, -32601, 'Method not found');
+      }
+    }
+  }
+
+  _sendResult(id, result) {
+    const res = { jsonrpc: '2.0', id, result };
+    process.stdout.write(JSON.stringify(res) + '\n');
+  }
+
+  _sendError(id, code, message, data) {
+    const res = { jsonrpc: '2.0', id, error: { code, message, data } };
+    process.stdout.write(JSON.stringify(res) + '\n');
+  }
+}

--- a/test/mcp.test.js
+++ b/test/mcp.test.js
@@ -11,6 +11,7 @@ function createMcpClient(env) {
     env: { ...process.env, ...env },
     stdio: ['pipe', 'pipe', 'pipe'],
   });
+  child.stderr.on('data', d => process.stderr.write(d));
 
   let messageId = 1;
   const pending = new Map();
@@ -40,6 +41,13 @@ function createMcpClient(env) {
     }
   });
 
+  child.on('exit', (code) => {
+    for (const { reject } of pending.values()) {
+      reject(new Error(`Child exited with code ${code}`));
+    }
+    pending.clear();
+  });
+
   return {
     callTool: (name, args) => {
       return new Promise((resolve, reject) => {
@@ -62,7 +70,7 @@ function createMcpClient(env) {
 
 test('MCP Server Spending Controls', async t => {
   const client = createMcpClient({
-    AGENT_PAYER_SECRET_KEY: 'SBUVX4M65C5HHKO2J75Y7EGBYJ2UHY4ZIVW5JDFOYY6AUPXUKOIMXG4T', // valid testnet key
+    AGENT_PAYER_SECRET_KEY: 'SBTJBX7IF3W4IU2VRQXK2PPEAQJW5PZTRUQPL4CVIBEL42OE3YLETWWW', // valid testnet key
     MAX_FEE_PER_CALL_STROOPS: '500',
     MAX_SESSION_SPEND_STROOPS: '1000',
   });
@@ -82,6 +90,7 @@ test('MCP Server Spending Controls', async t => {
       res.end(
         JSON.stringify({
           error: 'payment_required',
+          x402Version: 1,
           accepts: [
             {
               scheme: 'exact',
@@ -99,6 +108,7 @@ test('MCP Server Spending Controls', async t => {
       res.end(
         JSON.stringify({
           error: 'payment_required',
+          x402Version: 1,
           accepts: [
             {
               scheme: 'exact',
@@ -121,12 +131,12 @@ test('MCP Server Spending Controls', async t => {
 
   await t.test('enforces per-call cap (600 > 500)', async () => {
     try {
+      console.log('Sending call_paid_resource...');
       await client.callTool('call_paid_resource', { url: url600 });
-      // The tool result itself has isError: true when error is handled.
-      // Wait, in my server implementation, if err.isToolError is true, it returns isError: true.
-      // But my errors are standard Error, so they go to _sendError and reject!
+      console.log('Received response from call_paid_resource, failing test');
       assert.fail('Should have rejected');
     } catch (err) {
+      console.log('Caught error:', err.message);
       assert.match(err.message, /Spending refused.*exceeds per-call limit/);
     }
   });

--- a/test/mcp.test.js
+++ b/test/mcp.test.js
@@ -1,0 +1,137 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const CLI_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), '../src/mcp/cli.js');
+
+function createMcpClient(env) {
+  const child = spawn(process.execPath, [CLI_PATH], {
+    env: { ...process.env, ...env },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  let messageId = 1;
+  const pending = new Map();
+
+  let buffer = '';
+  child.stdout.on('data', chunk => {
+    buffer += chunk.toString();
+    const lines = buffer.split('\n');
+    buffer = lines.pop();
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const msg = JSON.parse(line);
+        if (msg.id !== undefined && pending.has(msg.id)) {
+          const { resolve, reject } = pending.get(msg.id);
+          pending.delete(msg.id);
+          if (msg.error) {
+            reject(new Error(msg.error.message));
+          } else {
+            resolve(msg.result);
+          }
+        }
+      } catch {
+        console.error('Failed to parse MCP response:', line);
+      }
+    }
+  });
+
+  return {
+    callTool: (name, args) => {
+      return new Promise((resolve, reject) => {
+        const id = messageId++;
+        pending.set(id, { resolve, reject });
+        const req = JSON.stringify({
+          jsonrpc: '2.0',
+          id,
+          method: 'tools/call',
+          params: { name, arguments: args },
+        });
+        child.stdin.write(req + '\n');
+      });
+    },
+    close: () => {
+      child.kill();
+    },
+  };
+}
+
+test('MCP Server Spending Controls', async t => {
+  const client = createMcpClient({
+    AGENT_PAYER_SECRET_KEY: 'SBUVX4M65C5HHKO2J75Y7EGBYJ2UHY4ZIVW5JDFOYY6AUPXUKOIMXG4T', // valid testnet key
+    MAX_FEE_PER_CALL_STROOPS: '500',
+    MAX_SESSION_SPEND_STROOPS: '1000',
+  });
+
+  // Since we don't have a real HTTP endpoint to hit in this unit test that returns 402,
+  // we will rely on the fact that if it exceeds limits, it throws immediately before fetching,
+  // or after fetching when reading 402 requirements.
+  // Wait, the MCP server performs a fetch first (Unpaid). If the mock endpoint doesn't exist, it will throw fetch error.
+  // We can mock an HTTP server to return a 402 with specific price.
+
+  const http = await import('node:http');
+  const server = http.createServer((req, res) => {
+    if (req.url === '/test-200-stroops') {
+      res.writeHead(402, {
+        'Content-Type': 'application/json',
+      });
+      res.end(
+        JSON.stringify({
+          error: 'payment_required',
+          accepts: [
+            {
+              scheme: 'exact',
+              network: 'stellar:testnet',
+              price: { asset: 'native', amount: '200' },
+              payTo: 'GBQ...',
+            },
+          ],
+        }),
+      );
+    } else if (req.url === '/test-600-stroops') {
+      res.writeHead(402, {
+        'Content-Type': 'application/json',
+      });
+      res.end(
+        JSON.stringify({
+          error: 'payment_required',
+          accepts: [
+            {
+              scheme: 'exact',
+              network: 'stellar:testnet',
+              price: { asset: 'native', amount: '600' },
+              payTo: 'GBQ...',
+            },
+          ],
+        }),
+      );
+    } else {
+      res.writeHead(404);
+      res.end();
+    }
+  });
+
+  await new Promise(r => server.listen(0, r));
+  const port = server.address().port;
+  const url600 = `http://localhost:${port}/test-600-stroops`;
+
+  await t.test('enforces per-call cap (600 > 500)', async () => {
+    try {
+      await client.callTool('call_paid_resource', { url: url600 });
+      // The tool result itself has isError: true when error is handled.
+      // Wait, in my server implementation, if err.isToolError is true, it returns isError: true.
+      // But my errors are standard Error, so they go to _sendError and reject!
+      assert.fail('Should have rejected');
+    } catch (err) {
+      assert.match(err.message, /Spending refused.*exceeds per-call limit/);
+    }
+  });
+
+  server.closeAllConnections();
+  server.close();
+  client.close();
+});

--- a/test/mcp.test.js
+++ b/test/mcp.test.js
@@ -41,7 +41,7 @@ function createMcpClient(env) {
     }
   });
 
-  child.on('exit', (code) => {
+  child.on('exit', code => {
     for (const { reject } of pending.values()) {
       reject(new Error(`Child exited with code ${code}`));
     }


### PR DESCRIPTION
Resolves #28

This PR implements the agent-facing Model Context Protocol (MCP) server, completely decoupling the AI agent workflow from the manual API integration process.

### What was implemented:
- **Standalone MCP Server**: Implemented a lightweight `x402-mcp` CLI that serves MCP over `stdio`. It correctly speaks JSON-RPC 2.0 without pulling in heavy SDK dependencies since they were timing out in restricted environments.
- **Tools**:
  - `search_resources`: Uses the Facilitator's discovery API with all available filters.
  - `get_resource`: Fetches specific resource metadata.
  - `call_paid_resource`: The core proxy tool. Automatically performs 402 negotiation, builds and signs the x402 payment payload, injects it into the request, and retrieves the secure payload.
- **Hard Spending Controls**: Configurable `MAX_FEE_PER_CALL_STROOPS` and `MAX_SESSION_SPEND_STROOPS` strictly enforce boundaries. Surpassing these triggers an unrecoverable hard rejection *before* any network activity touches the Stellar ledger.
- **Safe Key Custody**: Requires `AGENT_PAYER_SECRET_KEY` in the environment to function. The key is securely passed to the signer and never exposed to the LLM context or network logs.
- **Consent Boundaries**: Tool descriptions make it explicitly clear which tools 'WILL SPEND MONEY' and which 'Does NOT spend money', satisfying LLM consent expectations.
- **Documentation**: Comprehensive instructions and configuration examples for Claude Desktop are provided in `docs/MCP.md`.
- **Packaging**: Exposed the `x402-mcp` binary in `package.json`.