### PR TITLE
docs(readme): correct what is built, name why conformance is unproven, link the org

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@
   </p>
   <p>
     <a href="#conformance"><strong>Conformance</strong></a> ·
-    <a href="#getting-started"><strong>Getting Started</strong></a> ·
+    <a href="#documentation"><strong>Documentation</strong></a> ·
     <a href="#known-gaps"><strong>Known Gaps</strong></a> ·
+    <a href="https://github.com/accensa"><strong>Accensa org</strong></a> ·
     <a href="https://github.com/x402-foundation/x402"><strong>x402 spec</strong></a>
   </p>
 </div>
@@ -25,8 +26,10 @@
 > [!WARNING]
 > **This is a conformance spike, not a production facilitator.** It exists to answer one
 > question: can an unmodified canonical x402 client complete a payment against a
-> facilitator we operate on Stellar testnet? It makes no availability claim, has no
-> persistence, and does not implement the Bazaar discovery layer.
+> facilitator we operate on Stellar testnet? **That question is still open** — see
+> [Conformance](#conformance) for exactly which boxes are unticked and why. It makes no
+> availability claim, is not deployed anywhere you can reach, and has published no settled
+> transaction hash.
 
 ## The Problem
 
@@ -65,10 +68,27 @@ operational concerns, is what lives here.
 
 ## Documentation
 
-Please refer to our [Documentation Hub](docs/README.md) for detailed role-based guides:
+Published docs for the whole organisation, including this service, are at
+**<https://accensa.github.io/accensa-app/docs/facilitator/overview>**.
+
+In-repo, refer to the [Documentation Hub](docs/README.md) for detailed role-based guides:
 - [Seller Guide](docs/SELLER.md)
 - [Buyer / Agent Guide](docs/BUYER.md)
 - [Operator Guide](docs/OPERATOR.md)
+
+Reference material: [Architecture](docs/ARCHITECTURE.md) ·
+[Bazaar discovery](docs/BAZAAR.md) · [MCP server](docs/MCP.md) ·
+[Conformance](docs/CONFORMANCE.md) · [Deployment](docs/DEPLOYMENT.md) ·
+[Operations](docs/OPERATIONS.md) · [Authentication](docs/AUTHENTICATION.md) ·
+[Threat model](docs/THREAT-MODEL.md) · [Audit readiness](docs/AUDIT.md) ·
+[Privacy](docs/PRIVACY.md) · [Glossary](docs/GLOSSARY.md)
+
+Sibling repositories in the [Accensa organisation](https://github.com/accensa):
+[`accensa-app`](https://github.com/accensa/accensa-app) (merchant dashboard, indexer,
+`@accensa/sdk`) and
+[`accensa-contracts`](https://github.com/accensa/accensa-contracts) (Soroban receipt
+anchoring and refund vault). A seller can use those without this, and an agent can use
+this without those.
 
 ### Tests
 
@@ -108,6 +128,25 @@ holds today on testnet:
 - [ ] `stellar:pubnet`
 - [ ] The x402 repository's e2e suite
 
+**Why the last four are unticked, stated rather than left vague.** The
+[conformance workflow](.github/workflows/conformance.yml) runs the upstream
+`x402-foundation/x402` e2e suite against this facilitator daily. It has run three times
+and passed zero scenarios. The blocker is not this service: `@x402/stellar` resolves the
+route's `$0.001` price to Circle's testnet USDC, friendbot funds XLM only, and Circle's
+testnet USDC cannot be minted on demand — so every buyer reaches the payment and fails in
+simulation with an empty balance:
+
+```
+HostError: Error(Contract, #10) "resulting balance is not within the allowed range", 0, -10000
+```
+
+Trustlines are now created for payer and payee automatically. A *balance* needs a
+pre-funded testnet treasury key supplied as the `TESTNET_USDC_TREASURY_SECRET` repository
+secret. Without it the job reports `usdc_ready=false` and **skips the suite rather than
+running a matrix that can only fail** — a missing faucet is a prerequisite gap, not a
+conformance result about this service. Until that secret exists, treat every box above as
+unproven, and see [`docs/CONFORMANCE.md`](docs/CONFORMANCE.md).
+
 Responses use the canonical field names — `VerifyResponse` carries `invalidReason` and
 `invalidMessage`; `SettleResponse` carries `errorReason`, `errorMessage`, `transaction`
 and `network`. There is no `reason` field, and inventing one produces a service that looks
@@ -119,9 +158,21 @@ correct locally and is non-conformant on the wire.
   `selectSigner`, plus an optional `feeBumpSigner` that decouples fee payment from
   sequence-number management. That pair is how bursty agent traffic avoids sequence
   contention. One signer is enough to prove conformance and not enough to serve load.
-- **No Bazaar.** Discovery, search and automatic cataloging are absent. This spike is only
-  about the payment path.
-- **No persistence.**
+- **Bazaar is built but unproven against a second implementation.** Discovery, search and
+  automatic cataloging landed on 2026-08-12 and are documented in
+  [`docs/BAZAAR.md`](docs/BAZAAR.md): a catalog datastore with migrations,
+  `GET /discovery/resources` with the full upstream filter set, `GET /discovery/search`
+  with lexical and hybrid (dense-embedding + reranking) retrieval, automatic cataloging
+  off the payment path, `EXTENSION-RESPONSES` reporting, and an MCP server
+  ([`docs/MCP.md`](docs/MCP.md)). What has *not* happened is any other party's client
+  reading this catalog. A search-evaluation harness and judgement set live in `eval/`.
+- **No deployment.** There is a `Dockerfile`, a `docker-compose.yml` and
+  [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md), but no instance is running at a URL anyone
+  can hit. Availability targets and a status page are tracked in
+  [#19](https://github.com/accensa/x402-facilitator-stellar/issues/19).
+- **No persistence by default.** The catalog has a PostgreSQL schema in `migrations/` and
+  uses it when `DATABASE_URL` is set; the settlement path holds nothing durable, tracked
+  in [#10](https://github.com/accensa/x402-facilitator-stellar/issues/10).
 - **`exact` only.** The `upto` scheme has no Stellar specification yet; design notes in
   [`accensa-contracts/docs/ADR-002`](https://github.com/accensa/accensa-contracts/blob/main/docs/ADR-002-upto-scheme.md).
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,24 @@
   "version": "0.0.1",
   "private": true,
   "description": "Conformance spike: a minimal x402 facilitator for Stellar built on @x402/stellar",
+  "keywords": [
+    "x402",
+    "stellar",
+    "soroban",
+    "facilitator",
+    "agentic-payments",
+    "payments",
+    "bazaar",
+    "mcp"
+  ],
+  "homepage": "https://accensa.github.io/accensa-app/docs/facilitator/overview",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/accensa/x402-facilitator-stellar.git"
+  },
+  "bugs": {
+    "url": "https://github.com/accensa/x402-facilitator-stellar/issues"
+  },
   "license": "Apache-2.0",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Context

Three things in the README no longer matched the repo, all found while auditing link wiring across the org.

## Changes

**Bazaar is built.** Known Gaps said *"No Bazaar. Discovery, search and automatic cataloging are absent"* and the header warning repeated it. That stopped being true on 08-12 (#20–#27, #29): catalog datastore with migrations, `GET /discovery/resources` with the full upstream filter set, `GET /discovery/search` with lexical and hybrid retrieval, automatic cataloging off the payment path, `EXTENSION-RESPONSES` reporting, and an MCP server — with `docs/BAZAAR.md` and `docs/MCP.md` written. The real gap is narrower and is now stated as such: **no other party's client has ever read this catalog.**

**Conformance now says *why*, not just *that*.** The four unticked boxes had no explanation, which reads as work not yet attempted. The suite has in fact run three times and passed zero scenarios, and the blocker is not this service — see #61. The `TESTNET_USDC_TREASURY_SECRET` prerequisite, and the fact that the job skips rather than fails without it, are now written where a reader will look.

**Two gaps that were not listed at all** — no deployment (#19) and no durable settlement store (#10) — now are.

## Also

- The header linked `#getting-started`, an anchor this README has never had. Replaced with `#documentation`.
- Documentation section now links the published docs site, the [Accensa org](https://github.com/accensa), the sibling repos, and the eleven in-repo reference docs that were previously reachable only by browsing `docs/`.
- `package.json` gains `homepage`, `repository`, `bugs`, and keywords.

## Verification

111 tests pass, eslint clean, prettier clean.