### PR TITLE
ci: run the upstream x402 e2e suite against this facilitator

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -68,9 +68,19 @@ jobs:
         with:
           version: 10
 
-      - name: Install the e2e harness
+      # setup.sh shells out to Go and uv for the non-TypeScript components. Go
+      # is preinstalled on the runner; uv is not.
+      - name: Install uv (needed by the harness setup for python components)
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      # `pnpm install` is NOT enough. install:all is `pnpm install && ./setup.sh`,
+      # and setup.sh is what builds the workspace @x402/* packages the spawned
+      # servers import. Without it every server dies at startup with
+      # "Cannot find module '@x402/express/dist/cjs/index.js'" — which is how the
+      # first run of this job failed.
+      - name: Install and build the e2e harness
         working-directory: x402/e2e
-        run: pnpm install --frozen-lockfile
+        run: pnpm install:all
 
       # The upstream directory is gitignored, which is the documented place for
       # a facilitator whose implementation does not live in that repository.
@@ -109,7 +119,13 @@ jobs:
         continue-on-error: true
         run: |
           set -o pipefail
-          pnpm test --testnet --families=stellar --min -v 2>&1 | tee ../../conformance-output.txt
+          # --facilitators=accensa matters. Without it the harness also starts
+          # its own reference facilitators, and a failure in one of those aborts
+          # the run before ours is ever exercised — which is what happened on the
+          # first run of this job, and is a fact about the harness rather than
+          # evidence about this service.
+          pnpm test --testnet --families=stellar --facilitators=accensa --min -v 2>&1 \
+            | tee ../../conformance-output.txt
 
       - name: Summarise
         if: always()

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -73,11 +73,25 @@ jobs:
       - name: Install uv (needed by the harness setup for python components)
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
-      # `pnpm install` is NOT enough. install:all is `pnpm install && ./setup.sh`,
-      # and setup.sh is what builds the workspace @x402/* packages the spawned
-      # servers import. Without it every server dies at startup with
-      # "Cannot find module '@x402/express/dist/cjs/index.js'" — which is how the
-      # first run of this job failed.
+      # The SDK monorepo has to be built before the harness, and upstream's own
+      # instructions do not say so. e2e/pnpm-workspace.yaml pulls in
+      # `../typescript/packages/*` as workspace packages, so `pnpm install`
+      # symlinks them — but nothing builds them, and every spawned server
+      # imports `@x402/<adapter>/dist/cjs/index.js`. Without this step each
+      # server dies at startup with MODULE_NOT_FOUND on a path inside
+      # `e2e/servers/typescript/node_modules/@x402/…`, which reads like a
+      # missing dependency and is really an unbuilt one.
+      #
+      # Everything is built rather than a filtered subset: servers/typescript
+      # declares a workspace dependency on all eighteen @x402/* packages and
+      # registers schemes for them at boot, so a filtered build just moves the
+      # same failure to whichever package the filter missed.
+      - name: Build the @x402/* workspace packages
+        working-directory: x402/typescript
+        run: |
+          pnpm install
+          pnpm build
+
       - name: Install the e2e harness
         working-directory: x402/e2e
         run: pnpm install

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -78,9 +78,37 @@ jobs:
       # servers import. Without it every server dies at startup with
       # "Cannot find module '@x402/express/dist/cjs/index.js'" — which is how the
       # first run of this job failed.
-      - name: Install and build the e2e harness
+      - name: Install the e2e harness
         working-directory: x402/e2e
-        run: pnpm install:all
+        run: pnpm install
+
+      # Split from install, and allowed to fail, because setup.sh builds all
+      # fifteen upstream components and exits non-zero if any one of them fails
+      # — including components on no Stellar code path. On 2026-08-12 a broken
+      # `server/typescript/http/next` build ended this job before a single
+      # scenario ran. Which failures actually matter is decided in the next
+      # step, not by setup.sh's exit code.
+      #
+      # -v because setup.sh swallows all build output without it, and a failure
+      # you cannot read is a failure you cannot report upstream.
+      - name: Build the e2e components
+        id: setup
+        working-directory: x402/e2e
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          ./setup.sh -v 2>&1 | tee "$GITHUB_WORKSPACE/setup-output.txt"
+
+      # Drops components whose build failed, and fails outright if that would
+      # leave nothing to run or if our own facilitator is the thing that broke.
+      - name: Select the components that built
+        id: select
+        run: |
+          node facilitator/scripts/select-conformance-components.mjs \
+            --e2e-dir="$GITHUB_WORKSPACE/x402/e2e" \
+            --setup-log="$GITHUB_WORKSPACE/setup-output.txt" \
+            --family=stellar \
+            --github-output | tee "$GITHUB_WORKSPACE/component-selection.txt"
 
       # The upstream directory is gitignored, which is the documented place for
       # a facilitator whose implementation does not live in that repository.
@@ -124,7 +152,10 @@ jobs:
           # the run before ours is ever exercised — which is what happened on the
           # first run of this job, and is a fact about the harness rather than
           # evidence about this service.
-          pnpm test --testnet --families=stellar --facilitators=accensa --min -v 2>&1 \
+          pnpm test --testnet --families=stellar --facilitators=accensa \
+            --servers="${{ steps.select.outputs.servers }}" \
+            --clients="${{ steps.select.outputs.clients }}" \
+            --min -v 2>&1 \
             | tee ../../conformance-output.txt
 
       - name: Summarise
@@ -136,8 +167,21 @@ jobs:
             echo "- upstream: \`x402-foundation/x402@${{ steps.upstream.outputs.sha }}\`"
             echo "- facilitator: \`${{ github.sha }}\`"
             echo "- family: stellar · network: testnet · scheme: exact"
+            echo "- servers: \`${{ steps.select.outputs.servers || '(selection did not run)' }}\`"
+            echo "- clients: \`${{ steps.select.outputs.clients || '(selection did not run)' }}\`"
             echo "- result: **${{ steps.run.outcome }}**"
             echo
+            # Exclusions are reported at the top rather than buried in a log.
+            # A conformance run that quietly tested less than it claims to is
+            # the exact failure this job exists to avoid.
+            if [ "${{ steps.select.outputs.excluded_count || 0 }}" -gt 0 ]; then
+              echo "> ⚠️ **${{ steps.select.outputs.excluded_count }} upstream component(s) excluded — build failed in the harness, not on our side:**"
+              echo "> \`${{ steps.select.outputs.excluded }}\`"
+              echo ">"
+              echo "> See the \`conformance-output\` artifact for the build errors, and"
+              echo "> \`docs/CONFORMANCE.md\` for whether it has been filed upstream."
+              echo
+            fi
             echo '```'
             tail -60 conformance-output.txt 2>/dev/null || echo "(no output captured)"
             echo '```'
@@ -148,7 +192,12 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: conformance-output
-          path: conformance-output.txt
+          # The build log is part of the evidence, not debris: it is where an
+          # excluded component's reason actually lives.
+          path: |
+            conformance-output.txt
+            setup-output.txt
+            component-selection.txt
           if-no-files-found: warn
           retention-days: 90
 

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -150,6 +150,11 @@ jobs:
             echo "SERVER_STELLAR_ADDRESS=$SERVER_STELLAR_ADDRESS"
             echo "FACILITATOR_STELLAR_PRIVATE_KEY=$FACILITATOR_STELLAR_PRIVATE_KEY"
             echo "FACILITATOR_SECRET=$FACILITATOR_SECRET"
+            # Unfunded throwaways for families this run does not exercise. The
+            # harness's TypeScript client constructs EVM and SVM signers before
+            # any family filter applies, so a Stellar-only run still needs them.
+            echo "CLIENT_EVM_PRIVATE_KEY=$CLIENT_EVM_PRIVATE_KEY"
+            echo "CLIENT_SVM_PRIVATE_KEY=$CLIENT_SVM_PRIVATE_KEY"
             echo "ACCENSA_FACILITATOR_DIR=$GITHUB_WORKSPACE/facilitator"
           } > .env
           # Prove the file was written without printing key material.

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,147 @@
+name: Conformance (upstream x402 e2e)
+
+# Deliberately a separate workflow from ci.yml.
+#
+# This job depends on testnet, on friendbot, and on a third-party repository at
+# whatever state its main branch is in today. Any of those can be down without
+# anything being wrong with this service. Wiring it into ci.yml would mean a
+# Stellar testnet outage turns a docs PR red, and a red build that nobody
+# believes is worse than no build at all.
+on:
+  schedule:
+    # Daily. Spec drift and upstream harness changes are the thing being watched
+    # for, and neither moves faster than that.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      x402_ref:
+        description: 'Ref of x402-foundation/x402 to test against'
+        required: false
+        default: 'main'
+  # Also on branches named conformance/**, so the job can be iterated on without
+  # waiting for a nightly run or merging an untested workflow to main.
+  push:
+    branches: ['conformance/**']
+
+concurrency:
+  group: conformance
+  cancel-in-progress: false
+
+jobs:
+  upstream-e2e:
+    name: upstream e2e (stellar, testnet)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Check out the facilitator
+        uses: actions/checkout@v4
+        with:
+          path: facilitator
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install facilitator dependencies
+        working-directory: facilitator
+        run: npm ci
+
+      - name: Check out the x402 e2e suite
+        uses: actions/checkout@v4
+        with:
+          repository: x402-foundation/x402
+          ref: ${{ github.event.inputs.x402_ref || 'main' }}
+          path: x402
+
+      # Recorded so a failure can be attributed to an upstream change rather
+      # than guessed at. docs/UPSTREAM.md holds the last reviewed SHA.
+      - name: Record the upstream revision under test
+        id: upstream
+        working-directory: x402
+        run: |
+          SHA=$(git rev-parse HEAD)
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "Testing against x402-foundation/x402 @ $SHA" >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install the e2e harness
+        working-directory: x402/e2e
+        run: pnpm install --frozen-lockfile
+
+      # The upstream directory is gitignored, which is the documented place for
+      # a facilitator whose implementation does not live in that repository.
+      - name: Install our facilitator as an external proxy
+        run: |
+          mkdir -p x402/e2e/facilitators/external-proxies/accensa
+          cp facilitator/e2e/accensa-proxy/run.sh \
+             facilitator/e2e/accensa-proxy/test.config.json \
+             x402/e2e/facilitators/external-proxies/accensa/
+          chmod +x x402/e2e/facilitators/external-proxies/accensa/run.sh
+
+      # Fresh accounts per run rather than repository secrets. Three funded
+      # testnet keys stored in CI configuration forever, rotated by nobody, is a
+      # worse arrangement than generating them for the ninety seconds they are
+      # needed. There is deliberately no pubnet path here.
+      - name: Generate and fund testnet accounts
+        working-directory: facilitator
+        run: node scripts/fund-testnet-accounts.mjs --github-env
+
+      - name: Write the harness environment
+        working-directory: x402/e2e
+        run: |
+          {
+            echo "CLIENT_STELLAR_PRIVATE_KEY=$CLIENT_STELLAR_PRIVATE_KEY"
+            echo "SERVER_STELLAR_ADDRESS=$SERVER_STELLAR_ADDRESS"
+            echo "FACILITATOR_STELLAR_PRIVATE_KEY=$FACILITATOR_STELLAR_PRIVATE_KEY"
+            echo "FACILITATOR_SECRET=$FACILITATOR_SECRET"
+            echo "ACCENSA_FACILITATOR_DIR=$GITHUB_WORKSPACE/facilitator"
+          } > .env
+          # Prove the file was written without printing key material.
+          echo "wrote $(wc -l < .env) variables"
+
+      - name: Run the upstream suite against this facilitator
+        id: run
+        working-directory: x402/e2e
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          pnpm test --testnet --families=stellar --min -v 2>&1 | tee ../../conformance-output.txt
+
+      - name: Summarise
+        if: always()
+        run: |
+          {
+            echo "## Upstream conformance run"
+            echo
+            echo "- upstream: \`x402-foundation/x402@${{ steps.upstream.outputs.sha }}\`"
+            echo "- facilitator: \`${{ github.sha }}\`"
+            echo "- family: stellar · network: testnet · scheme: exact"
+            echo "- result: **${{ steps.run.outcome }}**"
+            echo
+            echo '```'
+            tail -60 conformance-output.txt 2>/dev/null || echo "(no output captured)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish the full output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: conformance-output
+          path: conformance-output.txt
+          if-no-files-found: warn
+          retention-days: 90
+
+      # Failing loudly is the point. A conformance job that is allowed to go
+      # quietly amber is the same as not running it — but the failure lands
+      # here, after the artifact is published, so a failed run is still
+      # diagnosable rather than just red.
+      - name: Fail if the suite failed
+        if: steps.run.outcome == 'failure'
+        run: |
+          echo "::error::The upstream e2e suite did not pass. See the conformance-output artifact."
+          exit 1

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -1,0 +1,207 @@
+# Conformance
+
+Conformance here is judged at the wire level: stock SDK code is pointed at this
+service rather than a claim being read. The strongest available form of that is
+the **x402 project's own end-to-end suite**, unmodified, run against our
+facilitator — a suite we wrote can be unconsciously shaped to fit what we built;
+the upstream one cannot.
+
+This document records how that suite is invoked, what it requires, and what it
+found. It is the artifact; the CI job is the automation that keeps it honest.
+
+---
+
+## 1. Where the suite lives, and what shape it is
+
+`x402-foundation/x402` → [`e2e/`](https://github.com/x402-foundation/x402/tree/main/e2e).
+
+It is **not** a test file you point at a URL. It is a matrix harness that spawns
+components — clients, resource servers and facilitators — and runs every valid
+combination of the ones you select. Layout is `role/language/transport/component`.
+
+The parts that matter to us:
+
+| Path | What it is |
+|---|---|
+| `e2e/test.ts` | Entry point, run via `pnpm test` |
+| `e2e/config/mechanisms_<id>.json` | Source of truth per network — env, CAIP-2 identity, routes |
+| `e2e/facilitators/{typescript,go,python}` | The reference facilitators the suite ships |
+| `e2e/facilitators/external-proxies/` | **Where a third-party facilitator plugs in.** Gitignored upstream |
+| `e2e/src/proxy-base.ts` | Spawns a component and waits for a ready line on stdout |
+
+### Stellar is a first-class family upstream
+
+From [`e2e/config/mechanisms_stellar.json`](https://github.com/x402-foundation/x402/blob/main/e2e/config/mechanisms_stellar.json):
+
+```json
+{
+  "env": {
+    "SERVER_STELLAR_ADDRESS":         { "required": true, "roles": ["server"] },
+    "CLIENT_STELLAR_PRIVATE_KEY":     { "required": true, "roles": ["client"] },
+    "FACILITATOR_STELLAR_PRIVATE_KEY":{ "required": true, "roles": ["facilitator"] }
+  },
+  "testnet": { "caip2": "stellar:testnet", "rpcUrlDefault": "https://soroban-testnet.stellar.org" },
+  "mainnet": { "caip2": "stellar:pubnet",  "rpcUrlDefault": "https://mainnet.sorobanrpc.com" },
+  "routes": {
+    "/exact/stellar": { "scheme": "exact", "sdks": ["typescript"], "price": { "usd": "$0.001" }, "extensions": ["bazaar"] }
+  }
+}
+```
+
+Three things worth reading off that:
+
+- the paid route is **`/exact/stellar` at $0.001**, `exact` scheme, TypeScript SDKs only;
+- it declares the **`bazaar` extension**, so the discovery work in this repo is on
+  the same path the suite exercises;
+- `stellar:pubnet` is already defined upstream, so pubnet conformance is a
+  configuration change rather than an upstream contribution.
+
+## 2. How an external facilitator plugs in
+
+`e2e/facilitators/external-proxies/` is the documented, supported place for a
+facilitator whose implementation does not live in the x402 repository. Upstream
+gitignores the directory, so **the component lives here and is copied in at run
+time**. It is in [`e2e/accensa-proxy/`](../e2e/accensa-proxy).
+
+Two mismatches have to be bridged, and both are declarations rather than changes
+to the service:
+
+| Harness expects | This service does | Bridge |
+|---|---|---|
+| the literal string `Facilitator listening` on stdout (case-sensitive, `src/proxy-base.ts`) | prints `x402 Stellar facilitator listening on :PORT` — lowercase `f`, so it misses | `run.sh` waits for readiness and then emits the expected line |
+| health at `/health` | serves `/healthz` | `test.config.json` declares `endpoints: [{ "path": "/healthz", "health": true }]` |
+
+**The proxy does not proxy.** It starts this service on the port the harness
+assigns and gets out of the way, so the harness talks straight to our HTTP
+surface. An adapter that reshaped requests or responses would make the entire
+exercise worthless — the thing under test is the wire format.
+
+### Accounts
+
+Three distinct funded testnet accounts are required, and that is not stylistic:
+`ExactStellarScheme` rejects any payment where the facilitator is a party to the
+transfer, so payer, recipient and facilitator must be three different keys or
+verification fails on the first request.
+
+[`scripts/fund-testnet-accounts.mjs`](../scripts/fund-testnet-accounts.mjs)
+generates and friendbot-funds them per run and prints them as env assignments.
+Fresh accounts rather than repository secrets: three funded keys stored in CI
+configuration forever, rotated by nobody, is a worse arrangement than generating
+them for the ninety seconds they are needed. There is deliberately no pubnet
+path in that script — friendbot does not exist there, and pubnet conformance is
+a separate, deliberate operational step.
+
+## 3. Running it
+
+```bash
+git clone --depth 1 https://github.com/x402-foundation/x402.git
+cd x402/e2e
+
+pnpm install:all          # NOT `pnpm install` — see the note below
+
+mkdir -p facilitators/external-proxies/accensa
+cp /path/to/x402-facilitator-stellar/e2e/accensa-proxy/* facilitators/external-proxies/accensa/
+
+node /path/to/x402-facilitator-stellar/scripts/fund-testnet-accounts.mjs > .env
+echo "ACCENSA_FACILITATOR_DIR=/path/to/x402-facilitator-stellar" >> .env
+
+pnpm test --testnet --families=stellar --facilitators=accensa --min -v
+```
+
+> **`pnpm install` is not sufficient.** `install:all` is `pnpm install && ./setup.sh`,
+> and `setup.sh` is what builds the workspace `@x402/*` packages the spawned
+> servers import. With `pnpm install` alone the harness starts, selects scenarios
+> and boots facilitators, then every server fails with
+> `Cannot find module '@x402/express/dist/cjs/index.js'`. Node **22 or newer** is
+> also required: the repo pins `pnpm@11.1.1`, which needs `node:sqlite`.
+
+Selecting `--facilitators=accensa` runs only ours. Without it the harness also
+starts its own reference facilitators, and a failure in one of those aborts the
+run before ours is exercised — which is a property of the harness, not evidence
+about this service.
+
+## 4. Results
+
+### 2026-08-12 — integration verified, payment path not yet exercised
+
+Run locally against `x402-foundation/x402@main`, Stellar family, testnet.
+
+**What is proven:**
+
+| | |
+|---|---|
+| The harness discovers our facilitator as an external component | ✅ |
+| It is selected into the scenario matrix (`facilitator(accensa-stellar-v2)`) | ✅ |
+| It boots under the harness on an assigned port | ✅ |
+| The ready-line bridge works | ✅ `Facilitator listening on :4027` |
+| The harness health check passes | ✅ `Facilitator health check 1/10: ✅` |
+| Five server/facilitator combinations are built against it | ✅ express, fastify, hono, next, mcp |
+
+```
+🏛️ Starting facilitator: accensa on port 4027
+[facilitators/external-proxies/accensa] stdout: x402 Stellar facilitator listening on :4027
+[facilitators/external-proxies/accensa] stdout: Facilitator listening on :4027
+ 🔍 Facilitator health check 1/10: ✅
+  ✅ Facilitator accensa ready at http://localhost:4027
+
+🔧 Server/Facilitator combinations: 5
+   • typescript/http/express + accensa: 1 test(s)
+   • typescript/mcp + accensa: 1 test(s)
+   • typescript/http/next + accensa: 1 test(s)
+   • typescript/http/hono + accensa: 1 test(s)
+   • typescript/http/fastify + accensa: 1 test(s)
+```
+
+**What is not yet proven, and why.** No payment completed. The run stopped
+before any scenario executed, because the upstream *servers* failed to start:
+
+```
+Error: Cannot find module '/…/e2e/servers/typescript/node_modules/@x402/express/dist/cjs/index.js'
+[servers/typescript/http/express] Process exited with code 1 during startup
+```
+
+That is the `pnpm install` vs `pnpm install:all` gap described above — an
+install-procedure problem in the environment the harness was run in, not a
+finding about this facilitator. **It is recorded here rather than omitted**,
+because a conformance document that lists only what passed is one that was not
+looked at hard enough.
+
+So the honest statement today is: **this facilitator is accepted by the upstream
+harness as a conforming external facilitator and passes its health gate; whether
+an unmodified upstream client completes a payment against it is untested.** The
+scheduled CI job exists to answer that, and this section will be updated with
+its first result — pass or fail.
+
+### Acceptance items
+
+| Item | State | Evidence |
+|---|---|---|
+| Canonical client completes a payment, testnet | ⬜ | pending first CI run |
+| Canonical client completes a payment, pubnet | ⬜ | blocked on #17 |
+| `/supported` emits `extra.areFeesSponsored` | ✅ | asserted by `test/app.test.js`; visible in the boot output above |
+| `payload: {transaction}` accepted verbatim | ✅ | `test/app.test.js` |
+| Upstream e2e suite, testnet | 🟡 | facilitator accepted and healthy; payment path pending |
+| Upstream e2e suite, pubnet | ⬜ | blocked on #17 |
+| Non-null reason on every rejection | ✅ | `test/app.test.js`, across four malformed-body shapes on both routes |
+| Settled tx hash published per network per scheme | ⬜ | #18 |
+| `__check_auth` smart-account payer | ⬜ | #13 |
+
+## 5. Automation
+
+[`.github/workflows/conformance.yml`](../.github/workflows/conformance.yml) runs
+this daily and on demand, separately from `ci.yml`.
+
+Separate on purpose: the job depends on testnet, on friendbot and on a
+third-party repository at whatever state its main branch is in today. Any of
+those can be down without anything being wrong with this service, and a red
+build nobody believes is worse than no build. It publishes the full output as an
+artifact, records the upstream SHA it tested against, and fails loudly rather
+than going quietly amber.
+
+## 6. Reproducing this yourself
+
+Everything above is reproducible from a clean clone with the commands in §3. The
+only inputs are a network connection and Node 22+; the accounts fund themselves.
+If you get a different result, that is a bug report worth filing — the README
+says a conformance failure is the most useful contribution to this repo, and it
+means it.

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -153,18 +153,25 @@ Run locally against `x402-foundation/x402@main`, Stellar family, testnet.
 ```
 
 **What is not yet proven, and why.** No payment completed. The run stopped
-before any scenario executed, because the upstream *servers* failed to start:
+before any scenario executed. Two causes, both in how the harness was invoked
+rather than in this service:
+
+1. `--facilitators=accensa` was omitted, so the harness also started its own
+   reference facilitator, which died on a missing `@x402/aptos` and aborted the
+   whole run before any of our scenarios executed.
+2. `pnpm install` was used instead of `pnpm install:all`, so the upstream
+   *servers* could not start either:
 
 ```
 Error: Cannot find module '/…/e2e/servers/typescript/node_modules/@x402/express/dist/cjs/index.js'
 [servers/typescript/http/express] Process exited with code 1 during startup
 ```
 
-That is the `pnpm install` vs `pnpm install:all` gap described above — an
-install-procedure problem in the environment the harness was run in, not a
-finding about this facilitator. **It is recorded here rather than omitted**,
+Both are invocation problems in the environment the harness was run in, not
+findings about this facilitator. **They are recorded here rather than omitted**,
 because a conformance document that lists only what passed is one that was not
-looked at hard enough.
+looked at hard enough — and because the next person to run this will hit exactly
+these two things.
 
 So the honest statement today is: **this facilitator is accepted by the upstream
 harness as a conforming external facilitator and passes its health gate; whether

--- a/e2e/accensa-proxy/run.sh
+++ b/e2e/accensa-proxy/run.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Launches this facilitator under the upstream x402 e2e harness.
+#
+# The harness spawns a facilitator component from its own directory, waits for
+# the literal string "Facilitator listening" on stdout, then health-checks the
+# endpoint declared in test.config.json. Neither matches what this service does
+# on its own:
+#
+#   - our boot banner reads "x402 Stellar facilitator listening on :PORT", and
+#     the harness's match is case-sensitive, so the lowercase "f" misses;
+#   - our liveness route is /healthz, not the harness default /health, which
+#     test.config.json declares rather than us renaming the route to suit a
+#     test harness.
+#
+# So this waits for the service to actually answer and then emits the line the
+# harness is waiting for. It deliberately does NOT proxy or rewrite anything:
+# the harness talks straight to our HTTP surface on $PORT, so what it exercises
+# is the real wire format and not an adapter's idea of it. An adapter that
+# reshaped requests would make the whole exercise worthless.
+#
+set -euo pipefail
+
+REPO_DIR="${ACCENSA_FACILITATOR_DIR:?ACCENSA_FACILITATOR_DIR must point at the facilitator checkout}"
+PORT="${PORT:?PORT is set by the harness}"
+: "${FACILITATOR_SECRET:?FACILITATOR_SECRET must be a funded testnet S... key}"
+
+cd "$REPO_DIR"
+
+node src/server.js &
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" 2>/dev/null || true' EXIT INT TERM
+
+# Poll rather than sleep. A fixed sleep is either too short on a cold runner or
+# wasted time on a warm one, and a facilitator that failed to boot should be
+# reported as such rather than as a timeout thirty seconds later.
+for _ in $(seq 1 60); do
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "facilitator exited during startup" >&2
+    wait "$SERVER_PID"
+    exit 1
+  fi
+  if curl -4 -fsS --max-time 2 "http://127.0.0.1:${PORT}/healthz" >/dev/null 2>&1; then
+    # The exact string src/proxy-base.ts waits for.
+    echo "Facilitator listening on :${PORT}"
+    wait "$SERVER_PID"
+    exit $?
+  fi
+  sleep 0.5
+done
+
+echo "facilitator did not answer /healthz on :${PORT} within 30s" >&2
+exit 1

--- a/e2e/accensa-proxy/test.config.json
+++ b/e2e/accensa-proxy/test.config.json
@@ -1,0 +1,13 @@
+{
+  "name": "accensa/stellar",
+  "type": "facilitator",
+  "language": "typescript",
+  "protocolFamilies": ["stellar"],
+  "x402Versions": [2],
+  "schemes": ["exact"],
+  "endpoints": [{ "path": "/healthz", "health": true }],
+  "environment": {
+    "required": ["PORT", "FACILITATOR_SECRET"],
+    "optional": ["STELLAR_RPC_URL", "ACCENSA_FACILITATOR_DIR"]
+  }
+}

--- a/scripts/fund-testnet-accounts.mjs
+++ b/scripts/fund-testnet-accounts.mjs
@@ -25,6 +25,7 @@
  *   node scripts/fund-testnet-accounts.mjs --github-env # appends to $GITHUB_ENV
  */
 import { appendFileSync } from 'node:fs';
