### PR TITLE
ci(conformance): send a cent per run, not a dollar

### DIFF
--- a/scripts/prepare-testnet-usdc.mjs
+++ b/scripts/prepare-testnet-usdc.mjs
@@ -19,8 +19,8 @@
  *   2. A USDC BALANCE on the payer. Nobody can mint Circle's testnet USDC on
  *      demand; it comes from Circle's faucet, which is a human with a browser.
  *      So this needs a pre-funded treasury account, supplied as
- *      TESTNET_USDC_TREASURY_SECRET, that dribbles out a fraction of a cent per
- *      run.
+ *      TESTNET_USDC_TREASURY_SECRET, that dribbles out a cent per run — see
+ *      PER_RUN_AMOUNT for why that figure is the real burn rate.
  *
  * ON THE TREASURY SECRET. Issue #14 asks for friendbot-funded fresh accounts
  * over stored keys, and everything that *can* be ephemeral still is: payer,
@@ -61,9 +61,16 @@ const HORIZON = process.env.HORIZON_URL ?? 'https://horizon-testnet.stellar.org'
 const USDC_ISSUER = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
 const EXPECTED_SAC = 'CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA';
 
-// One run spends $0.001. This is three orders of magnitude more, so a treasury
-// funded once from the faucet outlives any reasonable schedule.
-const PER_RUN_AMOUNT = '1.0000000';
+// One run spends $0.001 on the `/exact/stellar` route. This is 10x that, which
+// leaves room for a scenario that pays more than once without being so much
+// that the treasury drains on a schedule.
+//
+// The payer is a fresh keypair every run and is never swept, so whatever is sent
+// here is stranded once the run ends — this figure is the true per-run burn, not
+// a float. At 0.01 a single faucet pull of 20 USDC funds ~2,000 runs, which is
+// over five years of the daily cron. At the previous 1.0 it was 20 runs, or
+// under three weeks, and topping up needs a human at Circle's faucet.
+const PER_RUN_AMOUNT = '0.0100000';
 const TRUSTLINE_LIMIT = '1000000';
 
 const usdc = new Asset('USDC', USDC_ISSUER);


### PR DESCRIPTION
## Context

`PER_RUN_AMOUNT` was `1.0000000` USDC, justified in a comment as *"three orders of magnitude more"* than the `$0.001` the `/exact/stellar` route costs, so that *"a treasury funded once from the faucet outlives any reasonable schedule."*

That reasoning treats the amount as a float the payer draws down. It isn't. The payer is a **fresh keypair every run** (#14) and is never swept, so the whole amount is stranded the moment the run ends. `PER_RUN_AMOUNT` is the true per-run burn, not a buffer.

## The arithmetic

The treasury is now funded with **20 USDC** from Circle's faucet:

| `PER_RUN_AMOUNT` | Runs from 20 USDC | Daily cron runway |
|---|---|---|
| `1.0000000` (before) | 20 | under 3 weeks |
| `0.0100000` (after) | ~2,000 | over 5 years |

`0.01` is still **10x** the route's price, so a scenario paying more than once has room. And topping up is not automatable — Circle's testnet USDC can't be minted on demand, so running dry means a human back at the faucet, and in the meantime the job quietly reverts to `usdc_ready=false` and skips.

## Also

The file header claimed the treasury *"dribbles out a fraction of a cent per run"* — wrong at `1.0` (a dollar) and now accurate at `0.01` (a cent). Corrected, and pointed at the constant where the reasoning lives.

## Verification

111 tests pass, eslint clean, prettier clean. No behaviour change beyond the amount.