### PR TITLE
ci(conformance): prepare USDC trustlines, and skip honestly without a treasury

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -160,9 +160,28 @@ jobs:
           # Prove the file was written without printing key material.
           echo "wrote $(wc -l < .env) variables"
 
+      # The $0.001 route is priced in USDC, not XLM, so friendbot funding alone
+      # leaves the payer with no trustline and no balance and every scenario
+      # dies in simulation with Error(Contract, #13). Trustlines are free and
+      # created here; the balance needs a pre-funded treasury, because nobody
+      # can mint Circle's testnet USDC on demand.
+      #
+      # TESTNET_USDC_TREASURY_SECRET is a TESTNET-ONLY key. There is no pubnet
+      # path in that script and no pubnet secret is available to this job.
+      - name: Give the payer and payee testnet USDC
+        id: usdc
+        working-directory: facilitator
+        env:
+          TESTNET_USDC_TREASURY_SECRET: ${{ secrets.TESTNET_USDC_TREASURY_SECRET }}
+        run: node scripts/prepare-testnet-usdc.mjs --github-output
+
       - name: Run the upstream suite against this facilitator
         id: run
         working-directory: x402/e2e
+        # Skipped, rather than run and failed, when the payer cannot hold the
+        # asset: that is a missing prerequisite on our side, and reporting it as
+        # a conformance failure would misattribute it to the service.
+        if: steps.usdc.outputs.usdc_ready == 'true'
         continue-on-error: true
         run: |
           set -o pipefail
@@ -188,8 +207,17 @@ jobs:
             echo "- family: stellar · network: testnet · scheme: exact"
             echo "- servers: \`${{ steps.select.outputs.servers || '(selection did not run)' }}\`"
             echo "- clients: \`${{ steps.select.outputs.clients || '(selection did not run)' }}\`"
-            echo "- result: **${{ steps.run.outcome }}**"
+            echo "- result: **${{ steps.run.outcome == 'skipped' && 'not attempted' || steps.run.outcome }}**"
             echo
+            if [ "${{ steps.usdc.outputs.usdc_ready }}" != "true" ]; then
+              echo "> ⛔ **The suite was not run.** The payer could not be given the USDC the"
+              echo "> \`/exact/stellar\` route is priced in:"
+              echo ">"
+              echo "> ${{ steps.usdc.outputs.usdc_reason }}"
+              echo ">"
+              echo "> This is a missing prerequisite on our side, not a conformance result."
+              echo
+            fi
             # Exclusions are reported at the top rather than buried in a log.
             # A conformance run that quietly tested less than it claims to is
             # the exact failure this job exists to avoid.