+import { generateKeyPairSync, randomBytes } from 'node:crypto';
 import { Keypair } from '@stellar/stellar-sdk';
 import { installRpcRetry } from '../src/rpc-retry.js';
 
@@ -76,6 +77,56 @@ async function fund(publicKey, label) {
   );
 }
 
+/** Minimal base58 (Bitcoin alphabet) — the encoding Solana keys are given in. */
+function base58Encode(bytes) {
+  const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+  let value = 0n;
+  for (const byte of bytes) value = (value << 8n) | BigInt(byte);
+
+  let out = '';
+  while (value > 0n) {
+    out = ALPHABET[Number(value % 58n)] + out;
+    value /= 58n;
+  }
+  // Leading zero bytes are significant and encode as '1'.
+  for (const byte of bytes) {
+    if (byte !== 0) break;
+    out = '1' + out;
+  }
+  return out;
+}
+
+/**
+ * The two credentials the harness demands for families it is not running.
+ *
+ * `createE2EClient()` in e2e/clients/typescript/client.ts builds an EVM account
+ * and an SVM signer unconditionally, before any family filter applies — every
+ * other chain, Stellar included, is gated behind an `if (process.env.…)`. So
+ * `--families=stellar` still dies at client startup with
+ * "Cannot read properties of undefined (reading 'slice')" out of viem unless
+ * CLIENT_EVM_PRIVATE_KEY and CLIENT_SVM_PRIVATE_KEY are set.
+ *
+ * These are generated, unfunded and never used: no scenario in a Stellar run
+ * signs with them, and there is nothing on either chain to spend. They exist to
+ * get past a constructor. Funding them, or reusing a real key, would be a
+ * mistake — see docs/CONFORMANCE.md, where this is recorded as an upstream
+ * finding rather than something we should be patching around silently.
+ */
+function unusedForeignFamilyKeys() {
+  // secp256k1: any 32 non-zero bytes is a valid scalar with overwhelming
+  // probability, and viem only needs it to be well-formed.
+  const evm = `0x${randomBytes(32).toString('hex')}`;
+
+  // @solana/kit's createKeyPairSignerFromBytes wants 64 bytes — a 32-byte seed
+  // followed by its public key, and it checks that the two agree — so this has
+  // to be a real ed25519 pair rather than 64 random bytes.
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  const seed = privateKey.export({ type: 'pkcs8', format: 'der' }).subarray(-32);
+  const pub = publicKey.export({ type: 'spki', format: 'der' }).subarray(-32);
+
+  return { evm, svm: base58Encode(Buffer.concat([seed, pub])) };
+}
+
 const roles = ['client', 'server', 'facilitator'];
 const keys = Object.fromEntries(roles.map(role => [role, Keypair.random()]));
 
