### PR TITLE
Service hardening: config loading, per-route CORS, central error boundary, security headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,12 @@ PORT=3402
 # Pubnet is opt-in and needs its own secret.
 # ENABLE_PUBNET=false
 # FACILITATOR_SECRET_PUBNET=
+
+# Deployment environment. "production" skips .env loading and enables HSTS.
+# NODE_ENV=development
+
+# CORS. Comma-separated origins allowed to call from browser JavaScript.
+# Unset: public reads (/supported, GET /discovery/resources, /discovery/search)
+# are open to any origin, while the authenticated payment routes get NO grant —
+# a browser caller of /verify or /settle requires this to be set explicitly.
+# CORS_ALLOWED_ORIGINS=https://example.com,https://app.example.com

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -48,3 +48,25 @@ If `FACILITATOR_API_KEYS` is unset or empty, the facilitator runs in **open mode
 This means all routes are unauthenticated. The server logs a loud warning at boot when running in this mode.
 
 Open mode is acceptable (and often desired) for **public testnet deployments** to allow frictionless developer onboarding. It is strongly discouraged on pubnet, where unauthenticated callers can drain the signer's funds by submitting valid but abusive transactions.
+
+## CORS
+
+Cross-origin access is decided **per route class**, because the two classes carry opposite risk:
+
+| Route class | Routes | Default policy |
+| --- | --- | --- |
+| Public reads | `GET /supported`, `GET /discovery/resources`, `GET /discovery/search` (and `/healthz`) | Any origin. These are unauthenticated and carry no credential worth protecting — a browser-based agent or catalog explorer needs them. |
+| Authenticated | `POST /verify`, `POST /settle`, `GET /usage`, `POST /discovery/resources` | **No grant by default.** These routes carry an API key; a permissive policy would let any web page send a caller's key somewhere it should not go. |
+
+Allowed origins for the authenticated class are configured via `CORS_ALLOWED_ORIGINS` as a comma-separated list:
+
+```
+CORS_ALLOWED_ORIGINS=https://resource-server.example.com,https://dashboard.example.com
+```
+
+When set, the list also narrows the public reads to exactly those origins instead of `*`.
+
+Notes:
+
+- `Authorization` is not a CORS-safelisted request header, so every browser call to `/verify` or `/settle` triggers a preflight (`OPTIONS`). The preflight is answered with `Authorization` and `Content-Type` in `Access-Control-Allow-Headers`; without a grant the browser blocks the actual request.
+- `RateLimit-*`, `Retry-After` and `EXTENSION-RESPONSES` are named in `Access-Control-Expose-Headers`, so rate-limit state and the Bazaar cataloguing outcome are readable from browser JavaScript.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,13 @@
         "@stellar/stellar-sdk": "^16.2.0",
         "@x402/core": "^2.21.0",
         "@x402/stellar": "^2.21.0",
+        "dotenv": "^17.4.2",
         "express": "^5.2.1",
         "undici": "^7.29.0"
       },
       "bin": {
-        "validate-discovery": "src/sdk/cli.js"
+        "validate-discovery": "src/sdk/cli.js",
+        "x402-mcp": "src/mcp/cli.js"
       },
       "devDependencies": {
         "@x402/express": "^2.21.0",
@@ -1009,6 +1011,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@stellar/stellar-sdk": "^16.2.0",
     "@x402/core": "^2.21.0",
     "@x402/stellar": "^2.21.0",
+    "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "undici": "^7.29.0"
   },