--- a/scripts/fund-testnet-accounts.mjs
+++ b/scripts/fund-testnet-accounts.mjs
@@ -188,6 +188,10 @@ const env = {
   // The suite's own names, from e2e/config/mechanisms_stellar.json.
   CLIENT_STELLAR_PRIVATE_KEY: keys.client.secret(),
   SERVER_STELLAR_ADDRESS: keys.server.publicKey(),
+  // Not an upstream variable, and deliberately not written into the harness's
+  // .env: the payee's secret is needed only so scripts/prepare-testnet-usdc.mjs
+  // can give it a USDC trustline, without which it cannot receive the payment.
+  SERVER_STELLAR_PRIVATE_KEY: keys.server.secret(),
   FACILITATOR_STELLAR_PRIVATE_KEY: keys.facilitator.secret(),
   // What our own facilitator reads. Deliberately the same key as the one the
   // suite is told about, so the proxy and the service it fronts are one signer.

--- a/scripts/prepare-testnet-usdc.mjs
+++ b/scripts/prepare-testnet-usdc.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+/**
+ * Puts the harness's payer and payee accounts in a state where the upstream
+ * `/exact/stellar` route can actually be paid.
+ *
+ * WHY THIS IS NEEDED. The route is priced `$0.001`, and `@x402/stellar`
+ * resolves a USD price to its default stablecoin — on testnet that is
+ * `CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA`, the Stellar Asset
+ * Contract wrapping Circle's classic `USDC:GBBD47IF…`. Friendbot funds XLM and
+ * nothing else, so a fresh account has no trustline to that asset and no
+ * balance of it, and the payment dies in simulation:
+ *
+ *   HostError: Error(Contract, #13) … "trustline entry is missing for account"
+ *
+ * Two separate prerequisites follow, and they are not equally solvable:
+ *
+ *   1. TRUSTLINES on payer and payee. Free, and done here — a `changeTrust`
+ *      from each account is all it takes.
+ *   2. A USDC BALANCE on the payer. Nobody can mint Circle's testnet USDC on
+ *      demand; it comes from Circle's faucet, which is a human with a browser.
+ *      So this needs a pre-funded treasury account, supplied as
+ *      TESTNET_USDC_TREASURY_SECRET, that dribbles out a fraction of a cent per
+ *      run.
+ *
+ * ON THE TREASURY SECRET. Issue #14 asks for friendbot-funded fresh accounts
+ * over stored keys, and everything that *can* be ephemeral still is: payer,
+ * payee and facilitator are all generated per run. This one key cannot be,
+ * because the asset cannot be minted. It is testnet-only by construction —
+ * `Networks.TESTNET` is hardcoded below, there is no pubnet branch, and the
+ * asset is a testnet issuer's — so the worst case if it leaks is that someone
+ * takes a few testnet dollars that cost nothing to replace.
+ *
+ * When the secret is absent this exits 0 and reports `usdc_ready=false`. That
+ * is deliberate: the payment path being unprovable for want of a faucet is a
+ * configuration gap, not a conformance failure, and reporting it as a red
+ * conformance run would be the kind of lie this job exists to prevent.
+ *
+ * Usage:
+ *   node scripts/prepare-testnet-usdc.mjs --github-output
+ */
+import { appendFileSync } from 'node:fs';
+import {
+  Asset,
+  BASE_FEE,
+  Horizon,
+  Keypair,
+  Networks,
+  Operation,
+  TransactionBuilder,
+} from '@stellar/stellar-sdk';
+import { installRpcRetry } from '../src/rpc-retry.js';
+
+// Same IPv4 dead-end as friendbot and Soroban RPC — see src/rpc-retry.js.
+installRpcRetry({ log: msg => console.error(`  ${msg}`) });
+
+const HORIZON = process.env.HORIZON_URL ?? 'https://horizon-testnet.stellar.org';
+
+// Circle's testnet USDC issuer. Asserted against the SAC address below rather
+// than trusted: if upstream ever changes its default stablecoin, this run must
+// stop with a clear message instead of quietly preparing the wrong asset.
+const USDC_ISSUER = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+const EXPECTED_SAC = 'CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA';
+
+// One run spends $0.001. This is three orders of magnitude more, so a treasury
+// funded once from the faucet outlives any reasonable schedule.
+const PER_RUN_AMOUNT = '1.0000000';
+const TRUSTLINE_LIMIT = '1000000';
+
+const usdc = new Asset('USDC', USDC_ISSUER);
+if (usdc.contractId(Networks.TESTNET) !== EXPECTED_SAC) {
+  console.error(
+    `::error::USDC SAC mismatch — expected ${EXPECTED_SAC}, derived ${usdc.contractId(Networks.TESTNET)}. ` +
+      "Upstream's default Stellar stablecoin has changed; this script needs updating.",
+  );
+  process.exit(1);
+}
+
+const server = new Horizon.Server(HORIZON);
+
+/** Submits ops signed by `keypair`, tolerating a trustline that already exists. */
+async function submit(keypair, ops, label) {
+  const account = await server.loadAccount(keypair.publicKey());
+  const builder = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.TESTNET,
+  });
+  for (const op of ops) builder.addOperation(op);
+
+  const tx = builder.setTimeout(60).build();
+  tx.sign(keypair);
+
+  try {
+    const res = await server.submitTransaction(tx);
+    console.error(`  ${label}: ${res.hash}`);
+    return res.hash;
+  } catch (err) {
+    const codes = err?.response?.data?.extras?.result_codes;
+    // Re-running against an already-prepared account is not an error.
+    if (JSON.stringify(codes ?? {}).includes('op_already_exists')) {
+      console.error(`  ${label}: already in place`);
+      return null;
+    }
+    console.error(`  ${label} failed: ${JSON.stringify(codes ?? err.message)}`);
+    throw err;
+  }
+}
+
+const clientSecret = process.env.CLIENT_STELLAR_PRIVATE_KEY;
+const serverAddress = process.env.SERVER_STELLAR_ADDRESS;
+if (!clientSecret || !serverAddress) {
+  console.error('::error::CLIENT_STELLAR_PRIVATE_KEY and SERVER_STELLAR_ADDRESS must be set');
+  process.exit(2);
+}
+
+const outputs = {};
+const finish = (ready, reason) => {
+  outputs.usdc_ready = String(ready);
+  outputs.usdc_reason = reason;
+  if (process.argv.includes('--github-output') && process.env.GITHUB_OUTPUT) {
+    appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      Object.entries(outputs)
+        .map(([k, v]) => `${k}=${v}`)
+        .join('\n') + '\n',
+    );
+  }
+  console.error(ready ? `USDC ready: ${reason}` : `USDC not ready: ${reason}`);
+  process.exit(0);
+};
+
+const treasurySecret = process.env.TESTNET_USDC_TREASURY_SECRET;
+if (!treasurySecret) {
+  finish(
+    false,
+    'TESTNET_USDC_TREASURY_SECRET is not configured, so the payer cannot hold the ' +
+      'USDC the $0.001 route is priced in. Trustlines were not created either — ' +
+      'they are useless without a balance.',
+  );
+}
+
+const client = Keypair.fromSecret(clientSecret);
+const treasury = Keypair.fromSecret(treasurySecret);
+
+console.error(`Preparing USDC on ${HORIZON}`);
+console.error(`  asset    USDC:${USDC_ISSUER}`);
+console.error(`  treasury ${treasury.publicKey()}`);
+
+// The payee needs a trustline too — a transfer into an account with none fails
+// the same way the payer's does. Its secret is in CLIENT-shaped env only for
+// the payer, so the payee trustline is created by the payee keypair, which the
+// funding script emits alongside SERVER_STELLAR_ADDRESS.
+const serverSecret = process.env.SERVER_STELLAR_PRIVATE_KEY;
+if (!serverSecret || Keypair.fromSecret(serverSecret).publicKey() !== serverAddress) {
+  finish(
+    false,
+    'SERVER_STELLAR_PRIVATE_KEY is missing or does not match SERVER_STELLAR_ADDRESS, ' +
+      'so the payee cannot be given a USDC trustline and any transfer to it would fail.',
+  );
+}
+
+try {
+  const changeTrust = Operation.changeTrust({ asset: usdc, limit: TRUSTLINE_LIMIT });
+
+  await submit(client, [changeTrust], 'payer trustline');
+  await submit(Keypair.fromSecret(serverSecret), [changeTrust], 'payee trustline');
+
+  await submit(
+    treasury,
+    [Operation.payment({ destination: client.publicKey(), asset: usdc, amount: PER_RUN_AMOUNT })],
+    `payer funded with ${PER_RUN_AMOUNT} USDC`,
+  );
+} catch (err) {
+  // A treasury that has run dry, or Horizon being unavailable, is again a
+  // prerequisite problem rather than a conformance result.
+  finish(false, `preparation failed: ${err.message?.slice(0, 200) ?? err}`);
+}
+
+finish(true, `payer holds ${PER_RUN_AMOUNT} USDC and both accounts carry trustlines`);