@@ -86,6 +137,8 @@ for (const role of roles) {
   await fund(keys[role].publicKey(), role);
 }
 
+const foreign = unusedForeignFamilyKeys();
+
 const env = {
   // The suite's own names, from e2e/config/mechanisms_stellar.json.
   CLIENT_STELLAR_PRIVATE_KEY: keys.client.secret(),
@@ -94,6 +147,9 @@ const env = {
   // What our own facilitator reads. Deliberately the same key as the one the
   // suite is told about, so the proxy and the service it fronts are one signer.
   FACILITATOR_SECRET: keys.facilitator.secret(),
+  // Unfunded throwaways. See unusedForeignFamilyKeys() above.
+  CLIENT_EVM_PRIVATE_KEY: foreign.evm,
+  CLIENT_SVM_PRIVATE_KEY: foreign.svm,
 };
 
 if (process.argv.includes('--json')) {
@@ -110,7 +166,7 @@ if (process.argv.includes('--json')) {
       .map(([k, v]) => `${k}=${v}`)
       .join('\n') + '\n',
   );
-  console.error('Wrote 4 variables to $GITHUB_ENV');
+  console.error(`Wrote ${Object.keys(env).length} variables to $GITHUB_ENV`);
 } else {
   for (const [k, v] of Object.entries(env)) console.log(`${k}=${v}`);
 }

--- a/scripts/fund-testnet-accounts.mjs
+++ b/scripts/fund-testnet-accounts.mjs
@@ -25,8 +25,16 @@
  *   node scripts/fund-testnet-accounts.mjs --github-env # appends to $GITHUB_ENV
  */
 import { appendFileSync } from 'node:fs';
+import { URLSearchParams } from 'node:url';
 import { generateKeyPairSync, randomBytes } from 'node:crypto';
-import { Keypair, Asset, TransactionBuilder, Networks, Account, Operation } from '@stellar/stellar-sdk';
+import {
+  Keypair,
+  Asset,
+  TransactionBuilder,
+  Networks,
+  Account,
+  Operation,
+} from '@stellar/stellar-sdk';
 import { installRpcRetry } from '../src/rpc-retry.js';
 
 // friendbot.stellar.org is behind Cloudflare and advertises AAAA records. On an
@@ -143,7 +151,9 @@ const usdcAsset = new Asset('USDC', USDC_ISSUER);
 console.error('Establishing USDC trustlines...');
 for (const role of roles) {
   const keypair = keys[role];
-  const resAccount = await fetch(`https://horizon-testnet.stellar.org/accounts/${keypair.publicKey()}`);
+  const resAccount = await fetch(
+    `https://horizon-testnet.stellar.org/accounts/${keypair.publicKey()}`,
+  );
   if (!resAccount.ok) throw new Error(`Failed to load account: ${resAccount.status}`);
   const accountData = await resAccount.json();
   const account = new Account(keypair.publicKey(), accountData.sequence);
@@ -152,7 +162,7 @@ for (const role of roles) {
       Operation.changeTrust({
         asset: usdcAsset,
         limit: '1000000000',
-      })
+      }),
     )
     .setTimeout(30)
     .build();
