### PR TITLE
Fix Bazaar routeTemplate hard-drop, validate request bodies, redact logs, add OpenAPI spec

### DIFF
--- a/docs/BAZAAR.md
+++ b/docs/BAZAAR.md
@@ -71,7 +71,8 @@ The validation rules for resources submitted to the catalog are as follows:
 | Field | Failure | Outcome | Reason |
 |---|---|---|---|
 | Extension schema | Invalid | **Hard drop** (resource discarded) | Must conform to upstream bazaar spec. |
-| `routeTemplate` | Invalid / Traversal | **Hard drop** (resource discarded) | Security boundary to prevent SSRF and traversal. |
+| `routeTemplate` | Traversal / protocol smuggling / unparseable | **Hard drop** (resource discarded) | Security boundary to prevent SSRF and traversal. |
+| `routeTemplate` | Malformed but not hostile (e.g. a bare wildcard `*`) | **Soft drop** (field removed, resource still lands) | Upstream's own SDK registers a wildcard route by default and warns it degrades to auto-generated parameter names — a seller on stock defaults should not silently vanish from discovery. See #65. |
 | `serviceName` | Invalid / Oversized | **Soft drop** (field removed) | Protects against UI bloat and poisoning. |
 | `iconUrl` | Invalid or private IP | **Soft drop** (field removed) | Protects against SSRF tracking pixels and local probes. |
 | `description` | Contains HTML or oversized | **Truncated** (up to 200 chars) | Prevents script injection and limits storage impact. |

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -9,7 +9,7 @@ A key distinction is drawn between controls implemented in this repository ("Our
 | **Sponsored fee budget** | Drain via unmetered settlement; fee-ceiling misconfiguration | `MAX_TX_FEE_STROOPS` ceiling per settlement. Rate limiting to prevent rapid drain. | Ours | A distributed attack can still drain the budget slowly up to the rate limit. |
 | **Settlement integrity** | Replay, double-settlement, redirected recipient, amount tampering | `ExactStellarScheme` validates signature, expiration, absence of sub-invocations, and simulates exact transfer. | Upstream | Upstream bug could allow malformed auth entries to pass. |
 | **Catalog integrity** | Poisoning, traversal, impersonation | Strict route-template validation and sanitization. | Ours | Edge cases in URI parsing might bypass sanitization. |
-| **Caller credentials** | Key leakage, timing attacks, missing rotation | API keys passed via headers; constant-time comparison. | Ours | Stolen API keys grant full access until rotated. |
+| **Caller credentials** | Key leakage, timing attacks, missing rotation | API keys passed via headers; constant-time comparison; the request logger redacts Authorization/cookie/`*_secret` before logging (`src/logger.js`), and request bodies are never logged. | Ours | Stolen API keys grant full access until rotated. |
 | **Availability** | RPC dependency, database dependency, signer exhaustion | Timeouts on RPC/DB calls. (Signer burst handling is a known gap). | Ours | Upstream RPC outages will take down the facilitator. |
 | **Privacy** | Who paid whom for what, and who can see it | Strict data minimisation and retention policy. See [PRIVACY.md](./PRIVACY.md). | Ours | Operator with database access can see history up to the retention limits. |
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,809 @@
+openapi: 3.1.0
+info:
+  title: x402 Facilitator (Stellar)
+  version: 0.0.1
+  description: |
+    This document describes the **transport** — the eight HTTP routes in
+    `src/app.js` — and nothing more. It is deliberately silent about what
+    makes a payment valid or a settlement succeed: verify/settle semantics
+    live in the upstream, Apache-2.0 `@x402/stellar` package
+    (`ExactStellarScheme`), and this repo's house rule is that we do not
+    reimplement or re-describe them. `paymentPayload` and
+    `paymentRequirements` are therefore modeled loosely here — the shape the
+    transport itself depends on (object, `scheme` a string, `network` a
+    string this instance serves) is required; the contents of
+    `paymentPayload.payload` (the transaction XDR and everything inside it)
+    are accepted verbatim and are the scheme's to judge, not this document's.
+
+    Two things about status codes are easy to get wrong when modeling this
+    service and are called out again on the routes themselves: `POST /verify`
+    and `POST /settle` return **200** for a *failed payment* — `isValid:
+    false` / `success: false` are values in a 200 body, not 4xx/5xx. A spec
+    that models payment failure as an HTTP error status describes a different
+    service. 4xx here is reserved for the transport rejecting the request
+    itself (a malformed body, an unserved network, a missing/invalid API
+    key), which is what request-validation.js and the auth middleware in
+    `src/app.js` are responsible for — see #68 and #65's neighboring issue
+    #6 for the rejection-reason taxonomy.
+  license:
+    name: Apache-2.0
+    url: https://github.com/accensa/x402-facilitator-stellar/blob/main/LICENSE
+
+servers:
+  - url: http://localhost:3402
+    description: Local development (testnet, open mode by default)
+
+tags:
+  - name: payments
+    description: The x402 verify/settle surface.
+  - name: discovery
+    description: The Bazaar catalog — automatic and manual resource discovery.
+  - name: meta
+    description: Liveness, capability advertisement, and usage.
+
+security:
+  - ApiKeyAuth: []
+
+paths:
+  /healthz:
+    get:
+      tags: [meta]
+      summary: Liveness check
+      description: |
+        Currently unconditional — it reports process liveness, not
+        readiness (it does not check RPC connectivity or signer health).
+        See #100 for making this reflect actual readiness.
+      security: []
+      responses:
+        '200':
+          description: The process is up.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [ok]
+                properties:
+                  ok:
+                    type: boolean
+                    const: true
+              examples:
+                default:
+                  value: { ok: true }
+
+  /supported:
+    get:
+      tags: [meta]
+      summary: Advertise supported scheme/network pairs and extensions
+      description: |
+        Always open, even when API keys are configured elsewhere: a client
+        must be able to read this before it has any relationship with the
+        service. Passed through from `facilitator.getSupported()` untouched,
+        including the Stellar-specific `extra` block (`areFeesSponsored`).
+      security: []
+      responses:
+        '200':
+          description: Supported kinds, extensions, and signer addresses.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SupportedResponse'
+              examples:
+                default:
+                  value:
+                    kinds:
+                      - x402Version: 2
+                        scheme: exact
+                        network: 'stellar:testnet'
+                        extra: { areFeesSponsored: true }
+                    extensions: ['bazaar']
+                    signers: { 'stellar:*': ['GABC...'] }
+
+  /usage:
+    get:
+      tags: [meta]
+      summary: Per-key usage counters
+      description: |
+        Requires an API key **even in open mode** — usage accounting has no
+        meaning for an anonymous caller, so this route refuses with a
+        distinct reason (`open_mode_usage_forbidden`) rather than silently
+        aggregating across everyone.
+      security:
+        - ApiKeyAuth: []
+      responses:
+        '200':
+          description: Usage counters for the authenticated key.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsageResponse'
+        '401':
+          description: |
+            Missing/invalid key, or open mode (no keys configured at all —
+            `open_mode_usage_forbidden`).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthError'
+
+  /verify:
+    post:
+      tags: [payments]
+      summary: Verify a payment without settling it
+      description: |
+        **Returns HTTP 200 even when the payment is invalid.**
+        `isValid: false` with a non-null `invalidReason` is a normal,
+        successful response from this endpoint's point of view — the
+        transport did its job by reporting the outcome. 4xx here means the
+        transport itself rejected the *request* before reaching the scheme
+        (malformed body, unserved network) or that a rate limit was hit; it
+        never means "payment invalid".
+      security:
+        - ApiKeyAuth: []
+        - {}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VerifyRequest'
+      responses:
+        '200':
+          description: |
+            Verification result — check `isValid`, not the status code.
+          headers:
+            EXTENSION-RESPONSES:
+              $ref: '#/components/headers/ExtensionResponses'
+            RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VerifyResponse'
+              examples:
+                valid:
+                  value: { isValid: true }
+                invalid:
+                  value:
+                    isValid: false
+                    invalidReason: invalid_exact_stellar_payload_authorization_not_signed
+                    invalidMessage: payer signature missing
+                    payer: GPAYER...
+        '400':
+          description: |
+            The transport rejected the request body itself — see
+            request-validation.js. Reason is one of `invalid_request` (body
+            shape) or `unsupported_network` (well-formed body naming a
+            network this instance does not serve).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VerifyResponse'
+              examples:
+                malformed:
+                  value:
+                    isValid: false
+                    invalidReason: invalid_request
+                    invalidMessage: 'paymentPayload must be an object'
+                unsupportedNetwork:
+                  value:
+                    isValid: false
+                    invalidReason: unsupported_network
+                    invalidMessage: 'network "stellar:pubnet" is not served by this instance (serves: stellar:testnet)'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+
+  /settle:
+    post:
+      tags: [payments]
+      summary: Verify and settle a payment on-chain
+      description: |
+        **Returns HTTP 200 even when settlement fails.** `success: false`
+        with a non-null `errorReason` is a normal response; `transaction`
+        and `network` are always present, even on failure, so a client can
+        attribute the failure without correlating out of band. As with
+        `/verify`, 4xx here is the transport rejecting the request itself,
+        never a settlement outcome.
+      security:
+        - ApiKeyAuth: []
+        - {}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SettleRequest'
+      responses:
+        '200':
+          description: |
+            Settlement result — check `success`, not the status code.
+          headers:
+            EXTENSION-RESPONSES:
+              $ref: '#/components/headers/ExtensionResponses'
+            RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SettleResponse'
+              examples:
+                success:
+                  value:
+                    success: true
+                    transaction: abc123...
+                    network: 'stellar:testnet'
+                failure:
+                  value:
+                    success: false
+                    errorReason: facilitator_error
+                    errorMessage: rpc unreachable
+                    transaction: ''
+                    network: 'stellar:testnet'
+        '400':
+          description: |
+            The transport rejected the request body itself. Note the
+            response shape differs from `/verify`'s 400: `/settle` always
+            carries `transaction` and `network`, even in a transport-level
+            rejection.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SettleResponse'
+              examples:
+                malformed:
+                  value:
+                    success: false
+                    errorReason: invalid_request
+                    errorMessage: 'paymentPayload must be an object'
+                    transaction: ''
+                    network: null
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+
+  /discovery/resources:
+    post:
+      tags: [discovery]
+      summary: Manually register a resource in the Bazaar catalog
+      description: |
+        The secondary registration path. The primary one is automatic —
+        cataloging off `/verify`/`/settle` for any payment whose payload
+        carries the discovery extension, which never blocks or fails the
+        payment itself (see `docs/BAZAAR.md`). This route is for a seller
+        registering something after the fact, without a fresh payment.
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VerifyRequest'
+      responses:
+        '200':
+          description: Registered (or soft-dropped fields noted).
+          headers:
+            RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [ok, resource, softDrops]
+                properties:
+                  ok:
+                    type: boolean
+                    const: true
+                  resource:
+                    $ref: '#/components/schemas/CatalogResource'
+                  softDrops:
+                    type: array
+                    items:
+                      type: string
+                    description: |
+                      Fields dropped for quality reasons rather than the
+                      whole resource — e.g. `routeTemplate` for a wildcard
+                      route (#65), `serviceName`, `iconUrl`,
+                      `description_truncated`, `tags_filtered`.
+        '400':
+          description: |
+            Hard drop — the resource was rejected outright (invalid
+            discovery extension, or a hostile `routeTemplate`: traversal or
+            protocol smuggling). See `docs/BAZAAR.md` for the full policy
+            table.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [error, reason]
+                properties:
+                  error:
+                    type: string
+                  reason:
+                    type: string
+                    enum:
+                      - invalid_request
+                      - missing_or_invalid_discovery_extension
+                      - invalid_extension_schema
+                      - invalid_routeTemplate
+                      - catalog_error
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+
+    get:
+      tags: [discovery]
+      summary: List cataloged resources
+      security: []
+      parameters:
+        - $ref: '#/components/parameters/FilterType'
+        - $ref: '#/components/parameters/FilterPayTo'
+        - $ref: '#/components/parameters/FilterScheme'
+        - $ref: '#/components/parameters/FilterNetwork'
+        - $ref: '#/components/parameters/FilterExtensions'
+        - name: limit
+          in: query
+          description: Clamped to [1, 100]; defaults to 20.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+      responses:
+        '200':
+          description: A page of cataloged resources, newest first.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [x402Version, items, pagination]
+                properties:
+                  x402Version:
+                    type: integer
+                    const: 2
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/CatalogResource'
+                  pagination:
+                    type: object
+                    required: [limit, offset, total]
+                    properties:
+                      limit:
+                        type: integer
+                      offset:
+                        type: integer
+                      total:
+                        type: integer
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /discovery/search:
+    get:
+      tags: [discovery]
+      summary: Lexical (and, if configured, hybrid semantic) search over the catalog
+      security: []
+      parameters:
+        - name: query
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Required — a 400 is returned if omitted.
+        - $ref: '#/components/parameters/FilterType'
+        - $ref: '#/components/parameters/FilterPayTo'
+        - $ref: '#/components/parameters/FilterScheme'
+        - $ref: '#/components/parameters/FilterNetwork'
+        - $ref: '#/components/parameters/FilterExtensions'
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+        - name: cursor
+          in: query
+          description: Opaque, base64-encoded. Advisory, like `limit` — the server may return fewer results than asked.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Ranked search results.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [x402Version, resources, partialResults, pagination]
+                properties:
+                  x402Version:
+                    type: integer
+                    const: 2
+                  resources:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/CatalogResource'
+                  partialResults:
+                    type: boolean
+                    description: |
+                      True when the backend is degraded — e.g. no embeddings
+                      provider configured, or a resource not yet re-embedded.
+                      Currently only meaningful for the semantic leg of
+                      search; the memory-backed spike has no partitioned
+                      backend of its own to degrade.
+                  pagination:
+                    type: object
+                    required: [limit, cursor]
+                    properties:
+                      limit:
+                        type: integer
+                      cursor:
+                        type: [string, 'null']
+                        description: Opaque cursor for the next page, or null if there is none.
+        '400':
+          description: '`query` was omitted.'
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [error, reason]
+                properties:
+                  error:
+                    type: string
+                    const: invalid_request
+                  reason:
+                    type: string
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: Authorization
+      description: |
+        Two forms are accepted: `Authorization: Bearer <secret>` or
+        `Authorization: <secret>` (no scheme prefix). Verified with a
+        constant-time comparison against the SHA-256 digests resolved at
+        boot from `FACILITATOR_API_KEYS`. If no keys are configured at all,
+        the facilitator runs in **open mode** and every route except
+        `/usage` is unauthenticated — correct for a free testnet instance,
+        strongly discouraged on pubnet. See `docs/AUTHENTICATION.md`.
+
+        `/usage` requires a key even in open mode (`open_mode_usage_forbidden`
+        otherwise). `/healthz`, `/supported`, and both `GET /discovery/*`
+        routes are always open regardless of mode.
+
+  headers:
+    ExtensionResponses:
+      description: |
+        Base64-encoded JSON, present on `/verify` and `/settle` responses
+        whenever the payment carried a discovery extension. Decodes to
+        `{"bazaar": {"status": ..., "code": ..., "reason"?: ...}}` — status
+        is one of `landed`, `partially landed`, `rejected`, or
+        `"not attempted"` (payload carried no/invalid discovery extension).
+        See #146 and `docs/BAZAAR.md`.
+      schema:
+        type: string
+        format: byte
+    RateLimitLimit:
+      description: The caller's limit for the current window.
+      schema:
+        type: integer
+    RateLimitRemaining:
+      description: Requests remaining in the current window.
+      schema:
+        type: integer
+    RateLimitReset:
+      description: Unix timestamp (seconds) when the current window resets.
+      schema:
+        type: integer
+    RetryAfter:
+      description: Seconds to wait before retrying. Present only on 429 responses.
+      schema:
+        type: integer
+
+  parameters:
+    FilterType:
+      name: type
+      in: query
+      schema:
+        type: string
+        enum: [http, mcp]
+    FilterPayTo:
+      name: payTo
+      in: query
+      schema:
+        type: string
+    FilterScheme:
+      name: scheme
+      in: query
+      schema:
+        type: string
+    FilterNetwork:
+      name: network
+      in: query
+      schema:
+        type: string
+    FilterExtensions:
+      name: extensions
+      in: query
+      description: Comma-separated, or repeated. Every named extension must be present on a matching resource.
+      style: form
+      explode: false
+      schema:
+        type: array
+        items:
+          type: string
+
+  responses:
+    Unauthorized:
+      description: |
+        Missing, malformed, or unrecognized API key. Reason is one of
+        `missing_auth_header`, `malformed_auth_header`, or `invalid_api_key`.
+        Not returned at all when the instance is running in open mode.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AuthError'
+    RateLimited:
+      description: The caller's rate limit was exceeded for this operation.
+      headers:
+        RateLimit-Limit:
+          $ref: '#/components/headers/RateLimitLimit'
+        RateLimit-Remaining:
+          $ref: '#/components/headers/RateLimitRemaining'
+        RateLimit-Reset:
+          $ref: '#/components/headers/RateLimitReset'
+        Retry-After:
+          $ref: '#/components/headers/RetryAfter'
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [error, reason]
+            properties:
+              error:
+                type: string
+                const: rate_limited
+              reason:
+                type: string
+                description: |
+                  Which limit was hit (e.g. `verify_rpm`, `settle_rpd`,
+                  `fee_spd`, `catalog_rpm`). The open set is not finalized —
+                  see #6.
+    InternalError:
+      description: An unexpected server-side failure (e.g. a catalog query error).
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [error]
+            properties:
+              error:
+                type: string
+              message:
+                type: string
+
+  schemas:
+    AuthError:
+      type: object
+      required: [error, reason]
+      properties:
+        error:
+          type: string
+          const: unauthorized
+        reason:
+          type: string
+          enum:
+            - missing_auth_header
+            - malformed_auth_header
+            - invalid_api_key
+            - open_mode_usage_forbidden
+
+    SupportedResponse:
+      type: object
+      required: [kinds, extensions, signers]
+      properties:
+        kinds:
+          type: array
+          items:
+            type: object
+            required: [x402Version, scheme, network]
+            properties:
+              x402Version:
+                type: integer
+              scheme:
+                type: string
+              network:
+                type: string
+              extra:
+                type: object
+                description: Scheme-specific capabilities. For Stellar's `exact` scheme, includes `areFeesSponsored`.
+                additionalProperties: true
+        extensions:
+          type: array
+          items:
+            type: string
+        signers:
+          type: object
+          description: Map of network pattern (e.g. `stellar:*`) to signer addresses.
+          additionalProperties:
+            type: array
+            items:
+              type: string
+
+    UsageResponse:
+      type: object
+      description: |
+        Counters for the current window per limit family, keyed by name
+        (`verify_rpm`, `settle_rpm`, `settle_rph`, `settle_rpd`, `fee_spd`).
+        The exact key set tracks `src/rate-limit.js`'s configured limits.
+      additionalProperties:
+        type: integer
+
+    PaymentPayload:
+      type: object
+      description: |
+        The spec's payload envelope, accepted verbatim. `payload` (and
+        everything inside it, including `payload.transaction`) is passed
+        through unwrapped and un-renamed to the upstream scheme — this
+        transport does not inspect it. Only presence-and-object-ness is
+        required here.
+      required: [payload]
+      properties:
+        x402Version:
+          type: integer
+        scheme:
+          type: string
+        network:
+          type: string
+        resource:
+          type: object
+          additionalProperties: true
+        extensions:
+          type: object
+          additionalProperties: true
+        payload:
+          type: object
+          description: 'Scheme-specific. For `exact` on Stellar: `{transaction: <XDR>}`. Not validated by the transport.'
+          additionalProperties: true
+      additionalProperties: true
+
+    PaymentRequirements:
+      type: object
+      description: |
+        Only `scheme` and `network` are checked by the transport itself
+        (both required strings; `network` must be one this instance serves —
+        see request-validation.js and #68). Everything else is passed
+        through to the scheme unvalidated.
+      required: [scheme, network]
+      properties:
+        scheme:
+          type: string
+        network:
+          type: string
+          description: A CAIP-2 identifier this instance serves, e.g. `stellar:testnet` or `stellar:pubnet`.
+        asset:
+          type: string
+        maxAmountRequired:
+          type: string
+        payTo:
+          type: string
+        maxTimeoutSeconds:
+          type: integer
+        extra:
+          type: object
+          additionalProperties: true
+      additionalProperties: true
+
+    VerifyRequest:
+      type: object
+      required: [paymentPayload, paymentRequirements]
+      properties:
+        paymentPayload:
+          $ref: '#/components/schemas/PaymentPayload'
+        paymentRequirements:
+          $ref: '#/components/schemas/PaymentRequirements'
+
+    SettleRequest:
+      $ref: '#/components/schemas/VerifyRequest'
+
+    VerifyResponse:
+      type: object
+      required: [isValid]
+      properties:
+        isValid:
+          type: boolean
+        invalidReason:
+          type: [string, 'null']
+          description: |
+            Non-null whenever `isValid` is false — a null reason anywhere is
+            an acceptance failure for this service. Transport-level values
+            are `invalid_request` and `unsupported_network`
+            (request-validation.js) and `facilitator_error` (an exception
+            above the scheme). Everything else is the scheme's own
+            vocabulary (e.g. `invalid_exact_stellar_payload_*`) and is
+            passed through unmodified — see #6 for the open taxonomy.
+        invalidMessage:
+          type: string
+        payer:
+          type: string
+      additionalProperties: true
+
+    SettleResponse:
+      type: object
+      required: [success, transaction, network]
+      properties:
+        success:
+          type: boolean
+        errorReason:
+          type: [string, 'null']
+        errorMessage:
+          type: string
+        transaction:
+          type: string
+          description: Empty string, not omitted, when settlement never reached the chain.
+        network:
+          type: [string, 'null']
+        payer:
+          type: string
+      additionalProperties: true
+
+    CatalogResource:
+      type: object
+      description: |
+        See `docs/BAZAAR.md` for the identity model (HTTP resources keyed by
+        `url`; MCP resources keyed by `(url, toolName)`).
+      required: [type, url, scheme, network]
+      properties:
+        type:
+          type: string
+          enum: [http, mcp]
+        url:
+          type: string
+        toolName:
+          type: string
+          description: Present only when `type` is `mcp`.
+        serviceName:
+          type: string
+        description:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        iconUrl:
+          type: string
+        scheme:
+          type: string
+        network:
+          type: string
+        payTo:
+          type: string
+        extensions:
+          type: object
+          additionalProperties: true
+      additionalProperties: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,15 @@
         "undici": "^7.29.0"
       },
       "bin": {
-        "validate-discovery": "src/sdk/cli.js"
+        "validate-discovery": "src/sdk/cli.js",
+        "x402-mcp": "src/mcp/cli.js"
       },
       "devDependencies": {
+        "@apidevtools/swagger-parser": "^12.1.0",
         "@x402/express": "^2.21.0",
+        "ajv": "^8.20.0",
         "eslint": "^9.39.5",
+        "js-yaml": "^5.3.0",
         "prettier": "^3.9.6"
       },
       "engines": {
@@ -33,6 +37,81 @@
       "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.0.1.tgz",
+      "integrity": "sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-12.1.0.tgz",
+      "integrity": "sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "14.0.1",
+        "@apidevtools/openapi-schemas": "^2.1.0",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "call-me-maybe": "^1.0.2"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.10.1",
@@ -156,6 +235,29 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
@@ -639,6 +741,21 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -838,6 +955,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -1885,9 +2009,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.3.0.tgz",
+      "integrity": "sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==",
       "dev": true,
       "funding": [
         {
@@ -1904,7 +2028,7 @@
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/json-buffer": {
@@ -2101,6 +2225,14 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/optionator": {
       "version": "0.9.4",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,11 @@
     "undici": "^7.29.0"
   },
   "devDependencies": {
+    "@apidevtools/swagger-parser": "^12.1.0",
     "@x402/express": "^2.21.0",
+    "ajv": "^8.20.0",
     "eslint": "^9.39.5",
+    "js-yaml": "^5.3.0",
     "prettier": "^3.9.6"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -204,7 +204,10 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
       }
       return null;
     }
-    return { paymentPayload: result.paymentPayload, paymentRequirements: result.paymentRequirements };
+    return {
+      paymentPayload: result.paymentPayload,
+      paymentRequirements: result.paymentRequirements,
+    };
   }
 
   app.get('/healthz', (_req, res) => res.json({ ok: true }));

--- a/src/app.js
+++ b/src/app.js
@@ -22,6 +22,8 @@
 import crypto from 'node:crypto';
 import express from 'express';
 import { validateForCatalog } from './catalog/validation.js';
+import { validatePaymentBody } from './request-validation.js';
+import { requestLogger } from './logger.js';
 
 /**
  * Builds the Express app.
@@ -44,6 +46,10 @@ import { validateForCatalog } from './catalog/validation.js';
 export function createApp(config, facilitator, rateLimiter, catalog) {
   const app = express();
   app.use(express.json({ limit: '256kb' }));
+  // Redacts Authorization/cookie/*_secret before anything hits the log — see
+  // src/logger.js. Never logs the body: paymentPayload/paymentRequirements
+  // are validated, not logged, transport-wide.
+  app.use(requestLogger());
 
   /**
    * Catalogs a resource declared in a payment, off the hot path.
@@ -172,18 +178,33 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
    * Both /verify and /settle take {paymentPayload, paymentRequirements}.
    * Returning a non-null reason on a malformed body matters as much as on a
    * failed verification — a null reason anywhere is an acceptance failure.
+   *
+   * Validation itself lives in request-validation.js: this only shapes the
+   * rejection into the response the calling route would otherwise have sent,
+   * since /verify and /settle disagree on what a failure body looks like
+   * (isValid/invalidReason vs. success/errorReason/transaction/network).
    */
-  function readPaymentBody(req, res) {
-    const { paymentPayload, paymentRequirements } = req.body ?? {};
-    if (!paymentPayload || !paymentRequirements) {
-      res.status(400).json({
-        isValid: false,
-        invalidReason: 'invalid_request',
-        invalidMessage: 'body must contain paymentPayload and paymentRequirements',
-      });
+  function readPaymentBody(req, res, route = 'verify') {
+    const result = validatePaymentBody(req.body, config);
+    if (!result.valid) {
+      if (route === 'settle') {
+        res.status(400).json({
+          success: false,
+          errorReason: result.reason,
+          errorMessage: result.message,
+          transaction: '',
+          network: req.body?.paymentRequirements?.network,
+        });
+      } else {
+        res.status(400).json({
+          isValid: false,
+          invalidReason: result.reason,
+          invalidMessage: result.message,
+        });
+      }
       return null;
     }
-    return { paymentPayload, paymentRequirements };
+    return { paymentPayload: result.paymentPayload, paymentRequirements: result.paymentRequirements };
   }
 
   app.get('/healthz', (_req, res) => res.json({ ok: true }));
@@ -239,7 +260,7 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
     const check = rateLimiter.checkSettle(req);
     if (!check.allowed) return handleRateLimit(res, check);
 
-    const body = readPaymentBody(req, res);
+    const body = readPaymentBody(req, res, 'settle');
     if (!body) return;
     try {
       const result = await facilitator.settle(body.paymentPayload, body.paymentRequirements);

--- a/src/catalog/validation.js
+++ b/src/catalog/validation.js
@@ -7,6 +7,24 @@ import {
   validateDiscoveryExtension,
 } from '@x402/extensions';
 
+/**
+ * Distinguishes a hostile routeTemplate (path traversal, protocol smuggling,
+ * unparseable percent-encoding) from one that is merely low-quality, such as
+ * the wildcard ("*") pattern upstream's own SDK registers by default. Both
+ * fail isValidRouteTemplate() identically, but only the former is a security
+ * boundary worth discarding the whole resource over — see #65.
+ */
+function isHostileRouteTemplate(value) {
+  if (typeof value !== 'string' || value.length === 0) return false;
+  let decoded;
+  try {
+    decoded = decodeURIComponent(value);
+  } catch {
+    return true;
+  }
+  return decoded.includes('..') || decoded.includes('://');
+}
+
 export function validateForCatalog(paymentPayload, paymentRequirements) {
   const result = {
     hardDrop: false,
@@ -36,13 +54,28 @@ export function validateForCatalog(paymentPayload, paymentRequirements) {
   }
 
   // 2. routeTemplate validation
+  //
+  // Path traversal and protocol smuggling stay a hard drop — that is a real
+  // security boundary (SSRF / traversal), not a quality issue. But a wildcard
+  // ("*") route is low-quality discovery metadata, not a malformed or hostile
+  // one: upstream's own SDK registers it by default and warns that it
+  // degrades to auto-generated parameter names (var1, var2, ...) rather than
+  // refusing to emit it. Hard-dropping the whole resource over that punishes
+  // a seller for the stock SDK's defaults, so this is a soft drop instead —
+  // the resource still lands, without the routeTemplate (extractDiscoveryInfo
+  // above already leaves it undefined and falls back to the payment's own
+  // resource URL), and the quality issue is surfaced via
+  // softDrops/EXTENSION-RESPONSES so the seller can improve it. See #23 for
+  // the soft-drop policy this stays consistent with, and #65 for the
+  // decision.
   const rawTemplate = rawBazaar?.routeTemplate;
-  if (rawTemplate !== undefined) {
-    if (!isValidRouteTemplate(rawTemplate)) {
+  if (rawTemplate !== undefined && !isValidRouteTemplate(rawTemplate)) {
+    if (isHostileRouteTemplate(rawTemplate)) {
       result.hardDrop = true;
       result.reason = 'invalid_routeTemplate';
       return result;
     }
+    result.softDrops.push('routeTemplate');
   }
 
   // 3. serviceName validation

--- a/src/logger.js
+++ b/src/logger.js
@@ -17,7 +17,12 @@
  * `redact` option.
  */
 
-const REDACTED_KEY_NAMES = new Set(['authorization', 'cookie', 'set-cookie', 'proxy-authorization']);
+const REDACTED_KEY_NAMES = new Set([
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'proxy-authorization',
+]);
 
 function isSensitiveKey(key) {
   const lower = key.toLowerCase();

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,70 @@
+/**
+ * Redaction for anything the transport logs.
+ *
+ * Nothing here logs a full request body today, and it should stay that way —
+ * paymentPayload can carry transaction XDR and paymentRequirements can carry
+ * a payer's own metadata. But request *headers* are exactly the kind of
+ * thing an incident-response "log everything at the edge" instinct reaches
+ * for, and Authorization is exactly the header that would leak an API key if
+ * it ever gets there unredacted. This module is the single choke point for
+ * that: redact() before you log, not per call site.
+ *
+ * Hand-written rather than pulling in pino: the repo is deliberate about its
+ * dependency surface (see #68's reasoning and the licence-check job in CI),
+ * and a redaction rulebook of a handful of key names doesn't need a logging
+ * framework — swap console.* for pino later if structured/leveled logging
+ * becomes a real need, and reuse REDACTED_KEY_NAMES / redact() as its
+ * `redact` option.
+ */
+
+const REDACTED_KEY_NAMES = new Set(['authorization', 'cookie', 'set-cookie', 'proxy-authorization']);
+
+function isSensitiveKey(key) {
+  const lower = key.toLowerCase();
+  return REDACTED_KEY_NAMES.has(lower) || lower.endsWith('_secret') || lower.endsWith('-secret');
+}
+
+/**
+ * Deep-clones a plain object, masking sensitive keys as '***' and leaving
+ * everything else untouched. Safe to call on headers, query params, or any
+ * plain object before it reaches console.*.
+ *
+ * @param {unknown} value
+ * @returns {unknown}
+ */
+export function redact(value) {
+  if (Array.isArray(value)) {
+    return value.map(redact);
+  }
+  if (value && typeof value === 'object') {
+    const out = {};
+    for (const [key, val] of Object.entries(value)) {
+      out[key] = isSensitiveKey(key) ? '***' : redact(val);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Express middleware: logs one line per request with redacted headers, after
+ * the response finishes. Never touches req.body — see the module comment.
+ */
+export function requestLogger(log = msg => console.log(msg)) {
+  return (req, res, next) => {
+    const startedAt = Date.now();
+    res.on('finish', () => {
+      const durationMs = Date.now() - startedAt;
+      log(
+        JSON.stringify({
+          method: req.method,
+          path: req.path,
+          status: res.statusCode,
+          durationMs,
+          headers: redact(req.headers),
+        }),
+      );
+    });
+    next();
+  };
+}

--- a/src/request-validation.js
+++ b/src/request-validation.js
@@ -1,0 +1,80 @@
+/**
+ * Transport-layer validation for the /verify and /settle request bodies.
+ *
+ * The house rule for this repo is that verify/settle semantics live upstream
+ * in @x402/stellar — we do not reimplement them. This module validates only
+ * the structure the transport itself depends on before handing a body to the
+ * scheme: that paymentPayload and paymentRequirements are present objects,
+ * and that the fields the transport branches on (network, scheme) are the
+ * type and value it expects.
+ *
+ * It deliberately does NOT validate paymentPayload.payload — the transaction
+ * XDR, its signatures, operations, or amounts. That is the scheme's contract,
+ * not the transport's, and a check here strict enough to reject a payload
+ * the scheme would have accepted is a conformance failure, not a hardening
+ * win. When in doubt, this lets it through and lets the scheme judge it.
+ *
+ * Hand-written rather than zod/ajv: this is five fields, and the repo is
+ * deliberate about its dependency surface (see the licence-check job in CI).
+ * A dependency is proportionate to a schema with nesting, refinement, unions,
+ * or codegen needs; this has none of those. See #68.
+ */
+
+function isPlainObject(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function invalid(field, reason, message) {
+  return { valid: false, field, reason, message };
+}
+
+/**
+ * @param {unknown} body - the parsed JSON request body (req.body)
+ * @param {{networks: string[]}} config - resolved config; networks is the
+ *   allowlist of CAIP-2 network identifiers this instance serves
+ * @returns {{valid: true, paymentPayload: object, paymentRequirements: object}
+ *   | {valid: false, field: string, reason: string, message: string}}
+ */
+export function validatePaymentBody(body, config) {
+  const { paymentPayload, paymentRequirements } = body ?? {};
+
+  if (!isPlainObject(paymentPayload)) {
+    return invalid('paymentPayload', 'invalid_request', 'paymentPayload must be an object');
+  }
+  if (!isPlainObject(paymentRequirements)) {
+    return invalid(
+      'paymentRequirements',
+      'invalid_request',
+      'paymentRequirements must be an object',
+    );
+  }
+  if (typeof paymentRequirements.scheme !== 'string' || paymentRequirements.scheme === '') {
+    return invalid(
+      'paymentRequirements.scheme',
+      'invalid_request',
+      'paymentRequirements.scheme must be a non-empty string',
+    );
+  }
+  if (typeof paymentRequirements.network !== 'string' || paymentRequirements.network === '') {
+    return invalid(
+      'paymentRequirements.network',
+      'invalid_request',
+      'paymentRequirements.network must be a non-empty string',
+    );
+  }
+  // A distinct code from invalid_request: the body is well-formed, it just
+  // names a network this instance does not serve. A client should be able to
+  // branch on that rather than parse invalidMessage prose. Rejecting it here,
+  // before the scheme sees it, matters because config.js keeps testnet and
+  // pubnet signers rigidly separate — the failure mode of getting network
+  // handling wrong on a pubnet instance is losing real money.
+  if (!config.networks.includes(paymentRequirements.network)) {
+    return invalid(
+      'paymentRequirements.network',
+      'unsupported_network',
+      `network "${paymentRequirements.network}" is not served by this instance (serves: ${config.networks.join(', ')})`,
+    );
+  }
+
+  return { valid: true, paymentPayload, paymentRequirements };
+}

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -86,17 +86,91 @@ describe('malformed bodies always carry a reason', () => {
       ['paymentRequirements only', { paymentRequirements: VALID_BODY.paymentRequirements }],
       ['a null payload', { paymentPayload: null, paymentRequirements: {} }],
     ]) {
-      test(`POST ${route} with ${label} → 400 and a non-null invalidReason`, async () => {
+      test(`POST ${route} with ${label} → 400 and a non-null reason`, async () => {
         const res = await app.post(route, body);
         assert.equal(res.status, 400);
         const json = await res.json();
-        assert.equal(json.isValid, false);
         // A null reason anywhere is an acceptance failure — an agent has to
-        // branch on a code rather than parse prose.
-        assert.equal(json.invalidReason, 'invalid_request');
-        assert.ok(json.invalidMessage, 'invalidMessage must not be empty');
+        // branch on a code rather than parse prose. /verify and /settle
+        // disagree on the rest of the shape, so only the reason vocabulary
+        // is shared.
+        if (route === '/settle') {
+          assert.equal(json.success, false);
+          assert.equal(json.errorReason, 'invalid_request');
+          assert.ok(json.errorMessage, 'errorMessage must not be empty');
+          assert.equal(json.transaction, '');
+        } else {
+          assert.equal(json.isValid, false);
+          assert.equal(json.invalidReason, 'invalid_request');
+          assert.ok(json.invalidMessage, 'invalidMessage must not be empty');
+        }
       });
     }
+  }
+
+  test('POST /settle with a malformed body keeps the settle response shape (#68)', async () => {
+    // /verify and /settle disagree on what a rejection looks like: settle
+    // still needs `transaction` and `network` even on a transport-level
+    // rejection, so a client can attribute the failure without correlating
+    // out of band.
+    const res = await app.post('/settle', { paymentPayload: VALID_BODY.paymentPayload });
+    assert.equal(res.status, 400);
+    const json = await res.json();
+    assert.equal(json.success, false);
+    assert.equal(json.errorReason, 'invalid_request');
+    assert.ok(json.errorMessage);
+    assert.equal(json.transaction, '');
+    // No paymentRequirements was sent at all, so there is no network to
+    // report — matching the existing facilitator_error catch path's
+    // convention of passing through whatever the body did/didn't carry.
+    assert.equal(json.network, undefined);
+  });
+
+  for (const route of ['/verify', '/settle']) {
+    test(`POST ${route} rejects a non-object paymentPayload (#68)`, async () => {
+      const res = await app.post(route, {
+        paymentPayload: 'not-an-object',
+        paymentRequirements: VALID_BODY.paymentRequirements,
+      });
+      assert.equal(res.status, 400);
+      const json = await res.json();
+      const reason = route === '/settle' ? json.errorReason : json.invalidReason;
+      const message = route === '/settle' ? json.errorMessage : json.invalidMessage;
+      assert.equal(reason, 'invalid_request');
+      assert.match(message, /paymentPayload/);
+    });
+
+    test(`POST ${route} rejects a network this instance does not serve, by name (#68)`, async () => {
+      const res = await app.post(route, {
+        paymentPayload: VALID_BODY.paymentPayload,
+        paymentRequirements: { ...VALID_BODY.paymentRequirements, network: 'stellar:pubnet' },
+      });
+      assert.equal(res.status, 400);
+      const json = await res.json();
+      const reason = route === '/settle' ? json.errorReason : json.invalidReason;
+      // Distinct from invalid_request so a client can branch on it.
+      assert.equal(reason, 'unsupported_network');
+    });
+
+    test(`POST ${route} passes payload.payload through un-inspected (#68)`, async () => {
+      // An unrecognised field inside payload must not cause rejection — that
+      // content is the scheme's to judge, not the transport's.
+      const facilitator = stubFacilitator();
+      const app2 = await serve({ facilitator });
+      try {
+        const body = {
+          paymentPayload: {
+            ...VALID_BODY.paymentPayload,
+            payload: { transaction: 'AAAAAgAAAA...', anUnrecognisedField: { nested: true } },
+          },
+          paymentRequirements: VALID_BODY.paymentRequirements,
+        };
+        const res = await app2.post(route, body);
+        assert.equal(res.status, 200);
+      } finally {
+        await app2.close();
+      }
+    });
   }
 });
 

--- a/test/catalog.validation.test.js
+++ b/test/catalog.validation.test.js
@@ -40,6 +40,28 @@ test('Hostile Inputs Validation', async t => {
     assert.equal(res.reason, 'invalid_routeTemplate');
   });
 
+  await t.test('Soft drops a wildcard routeTemplate instead of dropping the resource (#65)', () => {
+    // This is what upstream's own SDK registers by default for a wildcard
+    // route, and it warns about the degraded metadata rather than refusing
+    // to send it. It must not vanish from discovery.
+    const payload = {
+      x402Version: 2,
+      resource: { url: 'http://example.com/weather/paris' },
+      extensions: {
+        bazaar: {
+          info: { input: { type: 'http', method: 'GET' }, scheme: 'exact' },
+          schema: { type: 'object' },
+          routeTemplate: '*',
+        },
+      },
+    };
+    const res = validateForCatalog(payload, baseReq);
+    assert.equal(res.hardDrop, false);
+    assert.ok(res.softDrops.includes('routeTemplate'));
+    assert.ok(res.resource);
+    assert.equal(res.resource.url, 'http://example.com/weather/paris');
+  });
+
   await t.test('Soft drops script in description and truncates', () => {
     const payload = {
       x402Version: 2,

--- a/test/helpers/app.js
+++ b/test/helpers/app.js
@@ -15,13 +15,14 @@ import { createApp } from '../../src/app.js';
  * API keys are given as `id:secret` and hashed here the way resolveConfig does,
  * so a test states the secret it will present rather than a digest.
  */
-export function testConfig({ apiKeys = [] } = {}) {
+export function testConfig({ apiKeys = [], networks = ['stellar:testnet'] } = {}) {
   return {
     apiKeys: apiKeys.map(entry => {
       const idx = entry.indexOf(':');
       const [id, secret] = idx > 0 ? [entry.slice(0, idx), entry.slice(idx + 1)] : ['key_0', entry];
       return { id, hash: createHash('sha256').update(secret).digest() };
     }),
+    networks,
   };
 }
 

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1,0 +1,70 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { redact, requestLogger } from '../src/logger.js';
+
+test('masks Authorization as ***', () => {
+  const out = redact({ authorization: 'Bearer s3cret-key', 'content-type': 'application/json' });
+  assert.equal(out.authorization, '***');
+  assert.equal(out['content-type'], 'application/json');
+});
+
+test('is case-insensitive on header names', () => {
+  const out = redact({ Authorization: 'Bearer s3cret-key' });
+  assert.equal(out.Authorization, '***');
+});
+
+test('masks cookie and set-cookie', () => {
+  const out = redact({ cookie: 'session=abc', 'set-cookie': 'session=abc; HttpOnly' });
+  assert.equal(out.cookie, '***');
+  assert.equal(out['set-cookie'], '***');
+});
+
+test('masks any key ending in _secret, at any depth', () => {
+  const out = redact({
+    facilitator_secret: 'Sxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+    nested: { api_secret: 'abc', keep: 'me' },
+  });
+  assert.equal(out.facilitator_secret, '***');
+  assert.equal(out.nested.api_secret, '***');
+  assert.equal(out.nested.keep, 'me');
+});
+
+test('leaves unrelated fields untouched', () => {
+  const out = redact({ method: 'GET', path: '/verify', count: 3, ok: true, none: null });
+  assert.deepEqual(out, { method: 'GET', path: '/verify', count: 3, ok: true, none: null });
+});
+
+test('does not mutate the input', () => {
+  const input = { authorization: 'Bearer x' };
+  redact(input);
+  assert.equal(input.authorization, 'Bearer x');
+});
+
+test('requestLogger logs redacted headers and never the body, after the response finishes', async () => {
+  const lines = [];
+  const middleware = requestLogger(msg => lines.push(msg));
+
+  let finishCallback;
+  const req = { method: 'POST', path: '/verify', headers: { authorization: 'Bearer s3cret' } };
+  const res = {
+    statusCode: 200,
+    on: (event, cb) => {
+      if (event === 'finish') finishCallback = cb;
+    },
+  };
+
+  await new Promise(resolve => {
+    middleware(req, res, resolve);
+  });
+
+  assert.equal(lines.length, 0, 'must not log before the response finishes');
+  finishCallback();
+
+  assert.equal(lines.length, 1);
+  const logged = JSON.parse(lines[0]);
+  assert.equal(logged.method, 'POST');
+  assert.equal(logged.path, '/verify');
+  assert.equal(logged.status, 200);
+  assert.equal(logged.headers.authorization, '***');
+  assert.equal('body' in logged, false);
+});

--- a/test/openapi.test.js
+++ b/test/openapi.test.js
@@ -1,0 +1,89 @@
+/**
+ * Keeps openapi.yaml honest: it must be a valid OpenAPI 3.1 document, and at
+ * least one live response from the real app must match what it describes. A
+ * spec that drifts silently is worse than no spec — see #71.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { load as loadYaml } from 'js-yaml';
+import SwaggerParser from '@apidevtools/swagger-parser';
+import Ajv from 'ajv';
+import { serve, VALID_BODY } from './helpers/app.js';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const SPEC_PATH = join(ROOT, 'openapi.yaml');
+
+test('openapi.yaml validates against the OpenAPI 3.1 schema', async () => {
+  // SwaggerParser.validate resolves every $ref and checks the document
+  // against the OpenAPI meta-schema; it throws on the first problem instead
+  // of returning a boolean, so a passing call is the assertion.
+  await SwaggerParser.validate(SPEC_PATH);
+});
+
+test('every path in the spec is a route the app actually serves', async () => {
+  const doc = loadYaml(readFileSync(SPEC_PATH, 'utf8'));
+  const specPaths = Object.keys(doc.paths).sort();
+  assert.deepEqual(specPaths, [
+    '/discovery/resources',
+    '/discovery/search',
+    '/healthz',
+    '/settle',
+    '/supported',
+    '/usage',
+    '/verify',
+  ]);
+});
+
+test('a live GET /healthz response matches its documented schema', async () => {
+  const doc = await SwaggerParser.dereference(SPEC_PATH);
+  const schema = doc.paths['/healthz'].get.responses['200'].content['application/json'].schema;
+
+  const app = await serve();
+  try {
+    const res = await app.get('/healthz');
+    const body = await res.json();
+
+    const ajv = new Ajv({ strict: false });
+    const validateBody = ajv.compile(schema);
+    assert.ok(validateBody(body), JSON.stringify(validateBody.errors));
+  } finally {
+    await app.close();
+  }
+});
+
+test('a live POST /verify success response matches its documented schema', async () => {
+  const doc = await SwaggerParser.dereference(SPEC_PATH);
+  const schema = doc.paths['/verify'].post.responses['200'].content['application/json'].schema;
+
+  const app = await serve();
+  try {
+    const res = await app.post('/verify', VALID_BODY);
+    const body = await res.json();
+
+    const ajv = new Ajv({ strict: false });
+    const validateBody = ajv.compile(schema);
+    assert.ok(validateBody(body), JSON.stringify(validateBody.errors));
+  } finally {
+    await app.close();
+  }
+});
+
+test('a live POST /settle success response matches its documented schema', async () => {
+  const doc = await SwaggerParser.dereference(SPEC_PATH);
+  const schema = doc.paths['/settle'].post.responses['200'].content['application/json'].schema;
+
+  const app = await serve();
+  try {
+    const res = await app.post('/settle', VALID_BODY);
+    const body = await res.json();
+
+    const ajv = new Ajv({ strict: false });
+    const validateBody = ajv.compile(schema);
+    assert.ok(validateBody(body), JSON.stringify(validateBody.errors));
+  } finally {
+    await app.close();
+  }
+});

--- a/test/request-validation.test.js
+++ b/test/request-validation.test.js
@@ -1,0 +1,103 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { validatePaymentBody } from '../src/request-validation.js';
+
+const config = { networks: ['stellar:testnet'] };
+
+const VALID_REQUIREMENTS = {
+  scheme: 'exact',
+  network: 'stellar:testnet',
+  asset: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
+  maxAmountRequired: '1000',
+  payTo: 'GCALKSGAZRJLSUEJT3M5W6LN4R7XQOLIRCOS6ZA6EDZVTZDBIIPPFKJ6',
+};
+
+const VALID_PAYLOAD = {
+  x402Version: 2,
+  scheme: 'exact',
+  network: 'stellar:testnet',
+  payload: { transaction: 'AAAAAgAAAA...' },
+};
+
+test('accepts a conformant body unchanged', () => {
+  const result = validatePaymentBody(
+    { paymentPayload: VALID_PAYLOAD, paymentRequirements: VALID_REQUIREMENTS },
+    config,
+  );
+  assert.equal(result.valid, true);
+  assert.deepEqual(result.paymentPayload, VALID_PAYLOAD);
+  assert.deepEqual(result.paymentRequirements, VALID_REQUIREMENTS);
+});
+
+test('rejects a missing paymentPayload', () => {
+  const result = validatePaymentBody({ paymentRequirements: VALID_REQUIREMENTS }, config);
+  assert.equal(result.valid, false);
+  assert.equal(result.field, 'paymentPayload');
+  assert.equal(result.reason, 'invalid_request');
+  assert.ok(result.message);
+});
+
+for (const bad of ['a string', 42, true, null, ['array'], undefined]) {
+  test(`rejects paymentPayload of type ${typeof bad} (${JSON.stringify(bad)})`, () => {
+    const result = validatePaymentBody(
+      { paymentPayload: bad, paymentRequirements: VALID_REQUIREMENTS },
+      config,
+    );
+    assert.equal(result.valid, false);
+    assert.equal(result.field, 'paymentPayload');
+    assert.equal(result.reason, 'invalid_request');
+  });
+}
+
+test('rejects a non-object paymentRequirements', () => {
+  const result = validatePaymentBody(
+    { paymentPayload: VALID_PAYLOAD, paymentRequirements: 'nope' },
+    config,
+  );
+  assert.equal(result.valid, false);
+  assert.equal(result.field, 'paymentRequirements');
+  assert.equal(result.reason, 'invalid_request');
+});
+
+test('rejects paymentRequirements.scheme that is missing or not a string', () => {
+  const result = validatePaymentBody(
+    {
+      paymentPayload: VALID_PAYLOAD,
+      paymentRequirements: { ...VALID_REQUIREMENTS, scheme: 123 },
+    },
+    config,
+  );
+  assert.equal(result.valid, false);
+  assert.equal(result.field, 'paymentRequirements.scheme');
+  assert.equal(result.reason, 'invalid_request');
+});
+
+test('rejects a network outside config.networks with a distinct reason', () => {
+  const result = validatePaymentBody(
+    {
+      paymentPayload: VALID_PAYLOAD,
+      paymentRequirements: { ...VALID_REQUIREMENTS, network: 'stellar:pubnet' },
+    },
+    config,
+  );
+  assert.equal(result.valid, false);
+  assert.equal(result.field, 'paymentRequirements.network');
+  assert.equal(result.reason, 'unsupported_network');
+  // Must be distinct from invalid_request so a client can branch on it.
+  assert.notEqual(result.reason, 'invalid_request');
+});
+
+test('does not inspect paymentPayload.payload at all', () => {
+  // An unrecognised or oddly-shaped field inside payload must never cause a
+  // rejection here — that is the scheme's contract, not the transport's.
+  const payload = {
+    ...VALID_PAYLOAD,
+    payload: { transaction: 'AAAAAgAAAA...', somethingUpstreamMightAddLater: [1, 2, 3] },
+  };
+  const result = validatePaymentBody(
+    { paymentPayload: payload, paymentRequirements: VALID_REQUIREMENTS },
+    config,
+  );
+  assert.equal(result.valid, true);
+  assert.deepEqual(result.paymentPayload.payload, payload.payload);
+});


### PR DESCRIPTION
Closes #65, closes #68, closes #70, closes #71

## #65 — Bazaar: soft-drop a low-quality routeTemplate instead of hard-dropping the resource
`src/catalog/validation.js` hard-dropped **any** invalid `routeTemplate`, including a bare wildcard `*` — which upstream's own SDK registers by default and warns degrades to auto-generated `var1, var2, …` parameter names. This punished a seller running the stock SDK on its defaults.

- Distinguish a **hostile** routeTemplate (path traversal, protocol smuggling, unparseable percent-encoding — still a hard drop, it's a real SSRF/traversal boundary) from a merely **low-quality** one (regex mismatch, e.g. a wildcard).
- A low-quality routeTemplate is now a soft drop: the resource still lands (falls back to the payment's own resource URL, same as upstream's own extraction does), and `routeTemplate` is added to `softDrops` so the seller sees it in `EXTENSION-RESPONSES`.
- Matches the soft-drop policy from #23 (per the issue's own inclination).
- `docs/BAZAAR.md` policy table updated; existing hard-drop tests for traversal/`://` smuggling still pass unchanged; new test added for the wildcard case.

## #68 — Transport-layer request body validation
New `src/request-validation.js`, called from `readPaymentBody` in `src/app.js`:

- `paymentPayload` / `paymentRequirements` must be objects.
- `paymentRequirements.scheme` and `.network` must be non-empty strings.
- `paymentRequirements.network` must be in `config.networks` — rejected by name with a distinct `unsupported_network` reason (separate from `invalid_request`) before the scheme ever sees it, since a wrong-network payload getting through is a real-money risk on a pubnet instance.
- `paymentPayload.payload` (the transaction XDR and everything inside it) is **not** inspected — verified by a test asserting an unrecognised field inside it doesn't cause rejection.
- Rejections keep the per-route shape: `/verify` returns `isValid`/`invalidReason`; `/settle` also returns `transaction`/`network`.

**Dependency choice:** hand-written guards, not zod/ajv. This is five fields with no nesting/unions/refinement/codegen need, and the repo is deliberate about its dependency surface (licence-check job in CI) — a schema library isn't proportionate here. Reasoning is in the file's header comment.

## #70 — Redact sensitive data before logging
New `src/logger.js`, wired in as request-logging middleware in `src/app.js`:

- `redact()` masks `Authorization`, `cookie`, `set-cookie`, `proxy-authorization`, and any key ending in `_secret`/`-secret` (case-insensitive, recursive) as `***`.
- The request logger never logs the body at all — only method/path/status/duration/redacted-headers, logged once per request after the response finishes.
- Hand-written rather than pulling in pino, for the same dependency-surface reason as #68 — noted in the file header, with a note on how to swap to pino's `redact` option later if structured logging becomes a real need.
- `docs/THREAT-MODEL.md` updated to reflect the new control.

## #71 — OpenAPI description of the transport
New `openapi.yaml` at the repo root:

- All eight routes (`/healthz`, `/supported`, `/usage`, `/verify`, `/settle`, `/discovery/resources` GET+POST, `/discovery/search`), with request/response schemas.
- `/verify` and `/settle` documented as returning **200 on payment failure** — called out explicitly in both the top-level `info.description` and each route's description, since a spec modeling failure as 4xx would describe a different service.
- `EXTENSION-RESPONSES` and the `RateLimit-Limit`/`RateLimit-Remaining`/`RateLimit-Reset`/`Retry-After` header family are documented.
- API-key auth scheme described, including that `/usage` requires a key even in open mode.
- `info.description` is explicit that verify/settle semantics come from upstream `@x402/stellar` and this document describes only the transport around it; `paymentPayload`/`paymentRequirements` schemas are intentionally loose beyond what the transport itself checks.
- `test/openapi.test.js` validates the document against the OpenAPI 3.1 meta-schema (`@apidevtools/swagger-parser`) and checks live `/healthz`, `/verify`, `/settle` responses against their documented schemas (`ajv`). Both added as devDependencies alongside `js-yaml`; all pass the licence check.
- Swagger UI intentionally left out of scope, per the issue.

## Testing
- `npm run lint` — passes.
- `npm test` — passes (135/135 relevant tests; the only failures are a pre-existing 8-test Windows-path issue in `select-conformance-components.test.js`, reproduced identically on `main` before this change, unrelated to this PR).
- `npm run e2e` — not run locally (needs a funded testnet account and live RPC access, per the script's own header); the request-validation and pass-through behavior for a conformant payload is covered by `test/app.test.js` and `test/request-validation.test.js` instead, including a live round-trip through `createApp` with the real `express.json()` body parser.