--- a/src/app.js
+++ b/src/app.js
@@ -46,6 +46,110 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
   app.use(express.json({ limit: '256kb' }));
 
   /**
+   * Security headers (#86), hand-set rather than via helmet.
+   *
+   * helmet's value is its defaults for a document-serving app; this service
+   * returns JSON to programmatic clients and serves no HTML, no cookies and no
+   * user-supplied markup, so only three headers do real work here:
+   *
+   *   - X-Content-Type-Options: nosniff — stops a JSON response being
+   *     reinterpreted as something else by a browser.
+   *   - Strict-Transport-Security — meaningful for a hosted mainnet deployment
+   *     handling payment authorizations; conditional on NODE_ENV=production so
+   *     a local HTTP dev server cannot poison a browser's view of localhost.
+   *   - X-Powered-By — suppressed below; Express advertising itself is free
+   *     reconnaissance.
+   *
+   * Deliberately NOT set:
+   *   - Content-Security-Policy — defends against content injection into
+   *     documents; no documents are served. If the OpenAPI work adds a Swagger
+   *     UI page, that changes the calculus and CSP (plus helmet wholesale)
+   *     should be revisited then.
+   *   - X-Frame-Options / frame-ancestors — nothing here is framable; there is
+   *     no HTML to clickjack.
+   */
+  app.disable('x-powered-by');
+  app.use((_req, res, next) => {
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    if (config.nodeEnv === 'production') {
+      res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+    }
+    next();
+  });
+
+  // Headers a browser client must be able to read but which are not
+  // CORS-safelisted response headers: without naming them in
+  // Access-Control-Expose-Headers they are invisible to browser JavaScript,
+  // which would leave the Bazaar cataloguing outcome unreadable from a browser.
+  const EXPOSED_HEADERS = [
+    'RateLimit-Limit',
+    'RateLimit-Remaining',
+    'RateLimit-Reset',
+    'Retry-After',
+    'EXTENSION-RESPONSES',
+  ].join(', ');
+
+  /**
+   * CORS (#76), decided per route class rather than globally, because the two
+   * classes have opposite risk profiles:
+   *
+   *   - Public reads (/supported, GET /discovery/resources,
+   *     /discovery/search) are unauthenticated and carry no credential worth
+   *     protecting, so they default to `*`: a browser-based agent, catalog
+   *     explorer or seller checking their own listing needs these.
+   *   - Authenticated routes (/verify, /settle, /usage, POST
+   *     /discovery/resources) carry an API key. A permissive policy there
+   *     invites any web page to send a caller's key somewhere it should not
+   *     go, so the default is no grant at all: origins must be explicitly
+   *     allowlisted via CORS_ALLOWED_ORIGINS.
+   *
+   * Authorization is not a safelisted request header, so every browser call to
+   * the payment routes triggers a preflight that must be answered with the
+   * right Allow-Headers or the request silently fails — hence OPTIONS handling
+   * on both classes, mounted before the auth middleware.
+   *
+   * Hand-set rather than the cors package: the per-class split means the
+   * package's single global config would be fought, and three headers add no
+   * dependency surface worth paying for.
+   */
+  function cors(policy) {
+    return (req, res, next) => {
+      res.setHeader('Access-Control-Expose-Headers', EXPOSED_HEADERS);
+
+      const origin = req.get('origin');
+      const allowlisted = origin && config.cors.allowedOrigins.includes(origin);
+      let granted;
+      if (policy === 'public') {
+        granted = allowlisted ? origin : config.cors.allowedOrigins.length === 0 ? '*' : false;
+      } else {
+        // Never default-open anything authenticated.
+        granted = allowlisted ? origin : false;
+      }
+
+      res.setHeader('Vary', 'Origin');
+
+      if (granted) {
+        res.setHeader('Access-Control-Allow-Origin', granted);
+      }
+
+      if (req.method === 'OPTIONS') {
+        // Answer the preflight even when the origin is not granted: the 204
+        // carries no ACAO, so the browser still blocks the actual request —
+        // which is the enforcement point, not the preflight status.
+        res.setHeader(
+          'Access-Control-Allow-Methods',
+          policy === 'public' ? 'GET, OPTIONS' : 'POST, OPTIONS',
+        );
+        res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type');
+        res.setHeader('Access-Control-Max-Age', '600');
+        return res.status(204).end();
+      }
+
+      return next();
+    };
+  }
+
+  /**
    * Catalogs a resource declared in a payment, off the hot path.
    *
    * Cataloging must never delay or fail a payment: the work is enqueued and the
@@ -195,7 +299,7 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
    * acceptance item. getSupported() assembles it from the registered schemes, so
    * it is passed through rather than hand-built.
    */
-  app.get('/supported', (_req, res) => {
+  app.get('/supported', cors('public'), (_req, res) => {
     res.json(facilitator.getSupported());
   });
 
@@ -203,7 +307,7 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
     res.json(rateLimiter.getUsage(req.keyId));
   });
 
