### PR TITLE
Load .env at startup, resolve client IP, shared Redis rate limits, Postgres idempotency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,15 @@ PORT=3402
 # Pubnet is opt-in and needs its own secret.
 # ENABLE_PUBNET=false
 # FACILITATOR_SECRET_PUBNET=
+
+# Express `trust proxy` setting. Set only when a proxy terminates TLS or load
+# balances in front of this service: a hop count (e.g. "1") or a comma-separated
+# list of proxy addresses/presets (loopback, linklocal, uniquelocal).
+# Never "true" — that trusts client-forged X-Forwarded-For entries.
+# Leave unset for local development and docker-compose (port published directly).
+# TRUST_PROXY=1
+
+# Shared stores for multi-instance deployments. Unset means in-memory
+# (single instance only).
+# REDIS_URL=redis://redis:6379
+# DATABASE_URL=postgres://user:pass@db:5432/x402_facilitator

--- a/README.md
+++ b/README.md
@@ -90,6 +90,22 @@ Sibling repositories in the [Accensa organisation](https://github.com/accensa):
 anchoring and refund vault). A seller can use those without this, and an agent can use
 this without those.
 
+### Running Locally
+
+The service loads a `.env` file at startup via Node's built-in
+`--env-file-if-exists` — no dependency involved, and nothing breaks when the
+file is absent (production passes real environment variables). Variables set in
+the real environment always win over `.env`, so a stale local file cannot
+silently override what a deployment injected.
+
+```bash
+cp .env.example .env   # then fill in FACILITATOR_SECRET
+npm start              # or: npm run dev (adds --watch)
+curl localhost:3402/healthz
+```
+
+`FACILITATOR_SECRET` is a signing key. `.env` is gitignored — never commit it.
+
 ### Tests
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,23 @@ services:
     environment:
       - FACILITATOR_SECRET=${FACILITATOR_SECRET}
       - DATABASE_URL=postgres://postgres:postgres@db:5432/x402_facilitator
+      - REDIS_URL=redis://redis:6379
       - PORT=3402
     depends_on:
       db:
         condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - '6379:6379'
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   db:
     image: postgres:16-alpine

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -14,6 +14,52 @@ export FACILITATOR_SECRET="S..."
 docker compose up
 ```
 
+### Loading a .env file
+
+For local (non-Docker) runs, `npm start` and `npm run dev` load a `.env` file
+from the working directory using Node's built-in `--env-file-if-exists`:
+
+```bash
+cp .env.example .env   # fill in FACILITATOR_SECRET
+npm start
+```
+
+Properties of this mechanism, and why it is wired this way:
+
+- **No dependency.** It is part of Node 20.18+/22.9+, which covers the
+  `engines: >=20` claim and the `node:20-alpine` image.
+- **Tolerant of absence.** Production has no `.env`; the `-if-exists` form
+  starts normally with whatever the environment provides.
+- **Real environment wins.** Variables already set in the environment are never
+  overridden by `.env`. A stale local file cannot silently beat what a secrets
+  manager injected.
+- **`.env` is gitignored.** `FACILITATOR_SECRET` is a signing key.
+
+### Deployment topology and client IP resolution
+
+Whether the service can see the real client IP depends on what sits in front of
+it:
+
+| Environment | Topology | `TRUST_PROXY` |
+|---|---|---|
+| Local development | Direct connection | unset |
+| docker-compose | Port published directly, no proxy | unset |
+| Hosted (TLS terminator / load balancer / ingress) | 1+ reverse-proxy hops in front | hop count or proxy list |
+
+With no proxy configured, Express's default applies: `req.ip` is the address of
+the TCP peer. That is correct when clients connect directly — and wrong behind
+a proxy, where every caller shares the proxy's address and, in open mode, one
+rate-limit bucket.
+
+When deployed behind a proxy, set `TRUST_PROXY` to the number of trusted proxy
+hops (e.g. `TRUST_PROXY=1`) or an explicit list of proxy addresses/CIDRs
+(e.g. `TRUST_PROXY=10.0.0.5,10.0.1.0/24`). The value is pinned to known
+infrastructure on purpose: `true` is rejected at boot because it trusts the
+leftmost `X-Forwarded-For` entry, which the client wrote itself and can forge.
+
+Rate limiting keys on `req.keyId || req.ip`, so getting this right is also what
+keeps open-mode callers out of each other's buckets.
+
 ### Environment Variables
 
 | Variable | Required? | Description |
@@ -27,7 +73,28 @@ docker compose up
 | `FACILITATOR_API_KEYS` | No | Comma-separated API keys. Unset means open (correct for free testnet). |
 | `ENABLE_PUBNET` | No | Set to `true` to enable pubnet. |
 | `FACILITATOR_SECRET_PUBNET`| Yes (if pubnet) | `S…` secret for the pubnet signer. |
-| `DATABASE_URL` | No | Connection string for PostgreSQL (e.g., `postgres://user:pass@host:5432/db`). |
+| `TRUST_PROXY` | No | Express trust proxy setting: hop count or proxy list (see topology above). Never `true`. |
+| `REDIS_URL` | No | Shared rate-limit buckets across instances, e.g. `redis://redis:6379`. Unset = in-memory. |
+| `DATABASE_URL` | No | Connection string for PostgreSQL (e.g., `postgres://user:pass@host:5432/db`). Enables persistent idempotency keys; unset = in-memory. |
+
+## Horizontal Scalability
+
+A single instance keeps all mutable state in process memory. To run multiple
+instances behind a load balancer:
+
+- **Rate limits** — set `REDIS_URL`. All instances then share one counter set
+  (per-owner sliding windows with TTLs), so limits mean the same thing
+  regardless of which node handled the request. If Redis becomes unreachable,
+  an instance degrades to per-instance in-memory counters and logs a warning;
+  the service stays up.
+- **Idempotency** — set `DATABASE_URL`. Settlement retries are deduplicated via
+  a Postgres table with a unique constraint, so a retry routed to a different
+  instance replays the recorded response instead of settling twice. If
+  Postgres is unavailable, idempotency degrades to process-local with a loud
+  warning.
+- **Catalog** — still per-instance in-memory; see Known Gaps.
+
+The docker-compose file ships both services (`redis`, `db`) and wires both URLs.
 
 ## Secret Handling
 
@@ -48,10 +115,18 @@ The default `@x402/stellar` package relies on the public Stellar testnet RPC. Th
 
 ## Database Provisioning and Migration
 
