### PR TITLE
docs(conformance): record the first real results — one payment settled, four scenarios failing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@
 > [!WARNING]
 > **This is a conformance spike, not a production facilitator.** It exists to answer one
 > question: can an unmodified canonical x402 client complete a payment against a
-> facilitator we operate on Stellar testnet? **That question is still open** — see
-> [Conformance](#conformance) for exactly which boxes are unticked and why. It makes no
-> availability claim, is not deployed anywhere you can reach, and has published no settled
-> transaction hash.
+> facilitator we operate on Stellar testnet? **As of 2026-08-14 the answer is yes, twice,
+> with settled transactions anyone can verify** — and **four of the five upstream server
+> components still fail**. See [Conformance](#conformance) for both halves. It makes no
+> availability claim and is not deployed anywhere you can reach.
 
 ## The Problem
 
@@ -123,29 +123,46 @@ holds today on testnet:
 - [x] Every rejection carries a non-null `invalidReason` — across malformed bodies,
       unregistered scheme/network pairs, and scheme-level failures
 - [x] The spec's `payload: {transaction}` shape is accepted verbatim
-- [ ] An unmodified canonical client completes a payment end-to-end
-- [ ] Settled transaction hash published
+- [x] **An unmodified canonical client completes a payment end-to-end**
+- [x] **Settled transaction hash published** — two, below
+- [ ] The x402 repository's e2e suite — **1 of 5 server components passes**
 - [ ] `stellar:pubnet`
-- [ ] The x402 repository's e2e suite
 
-**Why the last four are unticked, stated rather than left vague.** The
-[conformance workflow](.github/workflows/conformance.yml) runs the upstream
-`x402-foundation/x402` e2e suite against this facilitator daily. It has run three times
-and passed zero scenarios. The blocker is not this service: `@x402/stellar` resolves the
-route's `$0.001` price to Circle's testnet USDC, friendbot funds XLM only, and Circle's
-testnet USDC cannot be minted on demand — so every buyer reaches the payment and fails in
-simulation with an empty balance:
+### Settled on Stellar testnet, 2026-08-14
 
+An unmodified `typescript/http/fetch` client received a `402` with terms, signed a payment
+authorization, retried, and this facilitator verified and settled it on-chain — paying the
+network fee itself, so `areFeesSponsored` is observed rather than merely advertised.
+
+| Transaction | Ledger | Settled |
+|---|---|---|
+| [`5f1bd15a…5558`](https://stellar.expert/explorer/testnet/tx/5f1bd15aec8ca3c6390689ed7fed82506f6c3d8eb8ed325a05a8b83974925558) | 4134781 | 08:15:33Z |
+| [`ff798145…0590`](https://stellar.expert/explorer/testnet/tx/ff798145681ad66e20f39f60d91895e993bc8033bbc78847aa5ddf0ee1e70590) | 4134928 | 08:27:49Z |
+
+Both report `"successful": true` from Horizon. Verify without trusting this file:
+
+```bash
+curl -s https://horizon-testnet.stellar.org/transactions/5f1bd15aec8ca3c6390689ed7fed82506f6c3d8eb8ed325a05a8b83974925558 \
+  | jq '{successful, ledger, created_at}'
 ```
-HostError: Error(Contract, #10) "resulting balance is not within the allowed range", 0, -10000
-```
 
-Trustlines are now created for payer and payee automatically. A *balance* needs a
-pre-funded testnet treasury key supplied as the `TESTNET_USDC_TREASURY_SECRET` repository
-secret. Without it the job reports `usdc_ready=false` and **skips the suite rather than
-running a matrix that can only fail** — a missing faucet is a prerequisite gap, not a
-conformance result about this service. Until that secret exists, treat every box above as
-unproven, and see [`docs/CONFORMANCE.md`](docs/CONFORMANCE.md).
+### Four of five scenarios still fail
+
+`typescript/http/next` passes. `express`, `fastify`, `hono` and `mcp` do not — two with
+`Payment response header not found`, two with upstream's `402 facilitator_error`. This
+reproduced identically across two runs in which the harness ordered the combinations
+differently, so it is **structural rather than flaky**. Exactly one settlement occurs per
+run; the four failures never reach the chain.
+
+**It cannot currently be diagnosed**, because this facilitator emits four lines of output
+across an entire run — three startup banners and an exit code. Two of the failures mean
+*this service returned an error*, and there is no record of what it was. That makes
+[#7](https://github.com/accensa/x402-facilitator-stellar/issues/7) the blocking item
+rather than a nice-to-have; the investigation is
+[#64](https://github.com/accensa/x402-facilitator-stellar/issues/64).
+
+The full record, including the treasury prerequisite that had to be solved first and how
+to reproduce both results, is in [`docs/CONFORMANCE.md`](docs/CONFORMANCE.md).
 
 Responses use the canonical field names — `VerifyResponse` carries `invalidReason` and
 `invalidMessage`; `SettleResponse` carries `errorReason`, `errorMessage`, `transaction`
@@ -164,8 +181,11 @@ correct locally and is non-conformant on the wire.
   `GET /discovery/resources` with the full upstream filter set, `GET /discovery/search`
   with lexical and hybrid (dense-embedding + reranking) retrieval, automatic cataloging
   off the payment path, `EXTENSION-RESPONSES` reporting, and an MCP server
-  ([`docs/MCP.md`](docs/MCP.md)). What has *not* happened is any other party's client
-  reading this catalog. A search-evaluation harness and judgement set live in `eval/`.
+  ([`docs/MCP.md`](docs/MCP.md)). A search-evaluation harness and judgement set live in
+  `eval/`. **On 2026-08-14 another party's client read this catalog for the first time
+  and its listing was rejected** — upstream registers wildcard `*` route templates and
+  this repo's validation hard-drops them as `invalid_routeTemplate`
+  ([#65](https://github.com/accensa/x402-facilitator-stellar/issues/65)).
 - **No deployment.** There is a `Dockerfile`, a `docker-compose.yml` and
   [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md), but no instance is running at a URL anyone
   can hit. Availability targets and a status page are tracked in

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -122,6 +122,91 @@ about this service.
 
 ## 4. Results
 
+### 2026-08-14 — first payments settled on testnet; 1 of 5 server components passes
+
+The previous section closed by saying this one would be written with the first
+real result, pass or fail. It is both.
+
+**Two runs, `71743e1` against upstream `main`, twelve minutes apart.** Each
+settled exactly one payment on Stellar testnet, and each failed four scenarios.
+
+#### What passed — and it is the headline claim of this repository
+
+An **unmodified canonical client** (`typescript/http/fetch`) requested a
+paywalled route, received a `402` with terms, signed a payment authorization,
+retried, and this facilitator verified it and settled it on-chain. The fee was
+paid by the facilitator's own account, so `areFeesSponsored` is not just
+advertised in `/supported` — it is what happened.
+
+| Run | Transaction | Ledger | Settled |
+|---|---|---|---|
+| 1 | [`5f1bd15a…5558`](https://stellar.expert/explorer/testnet/tx/5f1bd15aec8ca3c6390689ed7fed82506f6c3d8eb8ed325a05a8b83974925558) | 4134781 | 2026-08-14T08:15:33Z |
+| 2 | [`ff798145…0590`](https://stellar.expert/explorer/testnet/tx/ff798145681ad66e20f39f60d91895e993bc8033bbc78847aa5ddf0ee1e70590) | 4134928 | 2026-08-14T08:27:49Z |
+
+Both return `"successful": true` from Horizon. Check them yourself:
+
+```bash
+curl -s https://horizon-testnet.stellar.org/transactions/5f1bd15aec8ca3c6390689ed7fed82506f6c3d8eb8ed325a05a8b83974925558 \
+  | jq '{successful, ledger, created_at}'
+```
+
+#### What failed — four of five, and it is structural
+
+| Server component | Run 1 | Run 2 | Failure |
+|---|---|---|---|
+| `typescript/http/next` | ✅ (5th) | ✅ (3rd) | — |
+| `typescript/http/express` | ❌ | ❌ | `Payment response header not found` |
+| `typescript/http/fastify` | ❌ | ❌ | `Payment response header not found` |
+| `typescript/http/hono` | ❌ | ❌ | `402 facilitator_error` |
+| `typescript/mcp` | ❌ | ❌ | `402 facilitator_error` |
+
+The two runs are reported together because the harness ordered the combinations
+differently in each, and that difference is the only useful control available.
+`next` passed from position 5 and again from position 3, while the same four
+failed in both. **So this is not flakiness, not USDC propagation lag, and not
+the treasury draining** — the first hypothesis after run 1 was that only the
+last combination passed because the payer's balance needed time to propagate,
+and run 2 disproves it.
+
+Exactly one settlement occurs per run, so the four failures never reached the
+chain at all. The one structural difference visible from outside is the route:
+`next` is exercised at `/api/exact/stellar/withX402`, the other four at
+`/exact/stellar` and `exact_stellar`.
+
+#### Why this cannot be diagnosed further today
+
+The facilitator produced **four lines of output across an entire run** — three
+startup banners and an exit code:
+
+```
+[facilitators/external-proxies/accensa] stdout: x402 Stellar facilitator listening on :4027
+[facilitators/external-proxies/accensa] stdout:   networks : stellar:testnet
+[facilitators/external-proxies/accensa] stdout: Facilitator listening on :4027
+[facilitators/external-proxies/accensa] Process exited with code 143
+```
+
+No request log, no verify or settle outcome, no rejection reason. Two of the
+four failures return upstream's `facilitator_error`, which means *this service
+returned an error* — and there is no record of what it was. Whether the other
+two are ours or upstream's is likewise unknowable from here.
+
+That makes [#7](https://github.com/accensa/x402-facilitator-stellar/issues/7)
+(structured logging, request correlation, `/metrics`) the blocking item for this
+document, not a nice-to-have. It is tracked against these runs in
+[#64](https://github.com/accensa/x402-facilitator-stellar/issues/64).
+
+#### A Bazaar finding, on the passing scenario
+
+```
+[Catalog] Hard drop: invalid_routeTemplate
+[x402] extension responses: {"bazaar":{"status":"rejected","code":"invalid_routeTemplate"}}
+```
+
+Upstream's server registers wildcard `*` route templates; this repo's catalog
+validation hard-drops them. This is the **first time another party's client has
+touched this catalog**, and the listing was rejected. Filed as
+[#65](https://github.com/accensa/x402-facilitator-stellar/issues/65).
+
 ### 2026-08-12 — integration verified, payment path not yet exercised
 
 Run locally against `x402-foundation/x402@main`, Stellar family, testnet.
@@ -181,17 +266,21 @@ its first result — pass or fail.
 
 ### Acceptance items
 
+Current as of 2026-08-14.
+
 | Item | State | Evidence |
 |---|---|---|
-| Canonical client completes a payment, testnet | ⬜ | pending first CI run |
+| Canonical client completes a payment, testnet | ✅ | [`5f1bd15a…`](https://stellar.expert/explorer/testnet/tx/5f1bd15aec8ca3c6390689ed7fed82506f6c3d8eb8ed325a05a8b83974925558) and [`ff798145…`](https://stellar.expert/explorer/testnet/tx/ff798145681ad66e20f39f60d91895e993bc8033bbc78847aa5ddf0ee1e70590), both `successful` on Horizon |
 | Canonical client completes a payment, pubnet | ⬜ | blocked on #17 |
-| `/supported` emits `extra.areFeesSponsored` | ✅ | asserted by `test/app.test.js`; visible in the boot output above |
+| `/supported` emits `extra.areFeesSponsored` | ✅ | `test/app.test.js`; and observed — the facilitator paid the fee on both settlements above |
 | `payload: {transaction}` accepted verbatim | ✅ | `test/app.test.js` |
-| Upstream e2e suite, testnet | 🟡 | facilitator accepted and healthy; payment path pending |
+| Upstream e2e suite, testnet | 🟡 | **1 of 5 server components passes.** `next` ✅; `express`, `fastify`, `hono`, `mcp` ❌ — reproducible across two runs, see above and #64 |
 | Upstream e2e suite, pubnet | ⬜ | blocked on #17 |
 | Non-null reason on every rejection | ✅ | `test/app.test.js`, across four malformed-body shapes on both routes |
-| Settled tx hash published per network per scheme | ⬜ | #18 |
+| Settled tx hash published per network per scheme | 🟡 | testnet `exact` published above; pubnet blocked on #17. #18 |
+| Bazaar listing accepted by a third-party client | ❌ | first attempt rejected `invalid_routeTemplate`, #65 |
 | `__check_auth` smart-account payer | ⬜ | #13 |
+| Structured logs sufficient to diagnose a failure | ❌ | four lines per run; #7, blocking #64 |
 
 ## 5. Automation
 


### PR DESCRIPTION
## Context

`docs/CONFORMANCE.md` closed its previous section promising to be updated with the first result of the scheduled job, *"pass or fail."* With the treasury in place (#61, #63), that result exists. It is both.

## ✅ The headline claim is proven

An unmodified `typescript/http/fetch` client received a `402` with terms, signed a payment authorization, retried, and this facilitator verified and settled it on Stellar testnet — **twice** — paying the network fee itself, so `areFeesSponsored` is observed rather than advertised.

| Transaction | Ledger | Settled |
|---|---|---|
| [`5f1bd15a…5558`](https://stellar.expert/explorer/testnet/tx/5f1bd15aec8ca3c6390689ed7fed82506f6c3d8eb8ed325a05a8b83974925558) | 4134781 | 2026-08-14T08:15:33Z |
| [`ff798145…0590`](https://stellar.expert/explorer/testnet/tx/ff798145681ad66e20f39f60d91895e993bc8033bbc78847aa5ddf0ee1e70590) | 4134928 | 2026-08-14T08:27:49Z |

Both `"successful": true` on Horizon, with the `curl` to check them without trusting this repo.

Two README boxes tick: *an unmodified canonical client completes a payment end-to-end* and *settled transaction hash published*. Partially addresses #18 (testnet `exact`; pubnet still #17).

## ❌ Four of five scenarios still fail

`express` and `fastify` with `Payment response header not found`; `hono` and `mcp` with upstream's `402 facilitator_error`. Only `next` passes.

Both runs are reported together because the harness ordered the combinations differently in each — `next` passed from position 5 and again from position 3, while the same four failed in both. **Structural, not flaky, not USDC propagation, not treasury drain.** The first hypothesis after run 1 was propagation lag; run 2 disproved it, and that is recorded rather than quietly dropped.

It cannot be diagnosed further because the facilitator emits four lines per run — three startup banners and an exit code. Two failures mean *this service returned an error* with no record of what it was. **#7 is promoted from nice-to-have to blocking**, tracked in **#64**.

## 🔎 And a Bazaar finding

The *passing* scenario surfaced the first third-party listing this catalog has ever received — rejected as `invalid_routeTemplate`. Known Gaps has said since 08-12 that the real gap was that no other party's client had read this catalog. One has now, and we dropped it. Filed as **#65**.

## Note on framing

The README gains a line saying **1 of 5 components passes**, sitting directly beneath the two settled hashes. That ratio is the honest headline; leading with the transactions alone would be the exact pattern this organisation is currently appealing against.

## Verification

Prettier clean, eslint clean. Docs only — no source changes.