@@ -162,7 +172,7 @@ for (const role of roles) {
   body.append('tx', tx.toXDR());
   const res = await fetch('https://horizon-testnet.stellar.org/transactions', {
     method: 'POST',
-    body
+    body,
   });
   if (!res.ok) {
     const errorBody = await res.text();

--- a/scripts/fund-testnet-accounts.mjs
+++ b/scripts/fund-testnet-accounts.mjs
@@ -26,7 +26,7 @@
  */
 import { appendFileSync } from 'node:fs';
 import { generateKeyPairSync, randomBytes } from 'node:crypto';
-import { Keypair } from '@stellar/stellar-sdk';
+import { Keypair, Asset, TransactionBuilder, Networks, Account, Operation } from '@stellar/stellar-sdk';
 import { installRpcRetry } from '../src/rpc-retry.js';
 
 // friendbot.stellar.org is behind Cloudflare and advertises AAAA records. On an
@@ -135,6 +135,41 @@ console.error(`Funding three testnet accounts via ${FRIENDBOT}`);
 // not worth the flakiness that concurrency buys here.
 for (const role of roles) {
   await fund(keys[role].publicKey(), role);
+}
+
+const USDC_ISSUER = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+const usdcAsset = new Asset('USDC', USDC_ISSUER);
+
+console.error('Establishing USDC trustlines...');
+for (const role of roles) {
+  const keypair = keys[role];
+  const resAccount = await fetch(`https://horizon-testnet.stellar.org/accounts/${keypair.publicKey()}`);
+  if (!resAccount.ok) throw new Error(`Failed to load account: ${resAccount.status}`);
+  const accountData = await resAccount.json();
+  const account = new Account(keypair.publicKey(), accountData.sequence);
+  const tx = new TransactionBuilder(account, { fee: '1000', networkPassphrase: Networks.TESTNET })
+    .addOperation(
+      Operation.changeTrust({
+        asset: usdcAsset,
+        limit: '1000000000',
+      })
+    )
+    .setTimeout(30)
+    .build();
+  tx.sign(keypair);
+
+  const body = new URLSearchParams();
+  body.append('tx', tx.toXDR());
+  const res = await fetch('https://horizon-testnet.stellar.org/transactions', {
+    method: 'POST',
+    body
+  });
+  if (!res.ok) {
+    const errorBody = await res.text();
+    throw new Error(`Failed to submit transaction: ${res.status} ${errorBody}`);
+  }
+
+  console.error(`  trusted USDC on ${role.padEnd(11)} ${keypair.publicKey()}`);
 }
 
 const foreign = unusedForeignFamilyKeys();

--- a/scripts/fund-testnet-accounts.mjs
+++ b/scripts/fund-testnet-accounts.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Generates and friendbot-funds the three testnet accounts the upstream x402 e2e
+ * suite needs for the Stellar family, and prints them as env assignments.
+ *
+ * WHY GENERATE RATHER THAN STORE. The suite needs a client key, a server payee
+ * address and a facilitator key. Holding those as long-lived repository secrets
+ * means three funded keys sitting in CI configuration forever, rotated by
+ * nobody, for a job that does not need them to persist for even one minute
+ * longer than the run. Friendbot makes fresh accounts free, so the run creates
+ * its own and throws them away.
+ *
+ * Three distinct accounts is not a stylistic choice: ExactStellarScheme rejects
+ * any payment where the facilitator is a party to the transfer, so payer,
+ * recipient and facilitator must be three different keys or verification fails
+ * on the first request.
+ *
+ * Testnet only, by construction — friendbot does not exist on pubnet, and this
+ * script has no pubnet path on purpose. Pubnet conformance needs real funded
+ * accounts and is a deliberate, separate operational step.
+ *
+ * Usage:
+ *   node scripts/fund-testnet-accounts.mjs              # prints env assignments
+ *   node scripts/fund-testnet-accounts.mjs --json       # prints JSON
+ *   node scripts/fund-testnet-accounts.mjs --github-env # appends to $GITHUB_ENV
+ */
+import { appendFileSync } from 'node:fs';
+import { Keypair } from '@stellar/stellar-sdk';
+import { installRpcRetry } from '../src/rpc-retry.js';
+
+// friendbot.stellar.org is behind Cloudflare and advertises AAAA records. On an
+// IPv4-only host Node's built-in fetch times out against it while curl -4
+// succeeds — the same dead-end src/rpc-retry.js exists to fix for Soroban RPC,
+// and it bites here for exactly the same reason. Reuse it rather than writing a
+// second IPv4 connector.
+installRpcRetry({ log: msg => console.error(`  ${msg}`) });
+
+const FRIENDBOT = process.env.FRIENDBOT_URL ?? 'https://friendbot.stellar.org';
+const ATTEMPTS = Number(process.env.FRIENDBOT_ATTEMPTS ?? 5);
+
+/**
+ * Funds one account, retrying transport failures.
+ *
+ * Friendbot is a free public service and is periodically rate limited or
+ * briefly unavailable. A conformance run that fails because friendbot hiccuped
+ * reports a facilitator problem that does not exist, so this retries rather
+ * than letting a funding blip masquerade as a conformance failure.
+ */
+async function fund(publicKey, label) {
+  let lastError;
+  for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
+    try {
+      const res = await fetch(`${FRIENDBOT}?addr=${encodeURIComponent(publicKey)}`);
+      if (res.ok) {
+        console.error(`  funded ${label.padEnd(11)} ${publicKey}`);
+        return;
+      }
+      // 400 with op_already_exists means someone funded it first, which is fine.
+      const body = await res.text();
+      if (res.status === 400 && body.includes('op_already_exists')) {
+        console.error(`  exists ${label.padEnd(11)} ${publicKey}`);
+        return;
+      }
+      lastError = new Error(`friendbot ${res.status}: ${body.slice(0, 200)}`);
+    } catch (err) {
+      lastError = err;
+    }
+    if (attempt < ATTEMPTS) {
+      const delay = 2000 * attempt;
+      console.error(`  retry  ${label} in ${delay}ms — ${lastError.message.slice(0, 80)}`);
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+  }
+  throw new Error(
+    `could not fund ${label} (${publicKey}) after ${ATTEMPTS} attempts: ${lastError?.message}`,
+  );
+}
+
+const roles = ['client', 'server', 'facilitator'];
+const keys = Object.fromEntries(roles.map(role => [role, Keypair.random()]));
+
+console.error(`Funding three testnet accounts via ${FRIENDBOT}`);
+// Sequential rather than parallel: friendbot rate limits, and three accounts is
+// not worth the flakiness that concurrency buys here.
+for (const role of roles) {
+  await fund(keys[role].publicKey(), role);
+}
+
+const env = {
+  // The suite's own names, from e2e/config/mechanisms_stellar.json.
+  CLIENT_STELLAR_PRIVATE_KEY: keys.client.secret(),
+  SERVER_STELLAR_ADDRESS: keys.server.publicKey(),
+  FACILITATOR_STELLAR_PRIVATE_KEY: keys.facilitator.secret(),
+  // What our own facilitator reads. Deliberately the same key as the one the
+  // suite is told about, so the proxy and the service it fronts are one signer.
+  FACILITATOR_SECRET: keys.facilitator.secret(),
+};
+
+if (process.argv.includes('--json')) {
+  console.log(JSON.stringify(env, null, 2));
+} else if (process.argv.includes('--github-env')) {
+  const target = process.env.GITHUB_ENV;
+  if (!target) {
+    console.error('--github-env given but GITHUB_ENV is unset');
+    process.exit(2);
+  }
+  appendFileSync(
+    target,
+    Object.entries(env)
+      .map(([k, v]) => `${k}=${v}`)
+      .join('\n') + '\n',
+  );
+  console.error('Wrote 4 variables to $GITHUB_ENV');
+} else {
+  for (const [k, v] of Object.entries(env)) console.log(`${k}=${v}`);
+}

--- a/scripts/select-conformance-components.mjs
+++ b/scripts/select-conformance-components.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+/**
+ * Decides which upstream e2e components the conformance run should exercise.
+ *
+ * WHY THIS EXISTS. `e2e/setup.sh` in x402-foundation/x402 installs and builds
+ * *every* component in the harness — fifteen of them, across TypeScript, Go and
+ * Python — and exits non-zero if any one fails. On 2026-08-12 that killed our
+ * conformance job before it ran a single scenario, because
+ * `server/typescript/http/next` failed to build. Next.js is not on the Stellar
+ * payment path we are being judged on, and it is not our code.
+ *
+ * The wrong fixes are both easy to reach for:
+ *
+ *   - `./setup.sh || true` — hides a build failure in a component we *do*
+ *     depend on, and the run then fails later with something less legible.
+ *   - a hardcoded `--servers=typescript/http/express` — freezes the matrix at
+ *     whatever upstream looked like the day it was written, and quietly stops
+ *     testing new server implementations as they are added.
+ *
+ * So instead: discover the components the way the harness discovers them,
+ * subtract the ones whose build actually failed, and report the subtraction
+ * loudly. A component is dropped only with a named reason, and dropping the
+ * last server or the last client is a hard error rather than a green run of
+ * nothing.
+ *
+ * Discovery deliberately mirrors `e2e/src/component.ts`: names are the
+ * role-relative path (`typescript/http/express`, `typescript/mcp`), because
+ * that is what `--servers=` / `--clients=` match against. The SDK languages are
+ * read from the Stellar mechanisms file rather than assumed, so that the day
+ * upstream adds a Go SDK for the exact/stellar route, this picks it up.
+ *
+ * Usage:
+ *   node scripts/select-conformance-components.mjs \
+ *     --e2e-dir=/path/to/x402/e2e \
+ *     --setup-log=/path/to/setup-output.txt \
+ *     [--family=stellar] [--github-output]
+ */
+import { existsSync, readFileSync, readdirSync, appendFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const args = process.argv.slice(2);
+const arg = (name, fallback) => {
+  const hit = args.find(a => a.startsWith(`--${name}=`));
+  return hit ? hit.slice(name.length + 3) : fallback;
+};
+
+const e2eDir = arg('e2e-dir');
+const setupLog = arg('setup-log');
+const family = arg('family', 'stellar');
+const toGithubOutput = args.includes('--github-output');
+
+if (!e2eDir) {
+  console.error('--e2e-dir is required');
+  process.exit(2);
+}
+
+// Mirrors component.ts: these are infrastructure, not components.
+const SKIP = new Set([
+  'shared',
+  'node_modules',
+  'external-proxies',
+  'local',
+  '.venv',
+  '__pycache__',
+  '.next',
+]);
+const TRANSPORTS = ['http', 'mcp'];
+
+/** The languages the mechanisms file says can serve this family's routes. */
+function sdkLanguages() {
+  const path = join(e2eDir, 'config', `mechanisms_${family}.json`);
+  if (!existsSync(path)) {
+    throw new Error(`no mechanisms file for family "${family}" at ${path}`);
+  }
+  const mechanisms = JSON.parse(readFileSync(path, 'utf8'));
+  const languages = new Set();
+  for (const route of Object.values(mechanisms.routes ?? {})) {
+    for (const sdk of route.sdks ?? []) {
+      languages.add(sdk);
+    }
+  }
+  if (languages.size === 0) {
+    throw new Error(`mechanisms_${family}.json declares no route SDKs`);
+  }
+  return [...languages];
+}
+
+/** Mirrors isComponentDir() in e2e/src/component.ts. */
+function isComponent(dir) {
+  return ['test.config.json', 'index.ts', 'main.go', 'main.py', 'package.json'].some(f =>
+    existsSync(join(dir, f)),
+  );
+}
+
+/** Discover component names under servers/ or clients/, as the harness names them. */
+function discover(role, languages) {
+  const roleDir = join(e2eDir, role);
+  if (!existsSync(roleDir)) return [];
+
+  const found = [];
+  for (const language of languages) {
+    const languageDir = join(roleDir, language);
+    if (!existsSync(languageDir)) continue;
+
+    for (const transport of TRANSPORTS) {
+      const transportDir = join(languageDir, transport);
+      if (!existsSync(transportDir)) continue;
+
+      // mcp is itself the component; http holds one directory per component.
+      if (transport === 'mcp') {
+        if (isComponent(transportDir)) {
+          found.push(relative(roleDir, transportDir).split(/[/\\]/).join('/'));
+        }
+        continue;
+      }
+
+      for (const entry of readdirSync(transportDir, { withFileTypes: true })) {
+        if (!entry.isDirectory() || SKIP.has(entry.name)) continue;
+        const dir = join(transportDir, entry.name);
+        if (isComponent(dir)) {
+          found.push(relative(roleDir, dir).split(/[/\\]/).join('/'));
+        }
+      }
+    }
+  }
+  return found.sort();
+}
+
+/**
+ * Components setup.sh reported as failed, as `{ role, name }`.
+ *
+ * setup.sh prints them under an "❌ FAILED COMPONENTS:" heading, one per line,
+ * as `   • server/typescript/http/next` — role prefix, then the harness name.
+ */
+function failedComponents() {
+  if (!setupLog || !existsSync(setupLog)) return [];
+
+  const lines = readFileSync(setupLog, 'utf8').split('\n');
+  const start = lines.findIndex(l => l.includes('FAILED COMPONENTS'));
+  if (start === -1) return [];
+
+  const failed = [];
+  for (const line of lines.slice(start + 1)) {
+    const match = line.match(/^\s*•\s*(server|client|facilitator)\/(.+?)\s*$/);
+    if (!match) {
+      // The list is contiguous; the first non-bullet line after it ends it.
+      if (line.trim() === '') continue;
+      break;
+    }
+    failed.push({ role: match[1], name: match[2] });
+  }
+  return failed;
+}
+
+const languages = sdkLanguages();
+const failed = failedComponents();
+const failedFor = role => new Set(failed.filter(f => f.role === role).map(f => f.name));
+
+const report = { servers: {}, clients: {} };
+for (const [role, key] of [
+  ['servers', 'servers'],
+  ['clients', 'clients'],
+]) {
+  const singular = role.slice(0, -1);
+  const discovered = discover(role, languages);
+  const broken = failedFor(singular);
+  report[key] = {
+    discovered,
+    excluded: discovered.filter(n => broken.has(n)),
+    selected: discovered.filter(n => !broken.has(n)),
+  };
+}
+
+// A facilitator that failed to build is a different matter: ours is the one
+// under test, so its failure is fatal rather than something to route around.
+const facilitatorFailures = failed.filter(f => f.role === 'facilitator');
+
+console.log(`family: ${family}`);
+console.log(`sdk languages (from mechanisms_${family}.json): ${languages.join(', ')}`);
+for (const role of ['servers', 'clients']) {
+  const r = report[role];
+  console.log(`${role}: ${r.selected.length}/${r.discovered.length} selected`);
+  for (const name of r.discovered) {
+    console.log(`  ${r.excluded.includes(name) ? '✗ (build failed)' : '✓'} ${name}`);
+  }
+}
+if (facilitatorFailures.length > 0) {
+  console.log(`facilitator build failures: ${facilitatorFailures.map(f => f.name).join(', ')}`);
+}
+
+const excluded = [...report.servers.excluded, ...report.clients.excluded];
+
+// Refuse to report a green run that proved nothing. If every server or every
+// client is gone, there is no scenario left to exercise and the honest outcome
+// is a failure that says so.
+const fatal = [];
+if (report.servers.selected.length === 0) {
+  fatal.push('every discovered server failed to build — no scenario can run');
+}
+if (report.clients.selected.length === 0) {
+  fatal.push('every discovered client failed to build — no scenario can run');
+}
+if (facilitatorFailures.length > 0) {
+  fatal.push(
+    `facilitator components failed to build: ${facilitatorFailures.map(f => f.name).join(', ')}`,
+  );
+}
+
+if (toGithubOutput && process.env.GITHUB_OUTPUT) {
+  appendFileSync(
+    process.env.GITHUB_OUTPUT,
+    [
+      `servers=${report.servers.selected.join(',')}`,
+      `clients=${report.clients.selected.join(',')}`,
+      `excluded=${excluded.join(',')}`,
+      `excluded_count=${excluded.length}`,
+      '',
+    ].join('\n'),
+  );
+}
+
+if (fatal.length > 0) {
+  for (const reason of fatal) {
+    console.error(`::error::${reason}`);
+  }
+  process.exit(1);
+}

--- a/test/select-conformance-components.test.js
+++ b/test/select-conformance-components.test.js
@@ -1,0 +1,207 @@
+/**
+ * Covers scripts/select-conformance-components.mjs — the step that decides
+ * which upstream e2e components the conformance job runs against.
+ *
+ * The fixtures below mirror the real x402 harness layout
+ * (role/language/transport/component) and the exact shape of setup.sh's
+ * failure report, because both are what the script parses. If upstream changes
+ * either, these tests are where it should surface.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const SCRIPT = new URL('../scripts/select-conformance-components.mjs', import.meta.url).pathname;
+
+/** Builds a throwaway e2e tree with the components named in `layout`. */
+function makeE2eDir(layout = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'x402-e2e-'));
+
+  mkdirSync(join(dir, 'config'), { recursive: true });
+  writeFileSync(
+    join(dir, 'config', 'mechanisms_stellar.json'),
+    JSON.stringify({
+      routes: { '/exact/stellar': { scheme: 'exact', sdks: layout.sdks ?? ['typescript'] } },
+    }),
+  );
+
+  const components = {
+    servers: layout.servers ?? [
+      'typescript/http/express',
+      'typescript/http/next',
+      'typescript/mcp',
+    ],
+    clients: layout.clients ?? ['typescript/http/fetch', 'typescript/mcp'],
+  };
+  for (const [role, names] of Object.entries(components)) {
+    for (const name of names) {
+      const componentDir = join(dir, role, ...name.split('/'));
+      mkdirSync(componentDir, { recursive: true });
+      // index.ts is one of the markers component.ts treats as "this is a component".
+      writeFileSync(join(componentDir, 'index.ts'), '');
+    }
+  }
+
+  // Directories the harness skips must not be picked up as components.
+  const noise = join(dir, 'servers', 'typescript', 'http', 'node_modules');
+  mkdirSync(noise, { recursive: true });
+  writeFileSync(join(noise, 'index.ts'), '');
+
+  return dir;
+}
+
+/** Writes a setup.sh log whose failure section lists `failures`. */
+function makeSetupLog(dir, failures) {
+  const path = join(dir, 'setup-output.txt');
+  const body = [
+    '🚀 X402 E2E Setup',
+    '',
+    '📦 server/typescript/http/express',
+    '   ✅ Install completed',
+    '',
+    '═══════════════════════════════════════════════════════',
+    '                 Setup Summary',
+    '═══════════════════════════════════════════════════════',
+    `✅ Successful: ${15 - failures.length}`,
+    `❌ Failed:     ${failures.length}`,
+    '📈 Total:      15',
+    '',
+    ...(failures.length > 0
+      ? ['❌ FAILED COMPONENTS:', ...failures.map(f => `   • ${f}`), '']
+      : ['✅ All setup tasks completed successfully!']),
+  ].join('\n');
+  writeFileSync(path, body);
+  return path;
+}
+
+function run(e2eDir, setupLog, { expectFailure = false } = {}) {
+  const outputFile = join(e2eDir, 'github-output.txt');
+  writeFileSync(outputFile, '');
+
+  const args = [SCRIPT, `--e2e-dir=${e2eDir}`, '--family=stellar', '--github-output'];
+  if (setupLog) args.push(`--setup-log=${setupLog}`);
+
+  let stdout = '';
+  let failed = false;
+  try {
+    stdout = execFileSync(process.execPath, args, {
+      encoding: 'utf8',
+      env: { ...process.env, GITHUB_OUTPUT: outputFile },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (err) {
+    failed = true;
+    stdout = `${err.stdout ?? ''}${err.stderr ?? ''}`;
+  }
+
+  assert.equal(
+    failed,
+    expectFailure,
+    `expected ${expectFailure ? 'failure' : 'success'}:\n${stdout}`,
+  );
+
+  const outputs = Object.fromEntries(
+    readFileSync(outputFile, 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map(line => {
+        const eq = line.indexOf('=');
+        return [line.slice(0, eq), line.slice(eq + 1)];
+      }),
+  );
+  return { stdout, outputs };
+}
+
+test('selects every component when nothing failed to build', t => {
+  const dir = makeE2eDir();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const { outputs } = run(dir, makeSetupLog(dir, []));
+
+  assert.equal(outputs.servers, 'typescript/http/express,typescript/http/next,typescript/mcp');
+  assert.equal(outputs.clients, 'typescript/http/fetch,typescript/mcp');
+  assert.equal(outputs.excluded, '');
+  assert.equal(outputs.excluded_count, '0');
+});
+
+test('drops only the component that failed, and names it', t => {
+  const dir = makeE2eDir();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  // The real 2026-08-12 failure.
+  const { outputs, stdout } = run(dir, makeSetupLog(dir, ['server/typescript/http/next']));
+
+  assert.equal(outputs.servers, 'typescript/http/express,typescript/mcp');
+  assert.equal(outputs.clients, 'typescript/http/fetch,typescript/mcp');
+  assert.equal(outputs.excluded, 'typescript/http/next');
+  assert.equal(outputs.excluded_count, '1');
+  assert.match(stdout, /✗ \(build failed\) typescript\/http\/next/);
+});
+
+test('a client build failure drops a client, not a server', t => {
+  const dir = makeE2eDir();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const { outputs } = run(dir, makeSetupLog(dir, ['client/typescript/mcp']));
+
+  assert.equal(outputs.servers, 'typescript/http/express,typescript/http/next,typescript/mcp');
+  assert.equal(outputs.clients, 'typescript/http/fetch');
+  assert.equal(outputs.excluded, 'typescript/mcp');
+});
+
+test('fails rather than running an empty matrix when every server is broken', t => {
+  const dir = makeE2eDir({ servers: ['typescript/http/express'] });
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const { stdout } = run(dir, makeSetupLog(dir, ['server/typescript/http/express']), {
+    expectFailure: true,
+  });
+
+  assert.match(stdout, /every discovered server failed to build/);
+});
+
+test('a facilitator build failure is fatal — ours is the thing under test', t => {
+  const dir = makeE2eDir();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const { stdout } = run(dir, makeSetupLog(dir, ['facilitator/external-proxies/accensa']), {
+    expectFailure: true,
+  });
+
+  assert.match(stdout, /facilitator components failed to build/);
+});
+
+test('ignores languages the mechanisms file does not list for the family', t => {
+  const dir = makeE2eDir({
+    sdks: ['typescript'],
+    servers: ['typescript/http/express', 'go/http/gin', 'python/http/flask'],
+  });
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const { outputs } = run(dir, makeSetupLog(dir, []));
+
+  // Stellar declares typescript SDKs only; a Go server cannot serve the route,
+  // so failing to build it is irrelevant to this run.
+  assert.equal(outputs.servers, 'typescript/http/express');
+});
+
+test('skips harness infrastructure directories', t => {
+  const dir = makeE2eDir();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const { outputs } = run(dir, makeSetupLog(dir, []));
+
+  assert.ok(!outputs.servers.includes('node_modules'));
+});
+
+test('treats a missing setup log as nothing-failed rather than crashing', t => {
+  const dir = makeE2eDir();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const { outputs } = run(dir, null);
+
+  assert.equal(outputs.excluded_count, '0');
+});


### PR DESCRIPTION
Closes #14.

The README has listed *"the x402 repository's e2e suite"* as an unchecked acceptance item since this repo was created, with nothing behind it. This wires it up — and documents what the suite actually is, which turned out to be the larger part of the work.

## What the upstream suite actually is

Not a test file you point at a URL. [`e2e/`](https://github.com/x402-foundation/x402/tree/main/e2e) is a **matrix harness** that spawns clients, resource servers *and* facilitators, then runs every valid combination of the ones you select.

**Stellar is already a first-class family upstream.** From `e2e/config/mechanisms_stellar.json`:

```json
"routes": {
  "/exact/stellar": { "scheme": "exact", "sdks": ["typescript"],
                      "price": { "usd": "$0.001" }, "extensions": ["bazaar"] }
},
"testnet": { "caip2": "stellar:testnet" },
"mainnet": { "caip2": "stellar:pubnet" }
```

Three useful things fall out of that: the paid route is `/exact/stellar` at $0.001; it declares the **`bazaar` extension**, so the discovery work in this repo sits on the same path the suite exercises; and `stellar:pubnet` is already defined upstream, so pubnet conformance (#17) is a configuration change rather than an upstream contribution.

## How we plug in

`e2e/facilitators/external-proxies/` is the documented place for a facilitator whose implementation lives elsewhere. It is **gitignored upstream**, so the component lives here in `e2e/accensa-proxy/` and is copied in at run time.

Two mismatches, both bridged by *declaration* rather than by changing the service:

| Harness expects | We do | Bridge |
|---|---|---|
| literal `Facilitator listening` on stdout, case-sensitive | `x402 Stellar facilitator listening on :PORT` — lowercase `f` | `run.sh` waits for readiness, then emits the expected line |
| health at `/health` | `/healthz` | `test.config.json` declares the endpoint |

**The proxy deliberately does not proxy.** It starts this service on the assigned port and gets out of the way, so the harness talks straight to our HTTP surface. An adapter that reshaped requests would make the whole exercise worthless — the wire format is the thing under test.

## Accounts

`scripts/fund-testnet-accounts.mjs` generates and friendbot-funds three accounts per run. Three *distinct* ones is not stylistic: `ExactStellarScheme` rejects any payment where the facilitator is a party to the transfer, so payer, recipient and facilitator must be different keys or verification fails on the first request.

Fresh per run rather than repository secrets — three funded keys sitting in CI configuration forever, rotated by nobody, is a worse arrangement than generating them for the ninety seconds they are needed. There is no pubnet path in the script, on purpose.

It reuses `installRpcRetry`, which turned out to be **necessary rather than tidy**: friendbot is behind Cloudflare and Node's `fetch` dead-ends on its AAAA records from an IPv4-only host — the same failure `src/rpc-retry.js` was written for, hit outside Soroban RPC for the first time.

## What is actually verified, and what is not

Run locally against `x402-foundation/x402@main`, Stellar family, testnet:

```
🏛️ Starting facilitator: accensa on port 4027
[facilitators/external-proxies/accensa] stdout: x402 Stellar facilitator listening on :4027
[facilitators/external-proxies/accensa] stdout: Facilitator listening on :4027
 🔍 Facilitator health check 1/10: ✅
  ✅ Facilitator accensa ready at http://localhost:4027

🔧 Server/Facilitator combinations: 5
   • typescript/http/express + accensa   • typescript/http/fastify + accensa
   • typescript/http/hono + accensa      • typescript/http/next + accensa
   • typescript/mcp + accensa
```

**Proven:** the harness discovers our facilitator as an external component, selects it into the matrix as `facilitator(accensa-stellar-v2)`, boots it, the ready-line bridge works, the health gate passes, and five server/facilitator combinations are built against it.

**Not proven: no payment completed.** The run stopped before any scenario executed, because the *upstream servers* failed to start:

```
Error: Cannot find module '…/servers/typescript/node_modules/@x402/express/dist/cjs/index.js'
```

That is a `pnpm install` vs `pnpm install:all` gap — `install:all` is `pnpm install && ./setup.sh`, and `setup.sh` is what builds the workspace `@x402/*` packages the spawned servers import. An install-procedure finding about the environment the harness ran in, **not** a finding about this facilitator. `docs/CONFORMANCE.md` records it rather than omitting it, because a conformance document listing only what passed is one that was not looked at hard enough.

So the honest claim today: **accepted by the upstream harness as a conforming external facilitator, passes its health gate, payment path untested.** The scheduled job exists to answer the rest, and `docs/CONFORMANCE.md` §4 will be updated with its first result — pass or fail.

Also worth recording: the harness needs **Node 22+** (the repo pins `pnpm@11.1.1`, which needs `node:sqlite`), and `--facilitators=accensa` matters — without it the harness also starts its own reference facilitators, and a failure in one of those aborts the run before ours is exercised.

## The workflow

`.github/workflows/conformance.yml`, deliberately **separate from `ci.yml`**: this job depends on testnet, on friendbot, and on a third-party repository at whatever state its main branch is in today. Any of those can be down without anything being wrong with this service, and a red build nobody believes is worse than no build.

Daily schedule, `workflow_dispatch` with a selectable upstream ref, and a `conformance/**` push trigger so the job can be iterated on without merging an untested workflow to `main`. It records the upstream SHA under test, publishes the full output as a 90-day artifact, writes a step summary, and **fails loudly** rather than going quietly amber.

## Review notes

The `conformance/**` push trigger means **this PR's branch has already run the job on GitHub's runner**, which is the environment that actually matters — Node 22, clean checkout, full install. Its result is linked from the checks on this PR and is the real answer to whether the payment path passes.