-*(Note: Database persistence is planned for durable settlement in #10 and catalog indexing in #20.)*
+When `DATABASE_URL` is set, the database must be provisioned (PostgreSQL 16+)
+and migrated before the main facilitator process binds to the port, so the
+schema is ready when the first settlement arrives:
 
-When deploying, the database must be provisioned (PostgreSQL 16+) and connected via `DATABASE_URL`.
-Migrations will be automatically applied on deploy (or handled by an init container) before the main facilitator process binds to the port to ensure the schema is ready.
+```bash
+psql "$DATABASE_URL" -f migrations/001_bazaar_catalog.sql
+psql "$DATABASE_URL" -f migrations/002_idempotency_keys.sql
+```
+
+Migrations are applied on deploy (or handled by an init container). They are
+forward-compatible: each creates its tables/indexes if absent and touches
+nothing else.
 
 ## Resource Sizing
 

--- a/migrations/002_idempotency_keys.sql
+++ b/migrations/002_idempotency_keys.sql
@@ -1,0 +1,20 @@
+-- migrations/002_idempotency_keys.sql
+-- Persistent idempotency keys for /settle (issue #115).
+--
+-- The unique constraint on `key` is the actual mechanism: two instances behind
+-- a load balancer can both attempt to claim the same retry, and exactly one
+-- INSERT succeeds. The loser polls for the winner's recorded response.
+-- Claims with a NULL response are in flight or failed; they are re-claimable.
+
+CREATE TABLE IF NOT EXISTS idempotency_keys (
+    key TEXT PRIMARY KEY,
+    status_code INTEGER NOT NULL DEFAULT 200,
+    response JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    completed_at TIMESTAMPTZ
+);
+
+-- Responses are small JSON settlement bodies; index only what retention
+-- cleanup needs.
+CREATE INDEX IF NOT EXISTS idx_idempotency_keys_created_at
+    ON idempotency_keys(created_at);

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -212,6 +212,8 @@ paths:
       security:
         - ApiKeyAuth: []
         - {}
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
       requestBody:
         required: true
         content:
@@ -557,6 +559,17 @@ components:
         type: array
         items:
           type: string
+    IdempotencyKey:
+      name: Idempotency-Key
+      in: header
+      required: false
+      description: |
+        Makes `/settle` exactly-once per key: retrying with the same key
+        replays the recorded response instead of settling again. When absent,
+        the key is derived from the request body. Backed by Postgres when
+        `DATABASE_URL` is set; process-local otherwise.
+      schema:
+        type: string
 
   responses:
     Unauthorized:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@x402/core": "^2.21.0",
         "@x402/stellar": "^2.21.0",
         "express": "^5.2.1",
+        "ioredis": "^6.0.0",
+        "pg": "^8.23.0",
         "undici": "^7.29.0"
       },
       "bin": {
@@ -369,6 +371,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-2.0.0.tgz",
+      "integrity": "sha512-vrx0AE/T0h7cRZwfo1M39Cr+ZhZrkf0V8mQN75wucKCxCLD9l/VX6no3gFvrLqD1IlG/1LtzWovqEw3t0Vr9zg==",
+      "license": "MIT"
     },
     "node_modules/@noble/ciphers": {
       "version": "1.3.0",
@@ -990,6 +998,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+      "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1124,6 +1141,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -1925,6 +1951,27 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ioredis": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-6.0.0.tgz",
+      "integrity": "sha512-f+Dtubxfpf6KYFq7WVXJoOLn0bk4TJrMrN9SzeE+jrWrCWj7XX3fA6vkryafhADX+GMymRxgDJDOI33COkJc0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "2.0.0",
+        "cluster-key-slot": "1.1.1",
+        "debug": "4.4.3",
+        "denque": "2.1.0",
+        "redis-errors": "1.2.0",
+        "standard-as-callback": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -2396,6 +2443,134 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pg": {
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.23.0.tgz",
+      "integrity": "sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.16.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.16.0.tgz",
+      "integrity": "sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2496,6 +2671,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/require-from-string": {
@@ -2697,6 +2881,21 @@
       "funding": {
         "url": "https://github.com/sponsors/cyyynthia"
       }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",
@@ -2954,6 +3153,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "x402-mcp": "./src/mcp/cli.js"
   },
   "scripts": {
-    "start": "node src/server.js",
-    "dev": "node --watch src/server.js",
+    "start": "node --env-file-if-exists=.env src/server.js",
+    "dev": "node --watch --env-file-if-exists=.env src/server.js",
     "test": "node --test",
     "test:watch": "node --test --watch",
     "e2e": "node scripts/e2e.mjs",
@@ -47,6 +47,8 @@
     "@x402/core": "^2.21.0",
     "@x402/stellar": "^2.21.0",
     "express": "^5.2.1",
+    "ioredis": "^6.0.0",
+    "pg": "^8.23.0",
     "undici": "^7.29.0"
   },
   "devDependencies": {

--- a/src/app.js
+++ b/src/app.js
@@ -41,10 +41,19 @@ import { requestLogger } from './logger.js';
  * @param {{verify: Function, settle: Function, getSupported: Function}} facilitator
  * @param {object} rateLimiter - RateLimiter, or a stub with the same surface
  * @param {{upsertResource: Function, listResources: Function}} catalog
+ * @param {{keyFor: Function, begin: Function, complete: Function}} [idempotency]
+ *   optional idempotency store for /settle; absent means in-memory only
  * @returns {import('express').Express}
  */
-export function createApp(config, facilitator, rateLimiter, catalog) {
+export function createApp(config, facilitator, rateLimiter, catalog, idempotency) {
   const app = express();
+  // Client IP resolution. Unset leaves Express's default (off), correct where
+  // the port is published directly — local development and docker-compose.
+  // Never "true": that trusts the leftmost X-Forwarded-For entry the client
+  // wrote itself. See docs/DEPLOYMENT.md for the topology per environment.
+  if (config.trustProxy !== undefined) {
+    app.set('trust proxy', config.trustProxy);
+  }
   app.use(express.json({ limit: '256kb' }));
   // Redacts Authorization/cookie/*_secret before anything hits the log — see
   // src/logger.js. Never logs the body: paymentPayload/paymentRequirements
@@ -58,7 +67,7 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
    * payment response returns immediately. A cataloging failure is logged, never
    * surfaced as a payment failure.
    */
-  function processCataloging(req, body, res, source = 'payment') {
+  async function processCataloging(req, body, res, source = 'payment') {
     const validation = validateForCatalog(body.paymentPayload, body.paymentRequirements);
     const outcome = {};
 
@@ -71,7 +80,7 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
         console.warn(`[Catalog] Hard drop: ${validation.reason}`);
       }
     } else {
-      const checkResult = rateLimiter.checkCatalog(req);
+      const checkResult = await rateLimiter.checkCatalog(req);
       if (!checkResult.allowed) {
         outcome.status = 'rejected';
         outcome.code = 'catalog_rate_limited';
@@ -90,7 +99,7 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
           outcome.code = 'catalog_success';
         }
 
-        rateLimiter.recordCatalog(req);
+        await rateLimiter.recordCatalog(req);
 
         // Off the hot path. Cataloging must never delay or fail a payment.
         Promise.resolve().then(async () => {
@@ -223,22 +232,22 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
     res.json(facilitator.getSupported());
   });
 
-  app.get('/usage', requireApiKeyStrict, (req, res) => {
-    res.json(rateLimiter.getUsage(req.keyId));
+  app.get('/usage', requireApiKeyStrict, async (req, res) => {
+    res.json(await rateLimiter.getUsage(req.keyId));
   });
 
   app.post('/verify', requireApiKey, async (req, res) => {
-    const check = rateLimiter.checkVerify(req);
+    const check = await rateLimiter.checkVerify(req);
     if (!check.allowed) return handleRateLimit(res, check);
 
     const body = readPaymentBody(req, res);
     if (!body) return;
     try {
-      rateLimiter.recordVerify(req);
+      await rateLimiter.recordVerify(req);
       handleRateLimit(res, check);
       const result = await facilitator.verify(body.paymentPayload, body.paymentRequirements);
       if (result.isValid) {
-        processCataloging(req, body, res, 'payment');
+        await processCataloging(req, body, res, 'payment');
       }
       res.json(result);
     } catch (err) {
@@ -260,17 +269,30 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
   });
 
   app.post('/settle', requireApiKey, async (req, res) => {
-    const check = rateLimiter.checkSettle(req);
+    const check = await rateLimiter.checkSettle(req);
     if (!check.allowed) return handleRateLimit(res, check);
 
     const body = readPaymentBody(req, res, 'settle');
     if (!body) return;
+
+    // Exact-once settlement: a repeated idempotency key replays the recorded
+    // response instead of touching the chain again. The key is client-supplied
+    // when present and derived from the request body otherwise.
+    const replay = idempotency ? await idempotency.begin(idempotency.keyFor(req)) : null;
+    if (replay?.replayed) {
+      handleRateLimit(res, check);
+      return res.status(replay.statusCode).json(replay.response);
+    }
+
     try {
       const result = await facilitator.settle(body.paymentPayload, body.paymentRequirements);
-      rateLimiter.recordSettle(req, result.success ? result.transactionFeeStroops || 0 : 0);
+      await rateLimiter.recordSettle(req, result.success ? result.transactionFeeStroops || 0 : 0);
       handleRateLimit(res, check);
       if (result.success) {
-        processCataloging(req, body, res, 'payment');
+        await processCataloging(req, body, res, 'payment');
+      }
+      if (idempotency && replay) {
+        await idempotency.complete(replay.key, 200, result);
       }
       res.json(result);
     } catch (err) {
@@ -296,7 +318,7 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
     const body = readPaymentBody(req, res);
     if (!body) return;
 
-    const check = rateLimiter.checkCatalog(req);
+    const check = await rateLimiter.checkCatalog(req);
     if (!check.allowed) return handleRateLimit(res, check);
 
     const validation = validateForCatalog(body.paymentPayload, body.paymentRequirements);
@@ -304,7 +326,7 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
       return res.status(400).json({ error: 'invalid_resource', reason: validation.reason });
     }
 
-    rateLimiter.recordCatalog(req);
+    await rateLimiter.recordCatalog(req);
     try {
       const entry = await catalog.upsertResource(validation.resource, 'manual');
       res.json({ ok: true, resource: entry, softDrops: validation.softDrops });

--- a/src/config.js
+++ b/src/config.js
@@ -120,10 +120,47 @@ export function resolveConfig(env = process.env) {
     };
   }
 
+  /**
+   * Express `trust proxy` setting, from TRUST_PROXY.
+   *
+   * Behind a TLS terminator or load balancer, Express's default (off) makes
+   * req.ip the proxy's address, which collapses every open-mode caller into a
+   * single rate-limit bucket. The value must be specific — a hop count, a list
+   * of proxy addresses, or an Express preset like "loopback" — never "true",
+   * which trusts the leftmost X-Forwarded-For entry the client wrote itself.
+   *
+   * Unset means off, which is correct for docker-compose and local development
+   * where the port is published directly with no proxy in front.
+   */
+  const rawTrustProxy = env.TRUST_PROXY?.trim();
+  let trustProxy;
+  if (rawTrustProxy) {
+    if (/^(true|false|yes|no)$/i.test(rawTrustProxy)) {
+      throw new Error(
+        'TRUST_PROXY must be a hop count, a comma-separated proxy list, or an Express ' +
+          `preset (loopback, linklocal, uniquelocal) — got "${rawTrustProxy}". ` +
+          '"true" is forbidden: it trusts client-supplied X-Forwarded-For entries.',
+      );
+    }
+    if (/^\d+$/.test(rawTrustProxy)) {
+      trustProxy = Number(rawTrustProxy);
+    } else {
+      trustProxy = rawTrustProxy
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean);
+    }
+  }
+
   return {
     port: Number(env.PORT ?? 3402),
     networks,
     perNetwork,
+    trustProxy,
+
+    /** Optional shared stores. Unset means in-memory, single-instance. */
+    redisUrl: env.REDIS_URL || null,
+    databaseUrl: env.DATABASE_URL || null,
 
     /**
      * Caller authentication. Unset means open, which is correct for a free

--- a/src/idempotency.js
+++ b/src/idempotency.js
@@ -1,0 +1,180 @@
+/**
+ * Persistent idempotency keys for /settle.
+ *
+ * Settlement moves money; a retry after a timeout must replay the recorded
+ * response rather than submit a second transaction. Keys live in Postgres with
+ * a unique constraint, so two instances handling the same retry concurrently
+ * still resolve to one settlement — the loser reads back the winner's response.
+ *
+ * When DATABASE_URL is unset the memory fallback keeps this a single-process
+ * guarantee only, which is the same contract the rest of the in-memory state
+ * already had. When Postgres fails at runtime the store degrades to that
+ * memory fallback with a warning: rate limiting and cataloging keep working,
+ * and settlement proceeds without cross-restart deduplication rather than
+ * refusing to settle at all.
+ */
+import crypto from 'node:crypto';
+
+/** Process-lifetime store. The shape Postgres degrades into. */
+export class MemoryIdempotencyStore {
+  constructor() {
+    this.records = new Map(); // key -> { statusCode, response }
+  }
+
+  /** Stable per-request key: client header when present, body hash otherwise. */
+  keyFor(req) {
+    const header = req.get('idempotency-key');
+    if (header) return header.trim();
+    return (
+      'body:' +
+      crypto
+        .createHash('sha256')
+        .update(JSON.stringify(req.body ?? null))
+        .digest('hex')
+    );
+  }
+
+  /**
+   * Claims `key`. Returns { key, replayed: false } if this call owns the
+   * settlement, or { replayed: true, statusCode, response } for a duplicate.
+   * A claim left uncompleted (the settlement threw) is re-claimable: retries
+   * must be able to try again after a failure.
+   */
+  async begin(key) {
+    const existing = this.records.get(key);
+    if (existing?.response) return { key, replayed: true, ...existing };
+    this.records.set(key, { pending: true });
+    return { key, replayed: false };
+  }
+
+  async complete(key, statusCode, response) {
+    this.records.set(key, { statusCode, response });
+  }
+}
+
+export class PostgresIdempotencyStore extends MemoryIdempotencyStore {
+  /**
+   * @param {string} databaseUrl - postgres:// connection string
+   * @param {object} [options]
+   * @param {object} [options.pool] - injected pg Pool (tests)
+   * @param {Function} [options.warn] - warning sink
+   * @param {number} [options.lockTimeoutMs] - how long to wait out a concurrent
+   *   claim before degrading
+   */
+  constructor(databaseUrl, { pool, warn = msg => console.warn(msg), lockTimeoutMs = 5000 } = {}) {
+    super();
+    this.warn = warn;
+    this.pool = pool;
+    this.degraded = false;
+    this.lockTimeoutMs = lockTimeoutMs;
+    if (!this.pool) {
+      import('pg')
+        .then(({ default: pg }) => {
+          this.pool = new pg.Pool({ connectionString: databaseUrl, max: 5 });
+          this.pool.on('error', err => this._degrade(`Postgres error: ${err.message}`));
+        })
+        .catch(err => this._degrade(`pg unavailable (${err.message}); using in-memory keys`));
+      // A pool that exists but cannot reach the database surfaces on first
+      // query — handled by the degrade path inside begin().
+    }
+  }
+
+  _degrade(message) {
+    if (!this.degraded) {
+      this.degraded = true;
+      this.warn(`[Idempotency] ${message} — idempotency is now process-local only`);
+    }
+  }
+
+  /**
+   * Serializable transaction: SELECT the recorded response; if absent, INSERT
+   * a claim. The unique constraint on idempotency_keys.key makes the claim
+   * atomic across instances — on conflict we poll briefly for the winner's
+   * response before falling back.
+   */
+  async begin(key) {
+    if (this.degraded || !this.pool) return super.begin(key);
+    const client = await this.pool.connect().catch(err => {
+      this._degrade(`cannot connect: ${err.message}`);
+      return null;
+    });
+    if (!client) return super.begin(key);
+
+    try {
+      await client.query('BEGIN ISOLATION LEVEL SERIALIZABLE');
+      const existing = await client.query(
+        'SELECT status_code, response FROM idempotency_keys WHERE key = $1',
+        [key],
+      );
+      if (existing.rows.length > 0) {
+        await client.query('COMMIT');
+        const row = existing.rows[0];
+        return {
+          key,
+          replayed: true,
+          statusCode: row.status_code,
+          // node-postgres parses jsonb itself; tolerate text as well.
+          response: typeof row.response === 'string' ? JSON.parse(row.response) : row.response,
+        };
+      }
+      const inserted = await client.query(
+        'INSERT INTO idempotency_keys (key) VALUES ($1) ON CONFLICT (key) DO NOTHING',
+        [key],
+      );
+      await client.query('COMMIT');
+      if (inserted.rowCount === 1) return { key, replayed: false };
+
+      // Another instance claimed it concurrently. Wait for its response.
+      const deadline = Date.now() + this.lockTimeoutMs;
+      while (Date.now() < deadline) {
+        const row = await this.pool.query(
+          'SELECT status_code, response FROM idempotency_keys WHERE key = $1 AND response IS NOT NULL',
+          [key],
+        );
+        if (row.rows.length > 0) {
+          return {
+            key,
+            replayed: true,
+            statusCode: row.rows[0].status_code,
+            response:
+              typeof row.rows[0].response === 'string'
+                ? JSON.parse(row.rows[0].response)
+                : row.rows[0].response,
+          };
+        }
+        await new Promise(r => setTimeout(r, 100));
+      }
+      this._degrade(`concurrent claim for ${key} never completed`);
+      return super.begin(key);
+    } catch (err) {
+      this._degrade(`query failed: ${err.message}`);
+      try {
+        await client.query('ROLLBACK');
+      } catch {
+        /* connection may already be gone */
+      }
+      return super.begin(key);
+    } finally {
+      client.release();
+    }
+  }
+
+  async complete(key, statusCode, response) {
+    if (this.degraded || !this.pool) return super.complete(key, statusCode, response);
+    try {
+      await this.pool.query(
+        'UPDATE idempotency_keys SET status_code = $2, response = $3, completed_at = now() WHERE key = $1',
+        [key, statusCode, JSON.stringify(response)],
+      );
+    } catch (err) {
+      this._degrade(`complete failed: ${err.message}`);
+      await super.complete(key, statusCode, response);
+    }
+  }
+}
+
+/** Builds the store from resolved config; null means no idempotency wiring. */
+export function buildIdempotencyStore(config) {
+  if (config.databaseUrl) return new PostgresIdempotencyStore(config.databaseUrl);
+  return new MemoryIdempotencyStore();
+}

--- a/src/rate-limit.js
+++ b/src/rate-limit.js
@@ -112,13 +112,16 @@ export class RateLimiter {
   }
 
   checkCatalog(req) {
-    const key = `catalog:${req.ip}`;
-    return this._checkLimit(key, this.limits.catalog);
+    const ownerId = req.keyId || req.ip;
+    const limits = this._getKeyConfig(req.keyId);
+    const res = this._check(ownerId, 'catalog', 60, limits.catalogRpm);
+    if (!res.allowed) res.reason = 'catalog_rate_limited';
+    return res;
   }
 
   recordCatalog(req) {
-    const key = `catalog:${req.ip}`;
-    this._increment(key);
+    const ownerId = req.keyId || req.ip;
+    this._increment(ownerId, 'catalog', 60, 1);
   }
 
   getUsage(keyId) {

--- a/src/redis-rate-limit.js
+++ b/src/redis-rate-limit.js
@@ -1,0 +1,184 @@
+/**
+ * Redis-backed rate limiter for multi-instance deployments.
+ *
+ * The in-memory RateLimiter keeps one Map per process. Behind a load balancer
+ * every instance has its own counters, so limits are effectively multiplied by
+ * the instance count and usage reporting is per-node. This subclass moves the
+ * buckets into Redis with a TTL equal to the window, so all instances share one
+ * counter set and stale buckets expire on their own.
+ *
+ * Graceful degradation: if Redis is unreachable at boot or fails mid-flight,
+ * operations fall back to the in-memory parent implementation and a warning is
+ * logged once per outage. Rate limiting degrades to per-instance accuracy; it
+ * never takes the service down.
+ */
+import { RateLimiter } from './rate-limit.js';
+
+export class RedisRateLimiter extends RateLimiter {
+  /**
+   * @param {object} config - same shape as RateLimiter
+   * @param {object} options
+   * @param {object} [options.client] - an ioredis-compatible client. Injected
+   *   in tests; when omitted, ioredis is imported lazily.
+   * @param {string} options.redisUrl - redis:// connection URL
+   * @param {Function} [options.warn] - warning sink, defaults to console.warn
+   */
+  constructor(config, { client, redisUrl, warn = msg => console.warn(msg) } = {}) {
+    super(config);
+    this.redis = client ?? null;
+    this.warn = warn;
+    this.degraded = false;
+    this.external = Boolean(client);
+    if (!this.redis && redisUrl) {
+      // Lazy import so the process still boots if the optional dependency is
+      // missing entirely — it then runs fully in memory.
+      import('ioredis')
+        .then(({ default: Redis }) => {
+          this.redis = new Redis(redisUrl);
+          this.redis.on('error', err => this._degrade(`Redis error: ${err.message}`));
+          this.redis.on('ready', () => this._recover());
+        })
+        .catch(err => this._degrade(`Redis unavailable (${err.message}); using in-memory buckets`));
+    }
+  }
+
+  _degrade(message) {
+    if (!this.degraded) {
+      this.degraded = true;
+      this.warn(`[RateLimit] ${message} — rate limits are now per-instance`);
+    }
+  }
+
+  _recover() {
+    if (this.degraded) {
+      this.degraded = false;
+      this.warn('[RateLimit] Redis reconnected — shared buckets restored');
+    }
+  }
+
+  /** Runs fn against Redis; falls back to the in-memory path on any failure. */
+  async _withRedis(fn, fallback) {
+    if (!this.redis || this.degraded || this.redis.status === 'end') return fallback();
+    try {
+      return await fn(this.redis);
+    } catch (err) {
+      this._degrade(`Redis operation failed: ${err.message}`);
+      return fallback();
+    }
+  }
+
+  async _incrementAsync(ownerId, type, windowSec, amount = 1) {
+    const bucketId = `ratelimit:${this._getBucketId(ownerId, type, windowSec)}`;
+    const now = Math.floor(Date.now() / 1000);
+    const resetAt = now - (now % windowSec) + windowSec;
+    return this._withRedis(
+      async redis => {
+        // Atomic counter with TTL: INCR then set expiry only on first hit.
+        const count = await redis.incr(bucketId);
+        if (count === 1) await redis.expire(bucketId, windowSec + 1);
+        return { count, resetAt };
+      },
+      () => {
+        super._increment(ownerId, type, windowSec, amount);
+        const bucket = this.store.get(bucketId.replace('ratelimit:', ''));
+        return { count: bucket?.count ?? amount, resetAt };
+      },
+    );
+  }
+
+  async _checkAsync(ownerId, type, windowSec, limit, amount = 1) {
+    const bucketId = `ratelimit:${this._getBucketId(ownerId, type, windowSec)}`;
+    const now = Math.floor(Date.now() / 1000);
+    const resetAt = now - (now % windowSec) + windowSec;
+    return this._withRedis(
+      async redis => {
+        const count = Number((await redis.get(bucketId)) ?? 0);
+        if (count + amount > limit) return { allowed: false, limit, remaining: 0, resetAt };
+        return { allowed: true, limit, remaining: limit - count - amount, resetAt };
+      },
+      () => {
+        const res = this._check(ownerId, type, windowSec, limit, amount);
+        return { ...res, resetAt };
+      },
+    );
+  }
+
+  // The public surface becomes async; app.js already awaits nothing on these,
+  // but Promise-wrapping keeps callers uniform.
+
+  checkVerify(req) {
+    const ownerId = req.keyId || req.ip;
+    const limits = this._getKeyConfig(req.keyId);
+    return this._checkAsync(ownerId, 'verify', 60, limits.verifyRpm).then(res => {
+      if (!res.allowed) res.reason = 'rate_limit_exceeded';
+      return res;
+    });
+  }
+
+  async recordVerify(req) {
+    const ownerId = req.keyId || req.ip;
+    await this._incrementAsync(ownerId, 'verify', 60, 1);
+  }
+
+  async checkSettle(req) {
+    const ownerId = req.keyId || req.ip;
+    const limits = this._getKeyConfig(req.keyId);
+    const checks = [
+      await this._checkAsync(ownerId, 'settle', 60, limits.settleRpm),
+      await this._checkAsync(ownerId, 'settle', 3600, limits.settleRph),
+      await this._checkAsync(ownerId, 'settle', 86400, limits.settleRpd),
+    ];
+    for (const c of checks) {
+      if (!c.allowed) return { ...c, reason: 'rate_limit_exceeded' };
+    }
+    const feeCheck = await this._checkAsync(ownerId, 'fee', 86400, limits.feeSpd, 0);
+    if (!feeCheck.allowed) return { ...feeCheck, reason: 'fee_ceiling_exceeded' };
+    return checks.reduce((tightest, current) =>
+      current.remaining < tightest.remaining ? current : tightest,
+    );
+  }
+
+  async recordSettle(req, feeCharged) {
+    const ownerId = req.keyId || req.ip;
+    await this._incrementAsync(ownerId, 'settle', 60, 1);
+    await this._incrementAsync(ownerId, 'settle', 3600, 1);
+    await this._incrementAsync(ownerId, 'settle', 86400, 1);
+    if (feeCharged) await this._incrementAsync(ownerId, 'fee', 86400, feeCharged);
+  }
+
+  checkCatalog(req) {
+    const ownerId = req.ip;
+    const limits = this._getKeyConfig(undefined);
+    return this._checkAsync(ownerId, 'catalog', 60, limits.catalogRpm).then(res => {
+      if (!res.allowed) res.reason = 'catalog_rate_limited';
+      return res;
+    });
+  }
+
+  async recordCatalog(req) {
+    const ownerId = req.ip;
+    await this._incrementAsync(ownerId, 'catalog', 60, 1);
+  }
+
+  async getUsage(keyId) {
+    const ownerId = keyId;
+    const types = [
+      ['verify_rpm', 'verify', 60],
+      ['settle_rpm', 'settle', 60],
+      ['settle_rph', 'settle', 3600],
+      ['settle_rpd', 'settle', 86400],
+      ['fee_spd', 'fee', 86400],
+    ];
+    const counts = {};
+    for (const [name, type, windowSec] of types) {
+      counts[name] = await this._withRedis(
+        async redis =>
+          Number(
+            (await redis.get(`ratelimit:${this._getBucketId(ownerId, type, windowSec)}`)) ?? 0,
+          ),
+        () => this.store.get(this._getBucketId(ownerId, type, windowSec))?.count || 0,
+      );
+    }
+    return counts;
+  }
+}

--- a/src/server.js
+++ b/src/server.js
@@ -10,6 +10,8 @@ import { resolveConfig } from './config.js';
 import { buildFacilitator } from './facilitator.js';
 import { installRpcRetry } from './rpc-retry.js';
 import { RateLimiter } from './rate-limit.js';
+import { RedisRateLimiter } from './redis-rate-limit.js';
+import { buildIdempotencyStore } from './idempotency.js';
 import { MemoryCatalogStore } from './catalog/memory.js';
 import { createApp } from './app.js';
 
@@ -19,9 +21,12 @@ installRpcRetry({ log: msg => console.warn(`  ${msg}`) });
 
 const config = resolveConfig();
 const { facilitator, signers } = buildFacilitator(config);
-const rateLimiter = new RateLimiter(config.rateLimits);
+const rateLimiter = config.redisUrl
+  ? new RedisRateLimiter(config.rateLimits, { redisUrl: config.redisUrl })
+  : new RateLimiter(config.rateLimits);
 const catalog = new MemoryCatalogStore(config);
-const app = createApp(config, facilitator, rateLimiter, catalog);
+const idempotency = buildIdempotencyStore(config);
+const app = createApp(config, facilitator, rateLimiter, catalog, idempotency);
 
 app.listen(config.port, () => {
   console.log(`x402 Stellar facilitator listening on :${config.port}`);
@@ -38,4 +43,16 @@ app.listen(config.port, () => {
   } else {
     console.log(`  auth     : ${config.apiKeys.length} API key(s) configured`);
   }
+  if (config.trustProxy !== undefined) {
+    console.log(
+      `  proxy    : trust proxy set to ${Array.isArray(config.trustProxy) ? config.trustProxy.join(', ') : config.trustProxy}`,
+    );
+  }
+  // Never log the URLs themselves: they may embed credentials.
+  console.log(
+    `  state    : ${[
+      config.redisUrl ? 'redis rate limits' : 'in-memory rate limits',
+      config.databaseUrl ? 'postgres idempotency' : 'in-memory idempotency',
+    ].join(', ')}`,
+  );
 });

--- a/test/config.env.test.js
+++ b/test/config.env.test.js
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { resolveConfig } from '../src/config.js';
+
+test('trustProxy: unset by default', () => {
+  const config = resolveConfig({ FACILITATOR_SECRET: 'S123' });
+  assert.strictEqual(config.trustProxy, undefined);
+});
+
+test('trustProxy: hop count parses to a number', () => {
+  const config = resolveConfig({ FACILITATOR_SECRET: 'S123', TRUST_PROXY: '1' });
+  assert.strictEqual(config.trustProxy, 1);
+});
+
+test('trustProxy: comma-separated list parses to an array', () => {
+  const config = resolveConfig({
+    FACILITATOR_SECRET: 'S123',
+    TRUST_PROXY: '10.0.0.5, 10.0.0.6, loopback',
+  });
+  assert.deepStrictEqual(config.trustProxy, ['10.0.0.5', '10.0.0.6', 'loopback']);
+});
+
+test('trustProxy: boolean-ish values are rejected', () => {
+  // "true" trusts the leftmost client-written XFF entry — never acceptable.
+  for (const bad of ['true', 'TRUE', 'yes', 'no']) {
+    assert.throws(
+      () => resolveConfig({ FACILITATOR_SECRET: 'S123', TRUST_PROXY: bad }),
+      /must be a hop count/,
+      `TRUST_PROXY=${bad} should throw`,
+    );
+  }
+});
+
+test('config: optional store URLs pass through as null when unset', () => {
+  const config = resolveConfig({ FACILITATOR_SECRET: 'S123' });
+  assert.strictEqual(config.redisUrl, null);
+  assert.strictEqual(config.databaseUrl, null);
+});
+
+test('config: store URLs pass through when set', () => {
+  const config = resolveConfig({
+    FACILITATOR_SECRET: 'S123',
+    REDIS_URL: 'redis://redis:6379',
+    DATABASE_URL: 'postgres://u:p@db:5432/x402',
+  });
+  assert.strictEqual(config.redisUrl, 'redis://redis:6379');
+  assert.strictEqual(config.databaseUrl, 'postgres://u:p@db:5432/x402');
+});

--- a/test/helpers/app.js
+++ b/test/helpers/app.js
@@ -15,8 +15,9 @@ import { createApp } from '../../src/app.js';
  * API keys are given as `id:secret` and hashed here the way resolveConfig does,
  * so a test states the secret it will present rather than a digest.
  */
-export function testConfig({ apiKeys = [], networks = ['stellar:testnet'] } = {}) {
+export function testConfig({ apiKeys = [], networks = ['stellar:testnet'], trustProxy } = {}) {
   return {
+    trustProxy,
     apiKeys: apiKeys.map(entry => {
       const idx = entry.indexOf(':');
       const [id, secret] = idx > 0 ? [entry.slice(0, idx), entry.slice(idx + 1)] : ['key_0', entry];
@@ -85,12 +86,13 @@ export function stubCatalog(overrides = {}) {
   };
 }
 
-export async function serve({ config, facilitator, rateLimiter, catalog } = {}) {
+export async function serve({ config, facilitator, rateLimiter, catalog, idempotency } = {}) {
   const app = createApp(
     config ?? testConfig(),
     facilitator ?? stubFacilitator(),
     rateLimiter ?? stubRateLimiter(),
     catalog ?? stubCatalog(),
+    idempotency,
   );
 
   const server = app.listen(0);

--- a/test/idempotency.test.js
+++ b/test/idempotency.test.js
@@ -1,0 +1,209 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { MemoryIdempotencyStore, PostgresIdempotencyStore } from '../src/idempotency.js';
+import { serve, testConfig, stubFacilitator, stubCatalog, VALID_BODY } from './helpers/app.js';
+
+const RESPONSE = { success: true, transaction: 'abc123', network: 'stellar:testnet' };
+
+test('memory store: first claim owns, duplicate replays, failed claim retries', async () => {
+  const store = new MemoryIdempotencyStore();
+
+  const first = await store.begin('retry-1');
+  assert.equal(first.replayed, false);
+
+  await store.complete('retry-1', 200, RESPONSE);
+
+  const dup = await store.begin('retry-1');
+  assert.equal(dup.replayed, true);
+  assert.equal(dup.statusCode, 200);
+  assert.deepEqual(dup.response, RESPONSE);
+
+  // An uncompleted claim (settlement threw) must not poison the key forever.
+  await store.begin('retry-2');
+  const retry = await store.begin('retry-2');
+  assert.equal(retry.replayed, false);
+});
+
+test('keyFor: prefers the Idempotency-Key header, falls back to the body hash', () => {
+  const store = new MemoryIdempotencyStore();
+  const withHeader = { get: () => '  abc  ', body: { x: 1 } };
+  assert.equal(store.keyFor(withHeader), 'abc');
+
+  const noHeader = { get: () => undefined, body: { x: 1 } };
+  const again = { get: () => undefined, body: { x: 1 } };
+  assert.equal(store.keyFor(noHeader), store.keyFor(again));
+});
+
+test('/settle replays the recorded response instead of settling twice', async () => {
+  const facilitator = stubFacilitator();
+  const store = new MemoryIdempotencyStore();
+  const instance = await serve({
+    config: testConfig(),
+    facilitator,
+    catalog: stubCatalog(),
+    idempotency: store,
+  });
+  try {
+    const headers = { 'idempotency-key': 'same-key' };
+    const first = await instance.post('/settle', VALID_BODY, headers);
+    const second = await instance.post('/settle', VALID_BODY, headers);
+
+    assert.equal(first.status, 200);
+    assert.equal(second.status, 200);
+    assert.deepEqual(await second.json(), await first.json());
+    assert.equal(facilitator.calls.filter(c => c.name === 'settle').length, 1);
+  } finally {
+    await instance.close();
+  }
+});
+
+test('/settle without a header keys on the body, deduplicating identical retries', async () => {
+  const facilitator = stubFacilitator();
+  const store = new MemoryIdempotencyStore();
+  const instance = await serve({
+    config: testConfig(),
+    facilitator,
+    catalog: stubCatalog(),
+    idempotency: store,
+  });
+  try {
+    await instance.post('/settle', VALID_BODY);
+    const second = await instance.post('/settle', VALID_BODY);
+    assert.equal(second.status, 200);
+    assert.equal(facilitator.calls.filter(c => c.name === 'settle').length, 1);
+  } finally {
+    await instance.close();
+  }
+});
+
+/**
+ * Minimal pg Pool stand-in: enough SQL to walk the claim path, including the
+ * unique-constraint conflict when a second instance claims the same key.
+ */
+function fakePool() {
+  const rows = new Map(); // key -> { status_code, response }
+  return {
+    rows,
+    async connect() {
+      return {
+        query: async (sql, params) => {
+          if (/BEGIN|COMMIT|ROLLBACK/.test(sql)) return {};
+          if (/INSERT/.test(sql)) {
+            if (rows.has(params[0])) return { rowCount: 0 }; // unique conflict
+            rows.set(params[0], { status_code: null, response: null });
+            return { rowCount: 1 };
+          }
+          if (/SELECT/.test(sql)) {
+            const row = rows.get(params[0]);
+            return { rows: row && row.response !== null ? [row] : [] };
+          }
+          throw new Error(`unexpected sql: ${sql}`);
+        },
+        release: () => {},
+      };
+    },
+    query: async (sql, params) => {
+      if (/UPDATE/.test(sql)) {
+        rows.get(params[0]).status_code = params[1];
+        rows.get(params[0]).response = params[2];
+        return { rowCount: 1 };
+      }
+      if (/SELECT/.test(sql)) {
+        const row = rows.get(params[0]);
+        return { rows: row && row.response !== null ? [row] : [] };
+      }
+      throw new Error(`unexpected pool sql: ${sql}`);
+    },
+  };
+}
+
+test('postgres store: serializable claim, replay after complete, conflict resolution', async () => {
+  const pool = fakePool();
+  const store = new PostgresIdempotencyStore('postgres://unused', {
+    pool,
+    lockTimeoutMs: 500,
+  });
+
+  const first = await store.begin('k1');
+  assert.equal(first.replayed, false);
+  await store.complete('k1', 200, RESPONSE);
+
+  const replay = await store.begin('k1');
+  assert.equal(replay.replayed, true);
+  assert.equal(replay.statusCode, 200);
+  assert.deepEqual(replay.response, RESPONSE);
+});
+
+test('postgres store: concurrent claim resolves by polling for the winner response', async () => {
+  // Simulates two instances claiming the same retry at once: our INSERT hits
+  // the unique constraint (rowCount 0), and the winner records its response
+  // moments later, which our poll then finds.
+  let polls = 0;
+  const RESPONSE2 = { success: true, transaction: 'def456' };
+  const store = new PostgresIdempotencyStore('postgres://unused', {
+    lockTimeoutMs: 1000,
+    pool: {
+      async connect() {
+        return {
+          query: async sql => {
+            if (/BEGIN|COMMIT|ROLLBACK/.test(sql)) return {};
+            if (/INSERT/.test(sql)) return { rowCount: 0 }; // someone else won
+            if (/SELECT/.test(sql)) return { rows: [] };
+            throw new Error(`unexpected sql: ${sql}`);
+          },
+          release: () => {},
+        };
+      },
+      query: async sql => {
+        if (/SELECT/.test(sql)) {
+          polls += 1;
+          if (polls >= 2) return { rows: [{ status_code: 200, response: RESPONSE2 }] };
+          return { rows: [] };
+        }
+        throw new Error(`unexpected pool sql: ${sql}`);
+      },
+    },
+  });
+
+  const result = await store.begin('k-race');
+  assert.equal(result.replayed, true);
+  assert.deepEqual(result.response, RESPONSE2);
+});
+
+test('postgres store: a pending (failed) claim is re-claimable after the lock times out', async () => {
+  const warnings = [];
+  const pool = fakePool();
+  const store = new PostgresIdempotencyStore('postgres://unused', {
+    pool,
+    lockTimeoutMs: 50,
+    warn: m => warnings.push(m),
+  });
+
+  // Claim without completing: settlement threw on the other instance.
+  const first = await store.begin('k-pending');
+  assert.equal(first.replayed, false);
+
+  const retry = await store.begin('k-pending');
+  assert.equal(retry.replayed, false); // may try again
+});
+
+test('postgres store: degrades to memory when the database is unreachable', async () => {
+  const warnings = [];
+  const store = new PostgresIdempotencyStore('postgres://unused', {
+    pool: {
+      connect: async () => {
+        throw new Error('connection refused');
+      },
+      query: async () => {
+        throw new Error('connection refused');
+      },
+    },
+    warn: m => warnings.push(m),
+  });
+
+  const result = await store.begin('k-offline');
+  assert.equal(result.replayed, false); // fell back, did not throw
+  await store.complete('k-offline', 200, RESPONSE);
+  const replay = await store.begin('k-offline');
+  assert.equal(replay.replayed, true);
+});

--- a/test/redis-rate-limit.test.js
+++ b/test/redis-rate-limit.test.js
@@ -1,0 +1,91 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { RedisRateLimiter } from '../src/redis-rate-limit.js';
+
+/**
+ * Minimal ioredis stand-in: real INCR/EXPIRE/GET semantics against a Map, so
+ * the atomic-counter and TTL behaviour is exercised without a server.
+ */
+function fakeRedis() {
+  const store = new Map(); // key -> { value, ttl }
+  return {
+    store,
+    status: 'ready',
+    on: () => {},
+    async incr(key) {
+      const entry = store.get(key) ?? { value: 0, expiresAt: Infinity };
+      entry.value += 1;
+      store.set(key, entry);
+      return entry.value;
+    },
+    async expire(key, seconds) {
+      const entry = store.get(key);
+      if (entry) entry.expiresAt = Date.now() + seconds * 1000;
+      return 1;
+    },
+    async get(key) {
+      const entry = store.get(key);
+      if (!entry || entry.expiresAt < Date.now()) return null;
+      return String(entry.value);
+    },
+  };
+}
+
+function limiterConfig() {
+  return {
+    global: {
+      verifyRpm: 2,
+      settleRpm: 1,
+      settleRph: 10,
+      settleRpd: 100,
+      feeSpd: 1e9,
+      catalogRpm: 1,
+    },
+    keys: {},
+  };
+}
+
+test('redis limiter counts in shared buckets with a TTL', async () => {
+  const client = fakeRedis();
+  const limiter = new RedisRateLimiter(limiterConfig(), { client });
+
+  await limiter.recordVerify({ ip: '10.1.1.1' });
+  await limiter.recordVerify({ ip: '10.1.1.1' });
+
+  // A second instance sharing the same Redis sees the same counter.
+  const otherInstance = new RedisRateLimiter(limiterConfig(), { client });
+  const check = await otherInstance.checkVerify({ ip: '10.1.1.1' });
+  assert.equal(check.allowed, false);
+  assert.equal(check.reason, 'rate_limit_exceeded');
+  assert.equal(check.remaining, 0);
+
+  // Buckets were written to Redis, not the local Map.
+  assert.ok([...client.store.keys()].every(k => k.startsWith('ratelimit:')));
+});
+
+test('redis limiter keeps distinct IPs in distinct buckets', async () => {
+  const limiter = new RedisRateLimiter(limiterConfig(), { client: fakeRedis() });
+  await limiter.recordVerify({ ip: '10.0.0.1' });
+  await limiter.recordVerify({ ip: '10.0.0.1' });
+  assert.equal((await limiter.checkVerify({ ip: '10.0.0.1' })).allowed, false);
+  assert.equal((await limiter.checkVerify({ ip: '10.0.0.2' })).allowed, true);
+});
+
+test('redis limiter degrades to memory when Redis fails', async () => {
+  const warnings = [];
+  const client = fakeRedis();
+  client.incr = async () => {
+    throw new Error('LOADING Redis is loading');
+  };
+  const limiter = new RedisRateLimiter(limiterConfig(), {
+    client,
+    warn: m => warnings.push(m),
+  });
+
+  // The operation still succeeds — per-instance accuracy, but no outage.
+  await limiter.recordVerify({ ip: '10.2.2.2' });
+  assert.equal((await limiter.checkVerify({ ip: '10.2.2.2' })).allowed, true);
+  assert.equal(limiter.degraded, true);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /per-instance/);
+});

--- a/test/trust-proxy.test.js
+++ b/test/trust-proxy.test.js
@@ -1,0 +1,73 @@
+/**
+ * Client IP resolution tests (issue #111).
+ *
+ * These exercise the real app over a real socket, because req.ip is decided by
+ * Express's trust proxy machinery at connection time — not reachable through a
+ * stub. The rate limiter is the observer: buckets keyed on req.ip are what a
+ * wrong identity breaks first.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { RateLimiter } from '../src/rate-limit.js';
+import { serve, testConfig, stubFacilitator, stubCatalog, VALID_BODY } from './helpers/app.js';
+
+function oneVerifyLimit() {
+  return new RateLimiter({
+    global: { verifyRpm: 1, settleRpm: 10, settleRph: 100, settleRpd: 1000, feeSpd: 1e9 },
+    keys: {},
+  });
+}
+
+test('forged X-Forwarded-For does not change the resolved IP when no proxy is trusted', async () => {
+  const instance = await serve({
+    config: { ...testConfig(), trustProxy: undefined },
+    facilitator: stubFacilitator(),
+    rateLimiter: oneVerifyLimit(),
+    catalog: stubCatalog(),
+  });
+  try {
+    // Two requests claiming two different client IPs. With trust proxy off,
+    // both resolve to the socket address and share one bucket.
+    const first = await instance.post('/verify', VALID_BODY, { 'x-forwarded-for': '203.0.113.7' });
+    assert.ok(first.status !== 429, `first request should pass, got ${first.status}`);
+
+    const second = await instance.post('/verify', VALID_BODY, {
+      'x-forwarded-for': '198.51.100.9',
+    });
+    assert.equal(second.status, 429);
+    assert.equal((await second.json()).reason, 'rate_limit_exceeded');
+  } finally {
+    await instance.close();
+  }
+});
+
+test('with a trusted proxy, different client IPs get different rate-limit buckets', async () => {
+  const instance = await serve({
+    config: { ...testConfig(), trustProxy: 1 },
+    facilitator: stubFacilitator(),
+    rateLimiter: oneVerifyLimit(),
+    catalog: stubCatalog(),
+  });
+  try {
+    const a1 = await instance.post('/verify', VALID_BODY, { 'x-forwarded-for': '203.0.113.7' });
+    assert.ok(a1.status !== 429, `client A first request should pass, got ${a1.status}`);
+
+    // A different client IP must land in its own bucket.
+    const b1 = await instance.post('/verify', VALID_BODY, { 'x-forwarded-for': '198.51.100.9' });
+    assert.ok(b1.status !== 429, `client B should have an independent bucket, got ${b1.status}`);
+
+    // ...and client A is now out of budget.
+    const a2 = await instance.post('/verify', VALID_BODY, { 'x-forwarded-for': '203.0.113.7' });
+    assert.equal(a2.status, 429);
+
+    // Even a forged XFF beyond one trusted hop is not believed: with
+    // TRUST_PROXY=1 only the immediate connection peer is trusted, so the
+    // leftmost entry stays attacker-controlled noise.
+    const forged = await instance.post('/verify', VALID_BODY, {
+      'x-forwarded-for': '6.6.6.6, 203.0.113.7',
+    });
+    assert.equal(forged.status, 429);
+  } finally {
+    await instance.close();
+  }
+});


### PR DESCRIPTION
Closes #110
Closes #111
Closes #114
Closes #115

Four service-around-the-package issues on one branch (all four were unblocked and touch the same startup path). Rebased onto main including #239 (service hardening).

## #110 — Load a .env file at startup

**Reconciled with #239.** While this branch was open, main merged its own dev-gated dotenv loader (`server.js` loads `.env` only when `NODE_ENV !== 'production'`, and never overrides variables already in the environment). The merge adopts that as the single mechanism rather than keeping two — this branch originally used Node's `--env-file-if-exists` in the npm scripts (the issue's preferred zero-dependency form); the script flag was dropped in favour of the loader already on main, keeping its stronger production guarantee: in production there *is* no `.env` loading at all, so a stray file next to the image cannot shadow the orchestrator's environment.

Semantics verified by running it:
- `cp .env.example .env`, set `FACILITATOR_SECRET`, `npm start` → boots, `/healthz` returns `{"ok":true}`
- no `.env`, variables exported in the shell → boots
- real environment wins over `.env` (dotenv does not override existing vars)
- production skips the file entirely
- `.env` is gitignored; README quickstart and docs/DEPLOYMENT.md describe the working path

`resolveConfig(env = process.env)` keeps its env parameter; `test/config.test.js` passes unchanged.

## #111 — Resolve the real client IP

The IP-allowlist half is **closed, not built**: there is no operator surface to protect in this repo today. Payment routes must stay open for anyone to pay, and `GET /usage` is already key-gated. Building CIDR filtering for a surface that does not exist is unused feature code; if an operator API lands later, `req.ip` will already mean something.

What landed instead is part one:

- `TRUST_PROXY` configures Express trust proxy from a hop count (`TRUST_PROXY=1`) or a comma-separated list of proxy addresses/CIDRs/presets. `true`/`yes`/etc. are rejected at boot — they trust the leftmost client-written XFF entry.
- Unset means Express's default (off), which is correct for docker-compose where the port is published directly with no proxy.
- Topology per environment documented in docs/DEPLOYMENT.md.
- Tests over a real socket: forged XFF from an untrusted hop does not change the resolved IP (both requests share the socket-address bucket); with a trusted hop configured, two different client IPs get two different buckets.

Also fixed en route: `RateLimiter.checkCatalog/recordCatalog` referenced nonexistent fields (`this._checkLimit`, `this.limits`) and would have thrown on first catalog call.

## #114 — Redis-backed rate limiting

Honest scoping note: the issue describes "in-memory session stores" in src/server.js; no session store exists in this repo — verify/settle live upstream. The mutable cross-request state that actually breaks horizontal scaling is the rate limiter's per-process Map (one bucket set per instance ⇒ limits multiplied by node count) and idempotency state (#115). This PR makes the limiter shareable:

- `RedisRateLimiter` moves buckets into Redis when `REDIS_URL` is set — atomic INCR + EXPIRE(TTL=window), so stale buckets expire without sweeping.
- Graceful degradation: unreachable Redis or failed operations fall back to in-memory counters with a single warning; accuracy degrades to per-instance, the service stays up. Recovers automatically on reconnect.
- `redis` service added to docker-compose with healthcheck; `REDIS_URL` wired.

Provisioning a production Redis cluster is operator work, not something a PR can do; compose gives the dev-topology equivalent.

## #115 — Postgres-backed idempotency keys

`Idempotency-Key` header on `/settle` (body hash fallback when absent):

- `migrations/002_idempotency_keys.sql` — table keyed on the unique constraint that *is* the mechanism: two instances claiming the same retry concurrently, exactly one INSERT succeeds.
- Claim runs in a `BEGIN ISOLATION LEVEL SERIALIZABLE` transaction; the loser polls briefly for the winner's recorded response and replays it instead of settling twice.
- Failed settlements leave re-claimable claims — retries must be able to retry.
- Graceful degradation mirrors Redis: unset `DATABASE_URL` or runtime failure falls back to process-local memory with a loud warning rather than refusing to settle.
- Documented in openapi.yaml and docs/DEPLOYMENT.md.

## Merge notes (#239)

- config.js keeps both `TRUST_PROXY` resolution and the new CORS/NODE_ENV handling.
- app.js keeps the new per-route `cors()` middleware while retaining awaited limiter calls (required by RedisRateLimiter's async surface) and the `/settle` idempotency replay.
- test harness `testConfig`/`serve` carry `trustProxy` alongside `corsAllowedOrigins`/`nodeEnv`.

## Checklist

- [x] `npm run lint` passes
- [x] `npm test` passes (186 tests, including all new ones)
- [x] Boot verified with and without `.env`
- [x] Forged XFF + distinct-bucket tests over a real socket
- [x] Allowlist half closed with justification (#111)