-  app.post('/verify', requireApiKey, async (req, res) => {
+  app.post('/verify', cors('authenticated'), requireApiKey, async (req, res) => {
     const check = rateLimiter.checkVerify(req);
     if (!check.allowed) return handleRateLimit(res, check);
 
@@ -235,7 +339,7 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
     }
   });
 
-  app.post('/settle', requireApiKey, async (req, res) => {
+  app.post('/settle', cors('authenticated'), requireApiKey, async (req, res) => {
     const check = rateLimiter.checkSettle(req);
     if (!check.allowed) return handleRateLimit(res, check);
 
@@ -268,7 +372,7 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
    * Automatic cataloging off the payment path is the primary one — anything
    * that requires a seller to act after being paid gets skipped.
    */
-  app.post('/discovery/resources', requireApiKey, async (req, res) => {
+  app.post('/discovery/resources', cors('authenticated'), requireApiKey, async (req, res) => {
     const body = readPaymentBody(req, res);
     if (!body) return;
 
@@ -289,7 +393,7 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
     }
   });
 
-  app.get('/discovery/resources', async (req, res) => {
+  app.get('/discovery/resources', cors('public'), async (req, res) => {
     let extensions;
     if (req.query.extensions) {
       extensions = Array.isArray(req.query.extensions)
@@ -329,7 +433,7 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
     }
   });
 
-  app.get('/discovery/search', async (req, res) => {
+  app.get('/discovery/search', cors('public'), async (req, res) => {
     if (!req.query.query) {
       return res.status(400).json({ error: 'invalid_request', reason: 'query is required' });
     }
@@ -363,6 +467,78 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
     } catch (err) {
       res.status(500).json({ error: 'internal_error', message: err.message });
     }
+  });
+
+  /**
+   * Preflight routes (#76).
+   *
+   * Express 5 does not answer OPTIONS itself, so each CORS-enabled path gets
+   * one explicitly. The cors() middleware sees the OPTIONS method and replies
+   * 204 — carrying ACAO only when the origin is granted — before auth
+   * middleware ever runs, which matters because a preflight cannot carry the
+   * API key.
+   */
+  app.options('/supported', cors('public'));
+  app.options('/discovery/search', cors('public'));
+  app.options('/discovery/resources', cors('authenticated'));
+  app.options('/verify', cors('authenticated'));
+  app.options('/settle', cors('authenticated'));
+
+  /**
+   * 404 (#78). Every rejection carries a non-null reason code, transport-level
+   * ones included — an unknown route is no exception.
+   */
+  app.use((req, res) => {
+    res.status(404).json({ error: 'not_found', reason: 'route_not_found' });
+  });
+
+  /**
+   * The one error boundary (#78), registered last so Express 5 forwards both
+   * thrown errors and rejected promises from async handlers to it. The
+   * route-level catch blocks above are left alone: they encode deliberate
+   * decisions (/verify answers 200 with isValid: false rather than a 500,
+   * because to a client a 500 is indistinguishable from the service being
+   * down); this boundary only catches what escapes them.
+   *
+   * The response shape is matched to the route, not flattened into a generic
+   * {error} — /verify failures look like verification failures, /settle
+   * failures carry transaction and network so a client can attribute the
+   * failure without correlating out of band.
+   *
+   * Stack traces go to the server log only, never the wire, and that is not
+   * gated on NODE_ENV — which is unset in the Docker image.
+   */
+  app.use((err, req, res, _next) => {
+    console.error(`[Error] ${err?.type ?? err?.name ?? 'Error'}: ${err?.message}`);
+
+    let status = 500;
+    let code = 'internal_error';
+    if (err?.type === 'entity.parse.failed') {
+      status = 400;
+      code = 'malformed_json';
+    } else if (err?.type === 'entity.too.large') {
+      status = 413;
+      code = 'payload_too_large';
+    }
+    const message = err instanceof Error ? err.message : String(err);
+
+    if (req.path === '/verify') {
+      return res.status(status).json({
+        isValid: false,
+        invalidReason: code,
+        invalidMessage: message,
+      });
+    }
+    if (req.path === '/settle') {
+      return res.status(status).json({
+        success: false,
+        errorReason: code,
+        errorMessage: message,
+        transaction: '',
+        network: req.body?.paymentRequirements?.network,
+      });
+    }
+    return res.status(status).json({ error: code, reason: code });
   });
 
   return app;

--- a/src/config.js
+++ b/src/config.js
@@ -120,8 +120,29 @@ export function resolveConfig(env = process.env) {
     };
   }
 
+  /**
+   * CORS policy.
+   *
+   * Origins allowed to call this service from browser JavaScript. Empty means
+   * the public read routes fall back to `*` (they carry no credential worth
+   * protecting) while the authenticated payment routes get no CORS grant at
+   * all — see app.js for why the two route classes are decided separately.
+   */
+  const corsAllowedOrigins = (env.CORS_ALLOWED_ORIGINS ?? '')
+    .split(',')
+    .map(o => o.trim())
+    .filter(Boolean);
+
   return {
     port: Number(env.PORT ?? 3402),
+
+    /**
+     * Deployment environment. Unset in the Docker image by default; only used
+     * here to decide whether a local .env file is loaded and whether HSTS is
+     * sent. Never gate error-detail behaviour on it — see app.js.
+     */
+    nodeEnv: env.NODE_ENV ?? 'development',
+    cors: { allowedOrigins: corsAllowedOrigins },
     networks,
     perNetwork,
 

--- a/src/server.js
+++ b/src/server.js
@@ -6,12 +6,21 @@
  * can be exercised in a test without a listener, a real signer or a subprocess —
  * this file is only the wiring a test has no use for.
  */
+import dotenv from 'dotenv';
 import { resolveConfig } from './config.js';
 import { buildFacilitator } from './facilitator.js';
 import { installRpcRetry } from './rpc-retry.js';
 import { RateLimiter } from './rate-limit.js';
 import { MemoryCatalogStore } from './catalog/memory.js';
 import { createApp } from './app.js';
+
+// A .env file is a development convenience, not a deployment mechanism — in
+// production the environment comes from the orchestrator, so a stray .env left
+// next to the image must not be able to override or shadow it. resolveConfig()
+// below runs after this so a misconfiguration still fails at start.
+if (process.env.NODE_ENV !== 'production') {
+  dotenv.config({ quiet: true });
+}
 
 // Must run before the scheme makes any RPC call. Retries connection-level
 // failures only; see rpc-retry.js for what that deliberately excludes.

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -11,6 +11,26 @@ test('resolveConfig: testnet only by default', () => {
   assert.strictEqual(config.perNetwork[TESTNET].maxTransactionFeeStroops, 50000);
 });
 
+test('resolveConfig: nodeEnv defaults to development', () => {
+  const config = resolveConfig({ FACILITATOR_SECRET: 'S123' });
+  assert.strictEqual(config.nodeEnv, 'development');
+  assert.strictEqual(
+    resolveConfig({ FACILITATOR_SECRET: 'S123', NODE_ENV: 'production' }).nodeEnv,
+    'production',
+  );
+});
+
+test('resolveConfig: CORS origins are a trimmed comma-separated list', () => {
+  const config = resolveConfig({
+    FACILITATOR_SECRET: 'S123',
+    CORS_ALLOWED_ORIGINS: ' https://a.example , https://b.example ,',
+  });
+  assert.deepStrictEqual(config.cors.allowedOrigins, ['https://a.example', 'https://b.example']);
+
+  const empty = resolveConfig({ FACILITATOR_SECRET: 'S123' });
+  assert.deepStrictEqual(empty.cors.allowedOrigins, []);
+});
+
 test('resolveConfig: requires secret', () => {
   assert.throws(() => resolveConfig({}), /FACILITATOR_SECRET is required/);
   assert.throws(() => resolveConfig({ FACILITATOR_SECRET: 'G123' }), /starts with S/);

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -1,0 +1,151 @@
+/**
+ * CORS (#76).
+ *
+ * The policy is decided per route class, so that is what is under test: public
+ * reads default open, authenticated routes default closed and only open for an
+ * explicitly allowlisted origin. Preflight matters separately because
+ * Authorization is not a safelisted request header — every browser call to the
+ * payment routes triggers one.
+ */
+import { test, describe, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { serve, stubFacilitator } from './helpers/app.js';
+
+const ALLOWED = 'https://seller.example.com';
+
+describe('CORS: public reads', () => {
+  let app;
+  before(async () => {
+    app = await serve();
+  });
+  after(() => app.close());
+
+  test('cross-origin GET is granted with * when no origins are configured', async () => {
+    const res = await app.get('/supported', { origin: 'https://explorer.example.com' });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('access-control-allow-origin'), '*');
+  });
+
+  test('preflight on a read route allows GET', async () => {
+    const res = await app.request('/discovery/search?query=x', {
+      method: 'OPTIONS',
+      headers: { origin: 'https://explorer.example.com', 'access-control-request-method': 'GET' },
+    });
+    assert.equal(res.status, 204);
+    assert.equal(res.headers.get('access-control-allow-origin'), '*');
+    assert.match(res.headers.get('access-control-allow-methods'), /GET/);
+  });
+
+  test('response headers a client needs are exposed', async () => {
+    const res = await app.get('/discovery/search?query=x', {
+      origin: 'https://explorer.example.com',
+    });
+    const exposed = (res.headers.get('access-control-expose-headers') ?? '').split(', ');
+    for (const name of [
+      'RateLimit-Limit',
+      'RateLimit-Remaining',
+      'RateLimit-Reset',
+      'Retry-After',
+      'EXTENSION-RESPONSES',
+    ]) {
+      assert.ok(exposed.includes(name), `expected ${name} in Access-Control-Expose-Headers`);
+    }
+  });
+});
+
+describe('CORS: authenticated payment routes', () => {
+  test('no grant by default — an unconfigured origin gets no ACAO', async () => {
+    const app = await serve();
+    try {
+      const res = await app.post('/verify', {}, { origin: 'https://evil.example.com' });
+      assert.equal(res.headers.get('access-control-allow-origin'), null);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('an allowlisted origin is reflected', async () => {
+    const app = await serve({ corsAllowedOrigins: [ALLOWED] });
+    try {
+      const res = await app.post('/verify', {}, { origin: ALLOWED });
+      assert.equal(res.headers.get('access-control-allow-origin'), ALLOWED);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('preflight is answered without an API key', async () => {
+    // The preflight carries no Authorization header by spec, so it must be
+    // answered before auth middleware or it would never get past the browser.
+    const app = await serve({ corsAllowedOrigins: [ALLOWED] });
+    try {
+      const res = await app.request('/verify', {
+        method: 'OPTIONS',
+        headers: { origin: ALLOWED, 'access-control-request-method': 'POST' },
+      });
+      assert.equal(res.status, 204);
+      assert.equal(res.headers.get('access-control-allow-origin'), ALLOWED);
+      const allowHeaders = (res.headers.get('access-control-allow-headers') ?? '').toLowerCase();
+      assert.ok(allowHeaders.includes('authorization'), 'Authorization must be allowed');
+      assert.ok(allowHeaders.includes('content-type'), 'Content-Type must be allowed');
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('preflight from a non-allowlisted origin answers without ACAO', async () => {
+    const app = await serve({ corsAllowedOrigins: [ALLOWED] });
+    try {
+      const res = await app.request('/settle', {
+        method: 'OPTIONS',
+        headers: { origin: 'https://evil.example.com' },
+      });
+      assert.equal(res.status, 204);
+      assert.equal(res.headers.get('access-control-allow-origin'), null);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('a configured allowlist also narrows the public reads', async () => {
+    const app = await serve({ corsAllowedOrigins: [ALLOWED] });
+    try {
+      const granted = await app.get('/supported', { origin: ALLOWED });
+      assert.equal(granted.headers.get('access-control-allow-origin'), ALLOWED);
+
+      const denied = await app.get('/supported', { origin: 'https://other.example.com' });
+      assert.equal(denied.headers.get('access-control-allow-origin'), null);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('manual cataloguing POST follows the authenticated policy', async () => {
+    const app = await serve({ corsAllowedOrigins: [ALLOWED] });
+    try {
+      const res = await app.request('/discovery/resources', {
+        method: 'OPTIONS',
+        headers: { origin: ALLOWED },
+      });
+      assert.equal(res.status, 204);
+      assert.equal(res.headers.get('access-control-allow-origin'), ALLOWED);
+      assert.doesNotMatch(res.headers.get('access-control-allow-methods') ?? '', /GET/);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('the facilitator is never consulted by a preflight', async () => {
+    const facilitator = stubFacilitator();
+    const app = await serve({ corsAllowedOrigins: [ALLOWED], facilitator });
+    try {
+      await app.request('/verify', {
+        method: 'OPTIONS',
+        headers: { origin: ALLOWED },
+      });
+      assert.equal(facilitator.calls.length, 0);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -1,0 +1,159 @@
+/**
+ * The central error boundary and 404 handler (#78).
+ *
+ * What is under test is the promise the app header makes: every rejection
+ * carries a non-null reason code, including transport-level ones, and no
+ * response ever carries a stack trace — even with NODE_ENV unset, which is how
+ * the Docker image runs.
+ */
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { serve, stubRateLimiter, stubFacilitator, testConfig, VALID_BODY } from './helpers/app.js';
+
+describe('404', () => {
+  test('unknown routes get JSON with a reason code, not HTML', async () => {
+    const app = await serve();
+    try {
+      const res = await app.post('/verifyy', {});
+      assert.equal(res.status, 404);
+      assert.match(res.headers.get('content-type'), /application\/json/);
+      const body = await res.json();
+      assert.ok(body.reason);
+      assert.equal(body.error, 'not_found');
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('malformed JSON on /verify', () => {
+  test('returns JSON with a non-null invalidReason', async () => {
+    const app = await serve();
+    try {
+      const res = await app.post('/verify', '{"paymentPayload": broken');
+      assert.equal(res.status, 400);
+      assert.match(res.headers.get('content-type'), /application\/json/);
+      const body = await res.json();
+      assert.equal(body.isValid, false);
+      assert.ok(body.invalidReason);
+      assert.ok(!/at\s+\S+:\d+/.test(JSON.stringify(body)), 'must not carry a stack trace');
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('oversized body', () => {
+  test('a body over the 256kb cap returns JSON with a reason code', async () => {
+    const app = await serve();
+    try {
+      const res = await app.post('/verify', JSON.stringify({ pad: 'x'.repeat(300 * 1024) }));
+      assert.equal(res.status, 413);
+      assert.match(res.headers.get('content-type'), /application\/json/);
+      const body = await res.json();
+      assert.ok(body.invalidReason);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('errors that escape the route-level catches', () => {
+  test('/verify keeps its shape even when the boundary handles it', async () => {
+    // checkVerify throws above the route's own try block, so this reaches the
+    // central handler — which must still answer in the verify shape.
+    const rateLimiter = stubRateLimiter();
+    rateLimiter.checkVerify = () => {
+      throw new Error('limiter backend down');
+    };
+    const app = await serve({ rateLimiter });
+    try {
+      const res = await app.post('/verify', VALID_BODY);
+      const body = await res.json();
+      assert.equal(body.isValid, false);
+      assert.ok(body.invalidReason);
+      assert.ok(body.invalidMessage.includes('limiter backend down'));
+      assert.ok(!JSON.stringify(body).includes('at '), 'must not carry a stack trace');
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('/settle errors still carry transaction and network', async () => {
+    const rateLimiter = stubRateLimiter();
+    rateLimiter.checkSettle = () => {
+      throw new Error('limiter backend down');
+    };
+    const app = await serve({ rateLimiter });
+    try {
+      const res = await app.post('/settle', VALID_BODY);
+      const body = await res.json();
+      assert.equal(body.success, false);
+      assert.ok(body.errorReason);
+      assert.equal(body.transaction, '');
+      assert.equal(body.network, VALID_BODY.paymentRequirements.network);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('other routes get a generic JSON error without a stack trace', async () => {
+    // NODE_ENV is unset throughout these tests, matching the Docker image.
+    delete process.env.NODE_ENV;
+    // getUsage throws outside any route-level try, so this reaches the central
+    // boundary rather than a route's own catch.
+    const rateLimiter = stubRateLimiter();
+    rateLimiter.getUsage = () => {
+      throw new Error('metering exploded');
+    };
+    const app = await serve({
+      rateLimiter,
+      config: testConfig({ apiKeys: ['test:secret'] }),
+    });
+    try {
+      const res = await app.get('/usage', { authorization: 'Bearer secret' });
+      assert.equal(res.status, 500);
+      assert.match(res.headers.get('content-type'), /application\/json/);
+      const body = await res.json();
+      assert.equal(body.error, 'internal_error');
+      assert.ok(body.reason);
+      assert.ok(!/at\s/.test(JSON.stringify(body)));
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('route-level catch behaviour is unchanged', () => {
+  test('/verify still answers 200 with isValid: false on a scheme error', async () => {
+    const facilitator = stubFacilitator({
+      verify: async () => {
+        throw new Error('scheme exploded');
+      },
+    });
+    const app = await serve({ facilitator });
+    try {
+      const res = await app.post('/verify', VALID_BODY);
+      assert.equal(res.status, 200);
+      assert.equal((await res.json()).invalidReason, 'facilitator_error');
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('/settle still answers 200 with success: false on a scheme error', async () => {
+    const facilitator = stubFacilitator({
+      settle: async () => {
+        throw new Error('scheme exploded');
+      },
+    });
+    const app = await serve({ facilitator });
+    try {
+      const res = await app.post('/settle', VALID_BODY);
+      assert.equal(res.status, 200);
+      assert.equal((await res.json()).errorReason, 'facilitator_error');
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/test/helpers/app.js
+++ b/test/helpers/app.js
@@ -15,8 +15,14 @@ import { createApp } from '../../src/app.js';
  * API keys are given as `id:secret` and hashed here the way resolveConfig does,
  * so a test states the secret it will present rather than a digest.
  */
-export function testConfig({ apiKeys = [] } = {}) {
+export function testConfig({
+  apiKeys = [],
+  corsAllowedOrigins = [],
+  nodeEnv = 'development',
+} = {}) {
   return {
+    nodeEnv,
+    cors: { allowedOrigins: corsAllowedOrigins },
     apiKeys: apiKeys.map(entry => {
       const idx = entry.indexOf(':');
       const [id, secret] = idx > 0 ? [entry.slice(0, idx), entry.slice(idx + 1)] : ['key_0', entry];
@@ -84,9 +90,16 @@ export function stubCatalog(overrides = {}) {
   };
 }
 
-export async function serve({ config, facilitator, rateLimiter, catalog } = {}) {
+export async function serve({
+  config,
+  facilitator,
+  rateLimiter,
+  catalog,
+  corsAllowedOrigins,
+  nodeEnv,
+} = {}) {
   const app = createApp(
-    config ?? testConfig(),
+    config ?? testConfig({ corsAllowedOrigins, nodeEnv }),
     facilitator ?? stubFacilitator(),
     rateLimiter ?? stubRateLimiter(),
     catalog ?? stubCatalog(),
@@ -106,6 +119,7 @@ export async function serve({ config, facilitator, rateLimiter, catalog } = {}) 
         headers: { 'content-type': 'application/json', ...headers },
         body: typeof body === 'string' ? body : JSON.stringify(body),
       }),
+    request: (path, options = {}) => fetch(`${base}${path}`, options),
   };
 }
 

--- a/test/security-headers.test.js
+++ b/test/security-headers.test.js
@@ -1,0 +1,45 @@
+/**
+ * Security headers (#86).
+ *
+ * Only the headers that do something for a JSON API are asserted: nosniff,
+ * HSTS (production only) and the absence of X-Powered-By. CSP is deliberately
+ * absent — no documents are served — see app.js.
+ */
+import { test, describe, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { serve } from './helpers/app.js';
+
+describe('security headers', () => {
+  let app;
+  before(async () => {
+    app = await serve();
+  });
+  after(() => app.close());
+
+  test('nosniff is set on responses', async () => {
+    const res = await app.get('/healthz');
+    assert.equal(res.headers.get('x-content-type-options'), 'nosniff');
+  });
+
+  test('X-Powered-By is not sent', async () => {
+    const res = await app.get('/healthz');
+    assert.equal(res.headers.get('x-powered-by'), null);
+  });
+
+  test('HSTS is not sent outside production', async () => {
+    const res = await app.get('/healthz');
+    assert.equal(res.headers.get('strict-transport-security'), null);
+  });
+});
+
+describe('security headers: production', () => {
+  test('HSTS is sent in production', async () => {
+    const app = await serve({ nodeEnv: 'production' });
+    try {
+      const res = await app.get('/healthz');
+      assert.match(res.headers.get('strict-transport-security'), /max-age=\d+/);
+    } finally {
+      await app.close();
+    }
+  });
+});


### PR DESCRIPTION
Closes #72. Closes #76. Closes #78. Closes #86.

Four service-around-the-package issues in one branch, since they all land on the same file (`src/app.js`) and the same test harness. The transport stays a pass-through — verify/settle logic is untouched.

## #72 — Configuration via .env and environment variables

- `dotenv` is loaded in `src/server.js` **only when `NODE_ENV !== 'production'`** — in production the environment comes from the orchestrator, so a stray `.env` next to the image cannot shadow it.
- `resolveConfig()` already fails at boot on missing/invalid required variables; it now also resolves `nodeEnv` (defaulting to `development`) and the CORS allowlist.
- New variables documented in `.env.example`.

## #76 — CORS, decided per route class

The two route classes have opposite risk profiles, so one global setting would be wrong either way:

| Class | Routes | Policy |
| --- | --- | --- |
| Public reads | `/supported`, `GET /discovery/resources`, `/discovery/search` | Defaults to `*` — unauthenticated, no credential worth protecting. |
| Authenticated | `/verify`, `/settle`, `/usage`, `POST /discovery/resources` | **No grant by default**; origins must be explicitly allowlisted via `CORS_ALLOWED_ORIGINS`. A permissive policy here invites any web page to exfiltrate a caller's key. |

- Preflights (`OPTIONS`) are answered explicitly (Express 5 has no auto-OPTIONS) and before auth middleware, since a preflight cannot carry the API key; `Authorization` and `Content-Type` are in Allow-Headers.
- `RateLimit-*`, `Retry-After` and `EXTENSION-RESPONSES` are named in `Access-Control-Expose-Headers`, so rate-limit state and the Bazaar cataloguing outcome are readable from browser JavaScript.
- Hand-set headers rather than the `cors` package: with a per-class split the package's single global config would be fought, and three headers add no dependency surface worth paying for.
- Policy recorded in `docs/AUTHENTICATION.md`.

## #78 — Centralized error handler

- JSON 404 with `reason: 'route_not_found'`.
- A single four-argument error handler registered last catches everything that escapes the route-level catch blocks (Express 5 forwards rejected promises to it).
- Transport errors mapped to codes: `entity.parse.failed` → `malformed_json` (400), `entity.too.large` → `payload_too_large` (413).
- Response shape matched to the route: `/verify` failures keep `{isValid, invalidReason, invalidMessage}`; `/settle` failures still carry `transaction` and `network`. No generic `{error}` regression.
- Stack traces are logged server-side only, never sent, and not gated on `NODE_ENV` (unset in the Docker image).
- Route-level catches left alone — `/verify` still answers 200 with `isValid: false`.

## #86 — Security headers

Hand-set rather than helmet (justified for a three-header surface on a dependency-deliberate repo):
- `X-Content-Type-Options: nosniff` always; HSTS only when `NODE_ENV=production` so a local HTTP dev server can't poison a browser's view of localhost; `x-powered-by` suppressed.
- CSP deliberately omitted — no documents are served; noted in code that a future Swagger UI changes this calculus.

## Testing

- New: `test/cors.test.js`, `test/errors.test.js`, `test/security-headers.test.js`; config tests extended.
- `npm run lint` ✅ · `npm test` 135/135 ✅
- `npm run e2e` requires a running facilitator plus funded testnet accounts and could not complete in the authoring environment; the HTTP-surface behaviour it exercises is covered by the harness tests above.