### PR DESCRIPTION
## Context

With the plumbing from #57 fixed, all five servers boot and every scenario now reaches the payment itself — where it fails in simulation. The scheduled run this morning passed **0 of 6**:

```
HostError: Error(Contract, #10) "resulting balance is not within the allowed range", 0, -10000
```

`@x402/stellar` resolves the route's `$0.001` price to its default stablecoin — on testnet, the SAC wrapping Circle's classic `USDC:GBBD47IF…`, asserted here against the address in the mechanism package rather than assumed. Friendbot funds XLM only, so a fresh payer has neither a trustline nor a balance.

## Changes

- **Trustlines are free and are now created** for payer and payee (`scripts/prepare-testnet-usdc.mjs`).
- **A balance is not.** Circle's testnet USDC cannot be minted on demand, so it needs a pre-funded treasury key supplied as the `TESTNET_USDC_TREASURY_SECRET` repository secret. Every other account stays ephemeral; this one cannot be, and it is testnet-only by construction — no pubnet branch exists in the script.
- **Without the secret the job reports `usdc_ready=false`, skips the suite, and says so in the summary** rather than running a matrix that can only fail. A missing faucet is a prerequisite gap, not a conformance result about this service.

## Follow-up required (not in this PR)

This makes the job *honest*. It does not make it *green*. To get an actual conformance pass someone must:

1. Fund a testnet account with Circle testnet USDC
2. Add its secret key as the `TESTNET_USDC_TREASURY_SECRET` repository secret

Until then the daily run will skip rather than fail. #18 tracks publishing the resulting settled transaction hashes.