### PR TITLE
feat: shared rate-limit store, readiness probe, RPC breaker, audit log

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,31 @@ PORT=3402
 # Pubnet is opt-in and needs its own secret.
 # ENABLE_PUBNET=false
 # FACILITATOR_SECRET_PUBNET=
+
+# ── Rate-limit store (#94) ────────────────────────────────────────────────
+# Unset or "memory" = per-process Map (today's behaviour, zero dependencies).
+# "postgres" shares limiter state across replicas via DATABASE_URL: two
+# instances then enforce ONE combined limit, and the daily fee ceiling
+# (fee_spd) survives restarts instead of resetting to zero.
+# RATE_LIMIT_STORE=postgres
+# DATABASE_URL=postgres://postgres:postgres@db:5432/x402_facilitator
+
+# ── RPC circuit breaker (#105) ────────────────────────────────────────────
+# Consecutive connection-level failures before the breaker opens for an RPC
+# host, and how long it stays open before letting a single probe through.
+# Defaults are deliberately conservative: 10 failures / 30s cooldown.
+# RPC_BREAKER_THRESHOLD=10
+# RPC_BREAKER_COOLDOWN_MS=30000
+
+# ── Readiness probe (#100) ────────────────────────────────────────────────
+# GET /health/ready checks each network's RPC and the signer's funded balance.
+# Its own dial timeout, result cache TTL, and the minimum acceptable balance:
+# READINESS_TIMEOUT_MS=3000
+# READINESS_CACHE_TTL_MS=5000
+# READINESS_FUNDING_FLOOR_STROOPS=0
+
+# ── Audit log (#109) ──────────────────────────────────────────────────────
+# Optional file that receives audit records (settlements, auth failures, rate
+# limit rejections, catalog writes) in addition to stdout, as one JSON line
+# per event. Unset = stdout only.
+# AUDIT_LOG_FILE=/var/log/facilitator/audit.jsonl

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,11 @@ RUN npm ci --omit=dev
 
 COPY --from=builder /app/src ./src
 
+# HEALTHCHECK is a LIVENESS probe, so it targets /healthz, not /health/ready.
+# /health/ready can fail on a downstream Soroban RPC outage; failing the
+# Docker-level check on that would restart-loop the container and make the
+# outage worse (a restart cannot fix someone else's RPC). Orchestrator traffic
+# gating belongs on GET /health/ready, which names the failing dependency.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider http://localhost:${PORT:-3402}/healthz || exit 1
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,11 @@ services:
       - FACILITATOR_SECRET=${FACILITATOR_SECRET}
       - DATABASE_URL=postgres://postgres:postgres@db:5432/x402_facilitator
       - PORT=3402
+      # Unset by default = per-process memory. Set RATE_LIMIT_STORE=postgres in
+      # the environment (or .env) to share limiter state across replicas and
+      # keep the daily fee ceiling alive across restarts.
+      - RATE_LIMIT_STORE=${RATE_LIMIT_STORE:-memory}
+      - AUDIT_LOG_FILE=${AUDIT_LOG_FILE:-}
     depends_on:
       db:
         condition: service_healthy

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -1,5 +1,49 @@
 # Audit-Readiness Package
 
+## Audit Trail (#109)
+
+Sensitive operations are recorded by `src/audit.js` as one JSON object per
+line, each carrying `"channel": "audit"` so records are separable from
+diagnostic logs (filterable at shipment; optionally mirrored to `AUDIT_LOG_FILE`
+for independent retention). Every record carries a timestamp (`ts`), the
+authenticated caller (`actor`: `keyId`, or `ip:<addr>` in open mode), the
+action (`event`) and the outcome.
+
+### What is audited, and why
+
+| Event | Included because |
+|---|---|
+| `settlement` | Money moved (or was attempted). Carries the **transaction hash**, network, fee and outcome, so a disputed settlement can be reconstructed against the chain. This is the record the audit trail exists for. |
+| `verification` | The gate before settlement. Outcomes and rejection reasons are needed to reconstruct why a payment never proceeded. |
+| `catalog_write` | A public listing is created or overwritten. Without it, a spoofed or hijacked listing cannot be investigated after the fact. Records url, tool name, source (payment/manual) and whether an existing entry was overwritten. |
+| `auth_failure` | Authentication probing/brute force. Records the reason code and source IP — never the presented key material. |
+| `rate_limit_rejected` | Abuse signal and evidence trail for callers hitting ceilings, including `fee_ceiling_exceeded` and store-unavailable refusals. |
+| `rpc_unreachable` | An open circuit breaker caused a caller-visible failure. Distinguishes "our dependency died" from "your payment was rejected" in the trail. |
+
+### What is deliberately not audited
+
+- **Reads** (`/supported`, `/discovery/resources`, `/discovery/search`,
+  `/usage`): no state changes, no money. Logging them would grow the trail
+  without evidentiary value and conflict with data minimisation
+  (docs/PRIVACY.md).
+- **Full request payloads**: never recorded — payloads carry signatures and
+  XDR blobs with no audit value once outcome + transaction hash are on file.
+- **Key material**: `req.keyId` only, never the key itself; the logger
+  additionally redacts secret-shaped fields as defence in depth.
+
+### Relationship to structured application logging (#7)
+
+#7 covers diagnostic logging, correlation IDs and metrics. This audit trail is
+a distinct artifact with different retention and integrity requirements, but
+it is not a second logging mechanism: it is a single structured writer
+emitting self-describing JSON lines that can be routed by the same shipment
+infrastructure #7 introduces. Retention follows docs/PRIVACY.md §7: audit
+records of settlements inherit the 90-day settlement-record class, other audit
+records the 7-day request-log class, pending the automated enforcement tracked
+in #50.
+
+## Proposed Scope
+
 ## Proposed Scope
 The scope of the audit includes the HTTP transport, configuration, authentication, and operational concerns implemented in this repository (`x402-facilitator-stellar`).
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -27,7 +27,61 @@ docker compose up
 | `FACILITATOR_API_KEYS` | No | Comma-separated API keys. Unset means open (correct for free testnet). |
 | `ENABLE_PUBNET` | No | Set to `true` to enable pubnet. |
 | `FACILITATOR_SECRET_PUBNET`| Yes (if pubnet) | `S…` secret for the pubnet signer. |
-| `DATABASE_URL` | No | Connection string for PostgreSQL (e.g., `postgres://user:pass@host:5432/db`). |
+| `DATABASE_URL` | No | Connection string for PostgreSQL (e.g., `postgres://user:pass@host:5432/db`). Required when `RATE_LIMIT_STORE=postgres`. |
+| `RATE_LIMIT_STORE` | No | `memory` (default) or `postgres`. Shared rate-limit state across replicas — see below. |
+| `RPC_BREAKER_THRESHOLD` | No | Consecutive connection failures that open the RPC circuit breaker (default `10`). |
+| `RPC_BREAKER_COOLDOWN_MS` | No | How long an open breaker waits before a half-open probe (default `30000`). |
+| `READINESS_TIMEOUT_MS` | No | Per-call timeout for readiness checks, independent of the RPC retry budget (default `3000`). |
+| `READINESS_CACHE_TTL_MS` | No | How long GET /health/ready serves a cached result (default `5000`). |
+| `READINESS_FUNDING_FLOOR_STROOPS` | No | Minimum signer balance reported by the readiness probe (default `0` = must exist). |
+| `AUDIT_LOG_FILE` | No | File that receives audit records in addition to stdout. |
+
+## Shared Rate-Limit State
+
+By default the rate limiter keeps its counters in process memory. That is fine
+for one replica and zero-config testnet, but it has two consequences at scale:
+
+- **A restart resets the daily fee ceiling** (`fee_spd`) — the only spend limit
+  on sponsored fees.
+- **N replicas enforce N separate limits** — every caller gets N× its
+  allowance.
+
+Setting `RATE_LIMIT_STORE=postgres` moves limiter state into Postgres (the
+database already provisioned by `docker-compose.yml`, via `DATABASE_URL`):
+
+- two processes sharing one store enforce one combined limit;
+- the fee counter survives restarts, redeploys and reschedules;
+- increments are atomic single-statement upserts (`migrations/002_rate_limit_buckets.sql`,
+  also created automatically on first use) — no lost counts under concurrency.
+
+Postgres was chosen over Redis because it is already part of the stack, and
+because its rows are never evicted: a fee counter is a value that must not be
+lost to an eviction policy. If Redis is ever introduced here it must run with
+`maxmemory-policy noeviction`.
+
+**Degrade behaviour:** when the shared store is unreachable, checks fail CLOSED
+with reason `rate_limit_store_unavailable`. Fail-open would mean unlimited
+sponsored spend during an outage — exactly the bug this feature exists to
+prevent.
+
+## Health Endpoints and Probes
+
+- `GET /healthz` — liveness. Always `{ ok: true }` while the process runs; no
+  dependency checks. Point container/orchestrator **restart** logic here.
+- `GET /health/ready` — readiness. Checks each configured network's Soroban RPC
+  reachability and the signer account's funded balance; returns `503` naming the
+  failing check per network when any is unhealthy. Results are cached
+  (`READINESS_CACHE_TTL_MS`) and each check runs under its own timeout
+  (`READINESS_TIMEOUT_MS`), independent of the ~12s retry budget in the payment
+  path. Point load-balancer **traffic gating** here.
+
+## Audit Log
+
+Security-relevant events — settlements (with transaction hash), verifications,
+catalog writes, authentication failures, and rate-limit rejections — are
+recorded as structured JSON lines with `"channel": "audit"`, separable from
+diagnostic logs. Set `AUDIT_LOG_FILE` to mirror them to a file with its own
+retention handling. See `docs/AUDIT.md` for the event catalogue and retention.
 
 ## Secret Handling
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,6 +1,47 @@
 # Operations & Rate Limiting
 
-The x402 facilitator includes an in-memory sliding-window rate limiter and usage meter. This protects the service from abuse and limits the cumulative fee exposure, as the service sponsors Stellar transaction fees for every settlement.
+The x402 facilitator includes a sliding-window rate limiter and usage meter. This protects the service from abuse and limits the cumulative fee exposure, as the service sponsors Stellar transaction fees for every settlement.
+
+## Health Endpoints
+
+Two endpoints, two different questions — keep them straight:
+
+### `GET /healthz` — liveness
+
+Always returns `200 { ok: true }` while the process runs. It performs **no
+dependency checks**, deliberately: a liveness probe that fails on a downstream
+outage triggers restart loops that make the outage worse (and a restart cannot
+fix someone else's RPC). The Docker `HEALTHCHECK` targets this endpoint.
+
+### `GET /health/ready` — readiness
+
+Returns `200 { status: "ready", ... }` when the instance can settle right now,
+or `503 { ok: false, status: "not_ready", networks: {...} }` naming which check
+failed for which network. Per configured network it checks:
+
+| Check | Meaning of failure |
+|---|---|
+| `rpc_reachable` | The network's Soroban RPC did not answer a bounded getHealth call. Every `/settle` will currently fail; stop routing traffic here. |
+| `signer_funded` | The facilitator signer account does not exist or is below `READINESS_FUNDING_FLOOR_STROOPS`. No settlement can be sponsored. Fund the account or fix the signer config. |
+
+The response also reports, without ever failing on them:
+- `breakers` — per-RPC-host circuit-breaker state (`open` means calls are being refused fast; see #105);
+- `catalog` — catalogue-store health. A cataloguing failure must never fail a payment, so it never fails readiness either.
+
+Results are cached for `READINESS_CACHE_TTL_MS` (default 5s) so probes do not
+become an RPC burst, and every underlying call runs under its own
+`READINESS_TIMEOUT_MS` (default 3s) rather than inheriting the payment path's
+~12s retry budget.
+
+**Probe wiring rule:** restart logic → `/healthz`; traffic gating (load
+balancers, Kubernetes `readinessProbe`) → `/health/ready`.
+
+## Rate Limit Store
+
+Counters live in process memory by default (`RATE_LIMIT_STORE` unset). For
+multi-replica deployments set `RATE_LIMIT_STORE=postgres` with `DATABASE_URL`
+so all replicas share one combined limit and the daily fee ceiling survives
+restarts — see docs/DEPLOYMENT.md ("Shared Rate-Limit State").
 
 ## Configuration
 

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -57,6 +57,7 @@ You can run your own instance of the X402 Facilitator. By doing so, you retain c
 
 We adhere to the following retention periods:
 - **Request Logs**: 7 days.
+- **Audit Records** (`channel: "audit"`, see docs/AUDIT.md): settlements follow the settlement-record class below; all other audit records follow the request-log class. They are separable from diagnostic logs precisely so these classes can be enforced independently.
 - **Search Queries**: 30 days.
 - **Settlement Records**: 90 days (retained longer for dispute resolution and refund processing).
 

--- a/migrations/002_rate_limit_buckets.sql
+++ b/migrations/002_rate_limit_buckets.sql
@@ -1,0 +1,19 @@
+-- migrations/002_rate_limit_buckets.sql
+--
+-- Shared state for the rate limiter / usage meter (issue #94). The service
+-- also creates this table itself on first use (CREATE TABLE IF NOT EXISTS in
+-- src/rate-limit-store.js); keeping the migration alongside 001 means an ops
+-- flow that applies migrations up front gets the same schema.
+--
+-- One row per limiter bucket. bucket_id embeds owner, counter type, window
+-- start and window size, e.g. "key_0:settle:1735689600:3600". Expired windows
+-- are swept opportunistically by the service; rows are never evicted under
+-- memory pressure, which is precisely why a daily fee ceiling is safe here.
+
+CREATE TABLE IF NOT EXISTS rate_limit_buckets (
+    bucket_id TEXT PRIMARY KEY,
+    count     BIGINT NOT NULL DEFAULT 0,
+    reset_at  BIGINT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_rate_limit_buckets_reset_at ON rate_limit_buckets(reset_at);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,12 @@
         "@x402/core": "^2.21.0",
         "@x402/stellar": "^2.21.0",
         "express": "^5.2.1",
+        "pg": "^8.23.0",
         "undici": "^7.29.0"
       },
       "bin": {
-        "validate-discovery": "src/sdk/cli.js"
+        "validate-discovery": "src/sdk/cli.js",
+        "x402-mcp": "src/mcp/cli.js"
       },
       "devDependencies": {
         "@x402/express": "^2.21.0",
@@ -2264,6 +2266,134 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pg": {
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.23.0.tgz",
+      "integrity": "sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.16.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.16.0.tgz",
+      "integrity": "sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2566,6 +2696,15 @@
         "url": "https://github.com/sponsors/cyyynthia"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -2822,6 +2961,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@x402/core": "^2.21.0",
     "@x402/stellar": "^2.21.0",
     "express": "^5.2.1",
+    "pg": "^8.23.0",
     "undici": "^7.29.0"
   },
   "devDependencies": {

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,6 @@
 /**
- * The HTTP surface: /verify, /settle, /supported, /usage, /discovery/resources.
+ * The HTTP surface: /verify, /settle, /supported, /usage, /discovery/resources,
+ * /healthz, /health/ready.
  *
  * @x402/core ships no facilitator router — it gives you x402Facilitator with
  * verify(), settle() and getSupported(), and the transport is yours. This file
@@ -22,6 +23,8 @@
 import crypto from 'node:crypto';
 import express from 'express';
 import { validateForCatalog } from './catalog/validation.js';
+import { createAuditLogger } from './audit.js';
+import { createReadinessChecker } from './readiness.js';
 
 /**
  * Builds the Express app.
@@ -39,20 +42,36 @@ import { validateForCatalog } from './catalog/validation.js';
  * @param {{verify: Function, settle: Function, getSupported: Function}} facilitator
  * @param {object} rateLimiter - RateLimiter, or a stub with the same surface
  * @param {{upsertResource: Function, listResources: Function}} catalog
+ * @param {object} [extras] - optional collaborators: a readiness checker, an
+ *   audit writer override, a breaker-state reader
  * @returns {import('express').Express}
  */
-export function createApp(config, facilitator, rateLimiter, catalog) {
+export function createApp(config, facilitator, rateLimiter, catalog, extras = {}) {
   const app = express();
   app.use(express.json({ limit: '256kb' }));
+
+  const audit = extras.audit ?? createAuditLogger();
+
+  // Readiness defaults to a real checker over the resolved config. A bare test
+  // config carries no networks, in which case the probe reports honestly that
+  // it has nothing to check rather than pretending to be ready.
+  const readiness =
+    extras.readiness ??
+    (Array.isArray(config.networks)
+      ? createReadinessChecker(config, {
+          breakerStates: extras.breakerStates ?? (() => null),
+          catalog,
+        })
+      : null);
 
   /**
    * Catalogs a resource declared in a payment, off the hot path.
    *
-   * Cataloging must never delay or fail a payment: the work is enqueued and the
-   * payment response returns immediately. A cataloging failure is logged, never
-   * surfaced as a payment failure.
+   * Cataloging must never delay or fail a payment: the expensive work is
+   * enqueued and the payment response returns immediately. A cataloging failure
+   * is logged, never surfaced as a payment failure.
    */
-  function processCataloging(req, body, res, source = 'payment') {
+  async function processCataloging(req, body, res, source = 'payment') {
     const validation = validateForCatalog(body.paymentPayload, body.paymentRequirements);
     const outcome = {};
 
@@ -65,12 +84,20 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
         console.warn(`[Catalog] Hard drop: ${validation.reason}`);
       }
     } else {
-      const checkResult = rateLimiter.checkCatalog(req);
+      const checkResult = await rateLimiter.checkCatalog(req);
       if (!checkResult.allowed) {
         outcome.status = 'rejected';
         outcome.code = 'catalog_rate_limited';
         outcome.reason = checkResult.reason;
         console.warn(`[Catalog] Rate limit exceeded for IP ${req.ip}`);
+        // Audited as a rejection but never allowed to shape the payment
+        // response: the 429/headers belong to the payment limiter, not here.
+        audit('rate_limit_rejected', {
+          actor: req.keyId ?? `ip:${req.ip}`,
+          route: 'catalog',
+          reason: checkResult.reason,
+          outcome_override: outcome.code,
+        });
       } else {
         if (validation.softDrops.length > 0) {
           outcome.status = 'partially landed';
@@ -84,12 +111,26 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
           outcome.code = 'catalog_success';
         }
 
-        rateLimiter.recordCatalog(req);
+        await rateLimiter.recordCatalog(req);
 
         // Off the hot path. Cataloging must never delay or fail a payment.
         Promise.resolve().then(async () => {
           try {
+            const existing = await catalog.getResource?.(
+              validation.resource.url,
+              validation.resource.toolName ?? null,
+            );
             await catalog.upsertResource(validation.resource, source);
+            // A public listing being created or overwritten is public state
+            // changing — recorded so a spoofed listing can be investigated
+            // after the fact.
+            audit('catalog_write', {
+              actor: req.keyId ?? `ip:${req.ip}`,
+              source,
+              url: validation.resource.url,
+              tool_name: validation.resource.toolName ?? null,
+              overwritten: Boolean(existing),
+            });
           } catch (err) {
             console.warn(`[Catalog] Async cataloging failed: ${err.message}`);
           }
@@ -113,10 +154,14 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
   function requireApiKey(req, res, next) {
     if (config.apiKeys.length === 0) return next();
 
+    const reject = reason => {
+      // The presented key material itself is deliberately never recorded.
+      audit('auth_failure', { actor: `ip:${req.ip}`, reason });
+      return res.status(401).json({ error: 'unauthorized', reason });
+    };
+
     const authHeader = req.get('authorization');
-    if (!authHeader) {
-      return res.status(401).json({ error: 'unauthorized', reason: 'missing_auth_header' });
-    }
+    if (!authHeader) return reject('missing_auth_header');
 
     let presentedKey = '';
     if (authHeader.startsWith('Bearer ')) {
@@ -124,11 +169,11 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
     } else if (!authHeader.includes(' ')) {
       presentedKey = authHeader;
     } else {
-      return res.status(401).json({ error: 'unauthorized', reason: 'malformed_auth_header' });
+      return reject('malformed_auth_header');
     }
 
     if (!presentedKey || presentedKey.includes(' ')) {
-      return res.status(401).json({ error: 'unauthorized', reason: 'malformed_auth_header' });
+      return reject('malformed_auth_header');
     }
 
     const presentedHash = crypto.createHash('sha256').update(presentedKey).digest();
@@ -143,7 +188,7 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
       }
     }
 
-    return res.status(401).json({ error: 'unauthorized', reason: 'invalid_api_key' });
+    return reject('invalid_api_key');
   }
 
   /**
@@ -154,6 +199,17 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
       return res.status(401).json({ error: 'unauthorized', reason: 'open_mode_usage_forbidden' });
     }
     requireApiKey(req, res, next);
+  }
+
+  /** Rate-limit rejections are auditable: they are abuse signals, not noise. */
+  function rejectRateLimited(req, res, route, checkResult, extra = {}) {
+    audit('rate_limit_rejected', {
+      actor: req.keyId ?? `ip:${req.ip}`,
+      route,
+      reason: checkResult.reason,
+      ...extra,
+    });
+    return handleRateLimit(res, checkResult);
   }
 
   function handleRateLimit(res, checkResult) {
@@ -189,6 +245,30 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
   app.get('/healthz', (_req, res) => res.json({ ok: true }));
 
   /**
+   * GET /health/ready — the readiness probe (#100).
+   *
+   * Unlike /healthz this CAN fail: 503 names which check failed for which
+   * network. Result is cached and bounded by its own timeout — see
+   * src/readiness.js. Catalogue trouble is reported but never fails readiness:
+   * a cataloguing failure must never fail a payment.
+   */
+  app.get('/health/ready', async (_req, res) => {
+    if (!readiness) {
+      return res.status(503).json({
+        ok: false,
+        status: 'not_ready',
+        reason: 'readiness_not_configured',
+      });
+    }
+    try {
+      const report = await readiness.check();
+      res.status(report.ok ? 200 : 503).json(report);
+    } catch (err) {
+      res.status(503).json({ ok: false, status: 'not_ready', error: err.message });
+    }
+  });
+
+  /**
    * GET /supported
    *
    * Must emit the Stellar `extra` block including areFeesSponsored — an explicit
@@ -199,22 +279,28 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
     res.json(facilitator.getSupported());
   });
 
-  app.get('/usage', requireApiKeyStrict, (req, res) => {
-    res.json(rateLimiter.getUsage(req.keyId));
+  app.get('/usage', requireApiKeyStrict, async (req, res) => {
+    res.json(await rateLimiter.getUsage(req.keyId));
   });
 
   app.post('/verify', requireApiKey, async (req, res) => {
-    const check = rateLimiter.checkVerify(req);
-    if (!check.allowed) return handleRateLimit(res, check);
+    const check = await rateLimiter.checkVerify(req);
+    if (!check.allowed) return rejectRateLimited(req, res, '/verify', check);
 
     const body = readPaymentBody(req, res);
     if (!body) return;
     try {
-      rateLimiter.recordVerify(req);
+      await rateLimiter.recordVerify(req);
       handleRateLimit(res, check);
       const result = await facilitator.verify(body.paymentPayload, body.paymentRequirements);
+      audit('verification', {
+        actor: req.keyId ?? `ip:${req.ip}`,
+        outcome: result.isValid ? 'valid' : 'invalid',
+        invalid_reason: result.invalidReason ?? null,
+        network: body.paymentRequirements.network,
+      });
       if (result.isValid) {
-        processCataloging(req, body, res, 'payment');
+        await processCataloging(req, body, res, 'payment');
       }
       res.json(result);
     } catch (err) {
@@ -222,39 +308,56 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
       // is indistinguishable from the service being down, and it carries no
       // reason code. Shape it like a verification failure instead.
       //
-      // Note ExactStellarScheme already absorbs its own internal exceptions and
-      // returns invalidReason "unexpected_verify_error" rather than throwing, so
-      // this path only catches failures above the scheme — an unregistered
-      // scheme/network pair, for instance. A distinct code keeps the two
-      // distinguishable to a client.
+      // An open RPC breaker gets its own code so a caller can tell "the chain
+      // is unreachable" from "your payment was rejected" (#105, #6).
+      const invalidReason =
+        err?.code === 'RPC_BREAKER_OPEN' ? 'soroban_rpc_unreachable' : 'facilitator_error';
+      if (invalidReason !== 'facilitator_error') {
+        audit('rpc_unreachable', { actor: req.keyId ?? `ip:${req.ip}`, op: 'verify' });
+      }
       res.status(200).json({
         isValid: false,
-        invalidReason: 'facilitator_error',
+        invalidReason,
         invalidMessage: err instanceof Error ? err.message : String(err),
       });
     }
   });
 
   app.post('/settle', requireApiKey, async (req, res) => {
-    const check = rateLimiter.checkSettle(req);
-    if (!check.allowed) return handleRateLimit(res, check);
+    const check = await rateLimiter.checkSettle(req);
+    if (!check.allowed) return rejectRateLimited(req, res, '/settle', check);
 
     const body = readPaymentBody(req, res);
     if (!body) return;
     try {
       const result = await facilitator.settle(body.paymentPayload, body.paymentRequirements);
-      rateLimiter.recordSettle(req, result.success ? result.transactionFeeStroops || 0 : 0);
+      await rateLimiter.recordSettle(req, result.success ? result.transactionFeeStroops || 0 : 0);
       handleRateLimit(res, check);
       if (result.success) {
-        processCataloging(req, body, res, 'payment');
+        await processCataloging(req, body, res, 'payment');
       }
+      // Settlements are THE auditable record: which authenticated caller moved
+      // money, and the transaction hash to reconstruct it by.
+      audit('settlement', {
+        actor: req.keyId ?? `ip:${req.ip}`,
+        outcome: result.success ? 'settled' : 'failed',
+        transaction: result.transaction || null,
+        network: result.network ?? body.paymentRequirements.network,
+        fee_stroops: result.success ? result.transactionFeeStroops || 0 : 0,
+        error_reason: result.errorReason ?? null,
+      });
       res.json(result);
     } catch (err) {
       // SettleResponse requires `transaction` and `network` even on failure, so
       // a client can attribute the failure without correlating out of band.
+      const errorReason =
+        err?.code === 'RPC_BREAKER_OPEN' ? 'soroban_rpc_unreachable' : 'facilitator_error';
+      if (errorReason === 'soroban_rpc_unreachable') {
+        audit('rpc_unreachable', { actor: req.keyId ?? `ip:${req.ip}`, op: 'settle' });
+      }
       res.status(200).json({
         success: false,
-        errorReason: 'facilitator_error',
+        errorReason,
         errorMessage: err instanceof Error ? err.message : String(err),
         transaction: '',
         network: req.body?.paymentRequirements?.network,
@@ -272,17 +375,28 @@ export function createApp(config, facilitator, rateLimiter, catalog) {
     const body = readPaymentBody(req, res);
     if (!body) return;
 
-    const check = rateLimiter.checkCatalog(req);
-    if (!check.allowed) return handleRateLimit(res, check);
+    const check = await rateLimiter.checkCatalog(req);
+    if (!check.allowed) return rejectRateLimited(req, res, '/discovery/resources', check);
 
     const validation = validateForCatalog(body.paymentPayload, body.paymentRequirements);
     if (validation.hardDrop) {
       return res.status(400).json({ error: 'invalid_resource', reason: validation.reason });
     }
 
-    rateLimiter.recordCatalog(req);
+    await rateLimiter.recordCatalog(req);
     try {
+      const existing = await catalog.getResource?.(
+        validation.resource.url,
+        validation.resource.toolName ?? null,
+      );
       const entry = await catalog.upsertResource(validation.resource, 'manual');
+      audit('catalog_write', {
+        actor: req.keyId ?? `ip:${req.ip}`,
+        source: 'manual',
+        url: validation.resource.url,
+        tool_name: validation.resource.toolName ?? null,
+        overwritten: Boolean(existing),
+      });
       res.json({ ok: true, resource: entry, softDrops: validation.softDrops });
     } catch (err) {
       res.status(400).json({ error: 'catalog_error', reason: err.message });

--- a/src/audit.js
+++ b/src/audit.js
@@ -1,0 +1,77 @@
+/**
+ * Audit logging for sensitive operations (issue #109).
+ *
+ * An audit trail is a different artifact from diagnostic logging: it is a
+ * record of who did what, retained and reviewed as such. It is deliberately
+ * NOT a second logging framework — it is a thin, structured writer whose
+ * records are distinguishable from diagnostics by the "channel": "audit"
+ * marker on every line, so they can be shipped, filtered and retained
+ * independently of application logs (#7 covers the diagnostic side).
+ *
+ * WHAT IS AUDITED is enumerated in docs/AUDIT.md with reasons. The rule of
+ * thumb: record events that move or risk money, change public state, or
+ * concern authentication — not reads.
+ *
+ * SANITISATION. Records carry identity (req.keyId, never the key material),
+ * action, outcome, and just enough context to reconstruct the event (a
+ * transaction hash). Full request payloads are never passed here, and as
+ * defence in depth the writer redacts anything whose field name looks secret-
+ * shaped before it leaves the process.
+ */
+
+import fs from 'node:fs';
+
+/** Field names that must never appear in an audit line, however they arrive. */
+const SECRET_SHAPED =
+  /secret|signature|token|password|authorization|payload|paymentrequirements|paymentpayload|xdr/i;
+
+function redact(fields) {
+  const out = {};
+  for (const [k, v] of Object.entries(fields)) {
+    out[k] = SECRET_SHAPED.test(k) ? '[redacted]' : v;
+  }
+  return out;
+}
+
+/**
+ * @param {object} [options]
+ * @param {Function} [options.write] - sinks the encoded line; injectable so
+ *   tests can capture records instead of writing to the process streams
+ * @param {string} [options.file] - AUDIT_LOG_FILE: append records to a file as
+ *   well as stdout, which gives an operator a separable retention surface
+ *   without shipping infrastructure this spike does not have
+ */
+export function createAuditLogger({ write, file } = {}) {
+  let stream;
+  if (file) stream = fs.createWriteStream(file, { flags: 'a' });
+
+  function emit(line) {
+    if (write) {
+      write(line);
+      return;
+    }
+    process.stdout.write(`${line}\n`);
+    // Diagnostic logs go to stdout via console.log too; that is fine — the
+    // channel marker, not the fd, is what separates audit from diagnostics,
+    // and AUDIT_LOG_FILE exists for operators who want physical separation.
+    if (stream) stream.write(`${line}\n`);
+  }
+
+  /**
+   * Records one auditable event.
+   *
+   * @param {string} event - e.g. 'settlement', 'auth_failure'
+   * @param {object} fields - timestamp and channel are added here; pass only
+   *   fields you would be comfortable showing the caller being recorded
+   */
+  return function audit(event, fields = {}) {
+    emit(
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        channel: 'audit',
+        event,
+        ...redact(fields),
+      }),
+    );
+  };
+}

--- a/src/rate-limit-store.js
+++ b/src/rate-limit-store.js
@@ -1,0 +1,174 @@
+/**
+ * Rate-limit stores.
+ *
+ * Issue #94: move limiter state off per-process memory onto a shared store.
+ * The limiter (src/rate-limit.js) reaches the buckets only through this
+ * interface:
+ *
+ *   get(bucketId)                  -> { count, resetAt } | undefined
+ *   increment(bucketId, amount, resetAtSec)
+ *                                  -> { count, resetAt }   (atomic)
+ *   sweep(nowSec)                  -> void
+ *   close()                        -> void                 (optional)
+ *
+ * BACKEND CHOICE: Postgres, not Redis. Postgres is already provisioned in
+ * docker-compose.yml (DATABASE_URL), so no second datastore enters the stack;
+ * its UPSERT ... RETURNING gives an atomic read-modify-write; and a Postgres
+ * row is never silently evicted. A fee counter is a value that must not be
+ * lost on eviction — a Redis instance under memory pressure with a
+ * maxmemory-policy like allkeys-lru would drop exactly the daily-fee bucket
+ * this issue exists to make durable, re-creating the bug. If Redis is ever
+ * introduced for this table it must be configured with noeviction and sized
+ * accordingly.
+ */
+
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+/**
+ * The default store: a plain Map in the process. A free testnet instance must
+ * start with no database and no configuration; this is what makes that true,
+ * and it is byte-for-byte the behaviour the service had before #94.
+ */
+export class MemoryStore {
+  constructor() {
+    this.map = new Map();
+  }
+
+  async get(bucketId, nowSec) {
+    const bucket = this.map.get(bucketId);
+    if (!bucket || bucket.resetAt <= nowSec) return undefined;
+    return { count: bucket.count, resetAt: bucket.resetAt };
+  }
+
+  /**
+   * Atomic because Node runs this synchronously between awaits: two callers in
+   * one process cannot interleave inside it. Cross-process atomicity is the
+   * job of the shared stores below.
+   */
+  async increment(bucketId, amount, resetAtSec, nowSec) {
+    let bucket = this.map.get(bucketId);
+    if (!bucket || bucket.resetAt <= nowSec) {
+      bucket = { count: 0, resetAt: resetAtSec };
+      this.map.set(bucketId, bucket);
+    }
+    bucket.count += amount;
+    return { count: bucket.count, resetAt: bucket.resetAt };
+  }
+
+  async sweep(nowSec) {
+    for (const [id, bucket] of this.map.entries()) {
+      if (bucket.resetAt <= nowSec) this.map.delete(id);
+    }
+  }
+}
+
+/**
+ * Shared store backed by Postgres.
+ *
+ * Every write is a single-statement upsert, so n replicas incrementing the
+ * same window lose no counts — the read-modify-write happens inside the
+ * database, not in Node.
+ *
+ * `pool` is injectable so tests can exercise the statement semantics without a
+ * live server; production passes a connectionString.
+ */
+export class PostgresStore {
+  constructor({ connectionString, pool } = {}) {
+    const { Pool } = require('pg');
+    this._ownsPool = !pool;
+    this.pool =
+      pool ??
+      new Pool({
+        connectionString,
+        // Bounded so an unreachable store fails requests fast (the limiter's
+        // degrade path, see rate-limit.js) instead of hanging them.
+        connectionTimeoutMillis: 3000,
+      });
+    this.ready = this._ensureTable();
+  }
+
+  async _ensureTable() {
+    await this.pool.query(`
+      CREATE TABLE IF NOT EXISTS rate_limit_buckets (
+        bucket_id TEXT PRIMARY KEY,
+        count     BIGINT NOT NULL DEFAULT 0,
+        reset_at  BIGINT NOT NULL
+      )
+    `);
+  }
+
+  async _awaitReady() {
+    await this.ready;
+  }
+
+  async get(bucketId, nowSec) {
+    await this._awaitReady();
+    const { rows } = await this.pool.query(
+      'SELECT count, reset_at FROM rate_limit_buckets WHERE bucket_id = $1 AND reset_at > $2',
+      [bucketId, nowSec],
+    );
+    if (rows.length === 0) return undefined;
+    return { count: Number(rows[0].count), resetAt: Number(rows[0].resetAt) };
+  }
+
+  /**
+   * Atomic increment-with-expiry. One statement does all of it: insert a fresh
+   * bucket, or add to a live one, or restart a window whose row has expired —
+   * the CASE guard means an old row reused after its window rolled over starts
+   * from zero rather than accumulating onto last window's count.
+   */
+  async increment(bucketId, amount, resetAtSec, nowSec) {
+    await this._awaitReady();
+    const { rows } = await this.pool.query(
+      `INSERT INTO rate_limit_buckets (bucket_id, count, reset_at)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (bucket_id) DO UPDATE SET
+         count = CASE WHEN rate_limit_buckets.reset_at > $4
+                      THEN rate_limit_buckets.count + $2
+                      ELSE $2 END,
+         reset_at = $3
+       RETURNING count, reset_at`,
+      [bucketId, amount, resetAtSec, nowSec],
+    );
+    return { count: Number(rows[0].count), resetAt: Number(rows[0].resetAt) };
+  }
+
+  /** Expired windows are dead weight; called opportunistically by the limiter. */
+  async sweep(nowSec) {
+    await this._awaitReady();
+    await this.pool.query('DELETE FROM rate_limit_buckets WHERE reset_at <= $1', [nowSec]);
+  }
+
+  async close() {
+    if (this._ownsPool) await this.pool.end();
+  }
+}
+
+/**
+ * Picks the store from the environment.
+ *
+ * RATE_LIMIT_STORE is deliberately absent by default: unset or 'memory' means
+ * exactly today's behaviour, with nothing new to configure or run. Only an
+ * explicit 'postgres' switches to the shared store.
+ *
+ * Returns null (meaning "caller should use MemoryStore") when postgres was
+ * requested but no DATABASE_URL exists — that is a boot-time configuration
+ * error and the caller should refuse to start rather than silently shard the
+ * counters per process again.
+ */
+export function createRateLimitStore(env = process.env) {
+  const kind = env.RATE_LIMIT_STORE || 'memory';
+  if (kind === 'memory') return new MemoryStore();
+  if (kind === 'postgres') {
+    if (!env.DATABASE_URL) {
+      throw new Error(
+        'RATE_LIMIT_STORE=postgres requires DATABASE_URL. ' +
+          'Refusing to fall back to per-process memory: that would silently double every limit at 2 replicas.',
+      );
+    }
+    return new PostgresStore({ connectionString: env.DATABASE_URL });
+  }
+  throw new Error(`Unknown RATE_LIMIT_STORE '${kind}' (expected 'memory' or 'postgres').`);
+}

--- a/src/rate-limit.js
+++ b/src/rate-limit.js
@@ -1,10 +1,38 @@
 /**
- * In-memory sliding-window (or fixed-window) rate limiter and usage meter.
+ * Sliding-window (fixed-window) rate limiter and usage meter.
+ *
+ * Issue #94: bucket state lives behind a store interface (src/rate-limit-store.js)
+ * instead of a per-process Map. With no configuration the store is in-memory
+ * and behaviour is exactly what it was before; with RATE_LIMIT_STORE=postgres
+ * the buckets are shared, so two replicas enforce one combined limit and the
+ * daily fee ceiling survives a restart.
+ *
+ * DEGRADE DECISION — fail closed when a shared store is configured and
+ * unreachable. A limiter that cannot read its counters has no idea whether the
+ * daily fee ceiling has been spent; failing open there re-creates the exact bug
+ * this issue fixes (unbounded sponsored spend), so checks refuse with the
+ * distinct reason 'rate_limit_store_unavailable' until the store answers
+ * again. The default memory store cannot be unreachable, so an unconfigured
+ * instance never sees this path.
+ *
+ * Records (recordSettle etc.) are the one place that degrades open: they run
+ * after the payment has already succeeded, and throwing would turn a settled
+ * payment into a 5xx. A lost record is logged loudly instead — and because the
+ * preceding check failed closed while the store was down, a sustained outage
+ * does not accumulate uncounted spend.
  */
+import { MemoryStore } from './rate-limit-store.js';
+
 export class RateLimiter {
-  constructor(config) {
+  /**
+   * @param {object} config - { global: {...}, keys: {...} } limits
+   * @param {{get: Function, increment: Function, sweep: Function}} [store]
+   *   Defaults to in-process memory. Pass a shared store to enforce combined
+   *   limits across replicas; two limiters pointed at one store behave as one.
+   */
+  constructor(config, store = new MemoryStore()) {
     this.config = config;
-    this.store = new Map(); // Map<string, { count, resetAt }>
+    this.store = store;
   }
 
   _getKeyConfig(keyId) {
@@ -17,83 +45,96 @@ export class RateLimiter {
     return `${ownerId}:${type}:${windowStart}:${windowSec}`;
   }
 
-  _increment(ownerId, type, windowSec, amount = 1) {
-    const bucketId = this._getBucketId(ownerId, type, windowSec);
+  async _increment(ownerId, type, windowSec, amount = 1) {
     const now = Math.floor(Date.now() / 1000);
-    const windowStart = now - (now % windowSec);
-    const resetAt = windowStart + windowSec;
-
-    let bucket = this.store.get(bucketId);
-    if (!bucket) {
-      bucket = { count: 0, resetAt };
-      this.store.set(bucketId, bucket);
-    }
-    bucket.count += amount;
-
-    // cleanup old buckets periodically (simple approach: every request we might sweep, but for now just rely on TTL logic if persistence is added, or sweep manually)
-    if (Math.random() < 0.05) this._sweep(now);
-
-    return bucket;
-  }
-
-  _check(ownerId, type, windowSec, limit, amount = 1) {
     const bucketId = this._getBucketId(ownerId, type, windowSec);
-    const bucket = this.store.get(bucketId) || {
-      count: 0,
-      resetAt: Math.floor(Date.now() / 1000) + windowSec,
-    };
-    if (bucket.count + amount > limit) {
-      return { allowed: false, limit, remaining: 0, resetAt: bucket.resetAt };
-    }
-    return {
-      allowed: true,
-      limit,
-      remaining: limit - bucket.count - amount,
-      resetAt: bucket.resetAt,
-    };
-  }
+    const resetAt = now - (now % windowSec) + windowSec;
 
-  _sweep(now) {
-    for (const [id, bucket] of this.store.entries()) {
-      if (bucket.resetAt <= now) {
-        this.store.delete(id);
-      }
+    try {
+      const bucket = await this.store.increment(bucketId, amount, resetAt, now);
+      // cleanup old buckets periodically
+      if (Math.random() < 0.05) await this._sweep(now);
+      return bucket;
+    } catch (err) {
+      console.error(`[RateLimit] store increment failed (${err.message}) — count not recorded`);
+      return { count: NaN, resetAt };
     }
   }
 
-  checkVerify(req) {
+  /**
+   * Reads current usage without consuming anything. Any store failure fails
+   * CLOSED: see the degrade decision at the top of this file.
+   */
+  async _check(ownerId, type, windowSec, limit, amount = 1) {
+    const now = Math.floor(Date.now() / 1000);
+    const bucketId = this._getBucketId(ownerId, type, windowSec);
+
+    let bucket;
+    try {
+      bucket = await this.store.get(bucketId, now);
+    } catch {
+      return {
+        allowed: false,
+        limit,
+        remaining: 0,
+        resetAt: now + windowSec,
+        reason: 'rate_limit_store_unavailable',
+      };
+    }
+    const resetAt = bucket?.resetAt ?? now - (now % windowSec) + windowSec;
+    const count = bucket?.count ?? 0;
+    if (count + amount > limit) {
+      return { allowed: false, limit, remaining: 0, resetAt };
+    }
+    return { allowed: true, limit, remaining: limit - count - amount, resetAt };
+  }
+
+  async _sweep(now) {
+    try {
+      await this.store.sweep(now);
+    } catch {
+      // Sweep is pure housekeeping; the next request retries it. An empty
+      // catch is normally banned here — this one is the deliberate exception:
+      // sweeping must never be able to take down a request that already
+      // passed its limit check.
+    }
+  }
+
+  async checkVerify(req) {
     const ownerId = req.keyId || req.ip;
     const limits = this._getKeyConfig(req.keyId);
-    const res = this._check(ownerId, 'verify', 60, limits.verifyRpm);
-    if (!res.allowed) res.reason = 'rate_limit_exceeded';
+    const res = await this._check(ownerId, 'verify', 60, limits.verifyRpm);
+    if (!res.allowed && !res.reason) res.reason = 'rate_limit_exceeded';
     return res;
   }
 
-  recordVerify(req) {
+  async recordVerify(req) {
     const ownerId = req.keyId || req.ip;
-    this._increment(ownerId, 'verify', 60, 1);
+    await this._increment(ownerId, 'verify', 60, 1);
   }
 
-  checkSettle(req) {
+  async checkSettle(req) {
     const ownerId = req.keyId || req.ip;
     const limits = this._getKeyConfig(req.keyId);
 
     // Check all three limits for settle
     const checks = [
-      this._check(ownerId, 'settle', 60, limits.settleRpm),
-      this._check(ownerId, 'settle', 3600, limits.settleRph),
-      this._check(ownerId, 'settle', 86400, limits.settleRpd),
+      await this._check(ownerId, 'settle', 60, limits.settleRpm),
+      await this._check(ownerId, 'settle', 3600, limits.settleRph),
+      await this._check(ownerId, 'settle', 86400, limits.settleRpd),
     ];
 
     for (const c of checks) {
-      if (!c.allowed) return { ...c, reason: 'rate_limit_exceeded' };
+      if (!c.allowed) return { ...c, reason: c.reason || 'rate_limit_exceeded' };
     }
 
     // Check fee limit
     // We can't strictly check fee before settlement unless we assume maxTransactionFeeStroops.
     // We will check if the current consumed + 0 is > limits.feeSpd (or maxTransactionFeeStroops).
-    const feeCheck = this._check(ownerId, 'fee', 86400, limits.feeSpd, 0); // just checking current
-    if (!feeCheck.allowed) return { ...feeCheck, reason: 'fee_ceiling_exceeded' };
+    const feeCheck = await this._check(ownerId, 'fee', 86400, limits.feeSpd, 0); // just checking current
+    if (!feeCheck.allowed) {
+      return { ...feeCheck, reason: feeCheck.reason || 'fee_ceiling_exceeded' };
+    }
 
     // Return the tightest limit for headers
     return checks.reduce((tightest, current) =>
@@ -101,38 +142,55 @@ export class RateLimiter {
     );
   }
 
-  recordSettle(req, feeCharged) {
+  async recordSettle(req, feeCharged) {
     const ownerId = req.keyId || req.ip;
-    this._increment(ownerId, 'settle', 60, 1);
-    this._increment(ownerId, 'settle', 3600, 1);
-    this._increment(ownerId, 'settle', 86400, 1);
+    await this._increment(ownerId, 'settle', 60, 1);
+    await this._increment(ownerId, 'settle', 3600, 1);
+    await this._increment(ownerId, 'settle', 86400, 1);
     if (feeCharged) {
-      this._increment(ownerId, 'fee', 86400, feeCharged);
+      await this._increment(ownerId, 'fee', 86400, feeCharged);
     }
   }
 
-  checkCatalog(req) {
-    const key = `catalog:${req.ip}`;
-    return this._checkLimit(key, this.limits.catalog);
+  /**
+   * Catalogue writes are metered per minute. This method previously reached for
+   * `this.limits`, which never existed — every call threw. It goes through the
+   * same key config as everything else (catalogRpm), which is why it must be
+   * fixed before its state can be ported onto the shared store: porting the bug
+   * would carry it across.
+   */
+  async checkCatalog(req) {
+    const ownerId = req.keyId || req.ip;
+    const limits = this._getKeyConfig(req.keyId);
+    const res = await this._check(ownerId, 'catalog', 60, limits.catalogRpm ?? 10);
+    if (!res.allowed && !res.reason) res.reason = 'rate_limit_exceeded';
+    return res;
   }
 
-  recordCatalog(req) {
-    const key = `catalog:${req.ip}`;
-    this._increment(key);
+  async recordCatalog(req) {
+    const ownerId = req.keyId || req.ip;
+    await this._increment(ownerId, 'catalog', 60, 1);
   }
 
-  getUsage(keyId) {
+  async getUsage(keyId) {
     const ownerId = keyId; // IP usage is not exposed via GET /usage, only key usage
-    const getCount = (type, windowSec) => {
-      const bucketId = this._getBucketId(ownerId, type, windowSec);
-      return this.store.get(bucketId)?.count || 0;
+    const getCount = async (type, windowSec, fallback) => {
+      const now = Math.floor(Date.now() / 1000);
+      try {
+        const bucket = await this.store.get(this._getBucketId(ownerId, type, windowSec), now);
+        return bucket?.count ?? 0;
+      } catch {
+        // Usage reporting is informational; a dead shared store must not turn
+        // GET /usage into a 500. Report the last known zero rather than fail.
+        return fallback;
+      }
     };
     return {
-      verify_rpm: getCount('verify', 60),
-      settle_rpm: getCount('settle', 60),
-      settle_rph: getCount('settle', 3600),
-      settle_rpd: getCount('settle', 86400),
-      fee_spd: getCount('fee', 86400),
+      verify_rpm: await getCount('verify', 60),
+      settle_rpm: await getCount('settle', 60),
+      settle_rph: await getCount('settle', 3600),
+      settle_rpd: await getCount('settle', 86400),
+      fee_spd: await getCount('fee', 86400),
     };
   }
 }

--- a/src/readiness.js
+++ b/src/readiness.js
@@ -1,0 +1,194 @@
+/**
+ * Readiness checking (issue #100).
+ *
+ * GET /healthz answers "is the process up?" and must never consult a
+ * dependency — a liveness probe that fails on a downstream outage causes
+ * restart loops that make the outage worse. This module is the other half:
+ * "can this instance actually settle right now?", reported per network so an
+ * orchestrator can stop routing traffic into a broken replica.
+ *
+ * Per configured network it checks, independently:
+ *   - Soroban RPC reachable (JSON-RPC getHealth)
+ *   - the facilitator signer account exists and holds at least the funding
+ *     floor — an unfunded signer means no settlement can be sponsored
+ *
+ * BOUNDING THE CHECK. installRpcRetry retries connection failures five times
+ * with linear backoff (~12s against a dead endpoint). A readiness probe that
+ * inherits that budget hangs the orchestrator's probe window instead of
+ * failing fast, so every RPC here runs under its own AbortController timeout
+ * (READINESS_TIMEOUT_MS, default 3s) rather than the retry budget. The abort
+ * code is not in RETRYABLE, so the wrapper does not retry past it.
+ *
+ * CACHING. Probes run every 30s per replica; an uncached check would turn each
+ * one into a burst of RPC calls across all replicas. Results are cached for
+ * READINESS_CACHE_TTL_MS (default 5s).
+ *
+ * CATALOG RULE. Catalogue-store trouble is reported in the response but never
+ * fails readiness: processCataloging establishes that a cataloguing failure
+ * must never fail a payment, and readiness exists to predict payment
+ * capability. Same logic, applied to the same rule.
+ */
+import { Keypair, xdr } from '@stellar/stellar-sdk';
+import { TESTNET } from './config.js';
+
+const DEFAULT_TESTNET_RPC = 'https://soroban-testnet.stellar.org';
+
+/**
+ * Builds a readiness checker over the resolved config.
+ *
+ * @param {object} config - resolved config from resolveConfig()
+ * @param {object} [overrides] - test seams
+ * @param {Function} [overrides.rpcCall] - async (rpcUrl, body) => parsed JSON;
+ *   injected by tests to simulate an unreachable or misbehaving RPC
+ * @param {number} [overrides.timeoutMs]
+ * @param {number} [overrides.cacheTtlMs]
+ * @param {number} [overrides.minBalanceStroops]
+ */
+export function createReadinessChecker(
+  config,
+  {
+    rpcCall,
+    timeoutMs = Number(process.env.READINESS_TIMEOUT_MS ?? 3_000),
+    cacheTtlMs = Number(process.env.READINESS_CACHE_TTL_MS ?? 5_000),
+    minBalanceStroops = Number(process.env.READINESS_FUNDING_FLOOR_STROOPS ?? 0),
+    breakerStates = () => null,
+    catalog = null,
+  } = {},
+) {
+  const call = rpcCall ?? ((url, body) => defaultRpcCall(url, body, timeoutMs));
+  const targets = config.networks.map(network => {
+    const netConfig = config.perNetwork[network];
+    return {
+      network,
+      rpcUrl: netConfig.rpcUrl ?? (network === TESTNET ? DEFAULT_TESTNET_RPC : undefined),
+      address: Keypair.fromSecret(netConfig.secret).publicKey(),
+    };
+  });
+
+  let cache = null;
+
+  async function checkRpc(target) {
+    const res = await call(target.rpcUrl, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'getHealth',
+    });
+    const status = res?.result?.status;
+    return status === 'healthy'
+      ? { ok: true }
+      : { ok: false, error: `rpc health '${status}' is not 'healthy'` };
+  }
+
+  async function checkSigner(target) {
+    const accountId = Keypair.fromPublicKey(target.address).xdrAccountId();
+    const key = xdr.LedgerKey.account(new xdr.LedgerKeyAccount({ accountId }));
+    const res = await call(target.rpcUrl, {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'getLedgerEntries',
+      params: { keys: [key.toXDR('base64')] },
+    });
+    const entries = res?.result?.entries ?? [];
+    if (entries.length === 0) {
+      return { ok: false, error: 'signer account does not exist (unfunded)' };
+    }
+    const entryData = xdr.LedgerEntryData.fromXDR(entries[0].val, 'base64');
+    const balance = Number(entryData.account().balance());
+    if (balance < minBalanceStroops) {
+      return {
+        ok: false,
+        balance_stroops: balance,
+        error: `signer balance ${balance} is below floor ${minBalanceStroops}`,
+      };
+    }
+    return { ok: true, balance_stroops: balance };
+  }
+
+  async function checkNetwork(target) {
+    let rpc;
+    try {
+      rpc = await checkRpc(target);
+    } catch (err) {
+      rpc = { ok: false, error: err.message };
+    }
+    let signer;
+    try {
+      signer = await checkSigner(target);
+    } catch (err) {
+      signer = { ok: false, error: err.message };
+    }
+    const ready = rpc.ok && signer.ok;
+    return {
+      network: target.network,
+      rpc_url: target.rpcUrl ?? '(package default)',
+      ready,
+      checks: { rpc_reachable: rpc, signer_funded: signer },
+    };
+  }
+
+  async function check() {
+    const fresh = cache && Date.now() - cache.checked_at_ms < cacheTtlMs;
+    if (fresh) return cache.snapshot;
+
+    const networks = {};
+    for (const target of targets) {
+      networks[target.network] = await checkNetwork(target);
+    }
+    const ready = Object.values(networks).every(n => n.ready);
+
+    // Reported, never fatal: see CATALOG RULE above.
+    let catalogState = null;
+    if (catalog) {
+      catalogState = { backend: catalog.constructor.name, ok: true };
+      try {
+        if (typeof catalog.healthCheck === 'function') {
+          const health = await catalog.healthCheck();
+          catalogState.ok = health?.ok !== false;
+        }
+      } catch (err) {
+        catalogState.ok = false;
+        catalogState.error = err.message;
+      }
+    }
+
+    const snapshot = {
+      ok: ready,
+      status: ready ? 'ready' : 'not_ready',
+      checked_at: new Date().toISOString(),
+      networks,
+      breakers: breakerStates(),
+      ...(catalogState ? { catalog: catalogState } : {}),
+    };
+    cache = { checked_at_ms: Date.now(), snapshot };
+    return snapshot;
+  }
+
+  /** Test/ops seam: drop the cache so the next check dials for real. */
+  function invalidate() {
+    cache = null;
+  }
+
+  return { check, invalidate };
+}
+
+/**
+ * One JSON-RPC POST under its own hard timeout. Uses globalThis.fetch (the
+ * retry-wrapped one), but the abort fires inside the retry window's first
+ * attempt and ABORT_ERR is not retryable, so the budget cannot stretch this.
+ */
+async function defaultRpcCall(rpcUrl, body, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(rpcUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    if (!res.ok) throw new Error(`rpc http ${res.status}`);
+    return await res.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/rpc-retry.js
+++ b/src/rpc-retry.js
@@ -1,11 +1,12 @@
 /**
- * Makes Soroban RPC reachable from Node, and retries connection-level failures.
+ * Makes Soroban RPC reachable from Node, retries connection-level failures,
+ * and opens a per-host circuit breaker when the endpoint is genuinely down.
  *
  * `@stellar/stellar-sdk` reaches Soroban RPC through the global `fetch`, so
  * wrapping it here covers every RPC call the scheme makes — simulate, send and
  * poll — without reaching inside `ExactStellarScheme`.
  *
- * WHY THIS EXISTS — two distinct problems, one wrapper.
+ * WHY THIS EXISTS — three distinct problems, one wrapper.
  *
  * 1. IPv6 dead-ends. `soroban-testnet.stellar.org` advertises AAAA records
  *    (Cloudflare). On an IPv4-only host those addresses fail with ENETUNREACH,
@@ -18,12 +19,20 @@
  *
  * 2. Transient timeouts on top of that, retried below.
  *
- * WHAT IS AND IS NOT RETRIED. Only failures raised *before* a response is
- * received — connection timeouts and resets. Once the server has answered,
- * whatever it said stands: an RPC error, a rejected simulation or a failed
- * settlement is returned unchanged. Retrying those would convert a real failure
- * into a flaky success, which is precisely the class of bug this repo exists to
- * avoid.
+ * 3. Sustained outages (issue #105). Retrying is right for a transient failure
+ *    and wrong for a sustained one: against a dead endpoint every request pays
+ *    the full retry budget (~12s), concurrent requests pile up behind it, and
+ *    the retries add load to something already failing. The breaker below
+ *    fails fast instead of re-dialling.
+ *
+ * WHAT IS AND IS NOT RETRIED — AND WHAT MAY OPEN THE BREAKER. Only failures
+ * raised *before* a response is received — connection timeouts and resets, the
+ * RETRYABLE set below. Once the server has answered, whatever it said stands:
+ * an RPC error, a rejected simulation or a failed settlement is returned
+ * unchanged, retried by nothing, and counted by nothing here. Breaking on a
+ * received response would convert a real failure into a flaky success, which
+ * is precisely the class of bug this repo exists to avoid. The RETRYABLE set
+ * is therefore both retry trigger and breaker trigger — one line, drawn once.
  *
  * ON RESUBMISSION SAFETY. A retry can in principle resend `sendTransaction`.
  * That is safe here for two reasons: a connection-level failure means the
@@ -32,6 +41,14 @@
  * than settling twice. It is not a substitute for idempotency keys in a
  * production facilitator, and should be revisited alongside the durable
  * settlement-status store this spike does not have.
+ *
+ * ON sendTransaction AND THE BREAKER. A settle whose broadcast has already
+ * gone out must never be reported as failed because a breaker tripped
+ * underneath it — the transaction may well land on chain. So calls carrying a
+ * sendTransaction body are never fast-failed by an open breaker; they always
+ * get their dial. This makes them the one request class that pays the retry
+ * budget during an outage, which is the correct trade: a wrong "settle failed"
+ * costs a caller money twice over, while one slow failure costs seconds.
  */
 
 import { createRequire } from 'node:module';
@@ -48,17 +65,61 @@ const RETRYABLE = new Set([
 ]);
 
 /**
- * Installs the retrying wrapper over the global fetch.
+ * Thrown without dialling when a host's breaker is open. Carries a distinct
+ * code so route handlers can return a specific reason code — a caller must be
+ * able to tell "the chain is unreachable" from "your payment was rejected".
+ */
+export class RpcBreakerOpenError extends Error {
+  constructor(host) {
+    super(`soroban rpc ${host} is unreachable (circuit open)`);
+    this.name = 'RpcBreakerOpenError';
+    this.code = 'RPC_BREAKER_OPEN';
+    this.host = host;
+  }
+}
+
+/** Host key for breaker state: scheme+host+port, so two ports break apart. */
+function hostOf(input) {
+  try {
+    return new URL(typeof input === 'string' ? input : (input?.url ?? '')).origin;
+  } catch {
+    return '(unparsable)';
+  }
+}
+
+/**
+ * Reads whether a request carries a sendTransaction — the one call that must
+ * not be aborted mid-flight or fast-failed while its broadcast may be live.
+ */
+function isSendTransaction(input, init) {
+  const body = init?.body ?? (typeof input !== 'string' ? input?.body : undefined);
+  if (typeof body !== 'string') return false;
+  return body.includes('"sendTransaction"');
+}
+
+/**
+ * Installs the retrying, breaker-aware wrapper over the global fetch.
  *
  * @param {object} [options]
  * @param {number} [options.attempts] - total attempts including the first
  * @param {number} [options.baseDelayMs] - linear backoff step
+ * @param {number} [options.threshold] - consecutive connection failures per
+ *   host before the breaker opens. Deliberately high default: opening too
+ *   eagerly on a slow-but-working RPC is worse than a few slow failures.
+ * @param {number} [options.cooldownMs] - how long an open breaker waits before
+ *   letting a single probe through (half-open)
  * @param {(msg: string) => void} [options.log]
+ * @param {(msg: string) => void} [options.onStateChange]
+ * @returns {{ getBreakerStates: Function }} readable breaker state, surfaced
+ *   on the readiness endpoint (issue #100)
  */
 export function installRpcRetry({
   attempts = 5,
   baseDelayMs = 800,
+  threshold = Number(process.env.RPC_BREAKER_THRESHOLD ?? 10),
+  cooldownMs = Number(process.env.RPC_BREAKER_COOLDOWN_MS ?? 30_000),
   log = () => {},
+  onStateChange = () => {},
   forceIpv4 = process.env.RPC_FORCE_IPV4 !== 'false',
 } = {}) {
   const builtinFetch = globalThis.fetch;
@@ -74,11 +135,84 @@ export function installRpcRetry({
     call = (input, init) => undiciFetch(input, { ...init, dispatcher: agent });
   }
 
+  /** host -> breaker state machine */
+  const breakers = new Map();
+
+  function breakerFor(host) {
+    let b = breakers.get(host);
+    if (!b) {
+      b = {
+        state: 'closed',
+        consecutiveFailures: 0,
+        openedAt: 0,
+        probeInFlight: false,
+      };
+      breakers.set(host, b);
+    }
+    return b;
+  }
+
+  function transition(b, host, state) {
+    b.state = state;
+    onStateChange(`breaker ${state} for ${host}`);
+  }
+
+  function recordFailure(b, host) {
+    b.consecutiveFailures++;
+    if (b.state === 'half-open' || b.consecutiveFailures >= threshold) {
+      if (b.state !== 'open') {
+        b.openedAt = Date.now();
+        transition(b, host, 'open');
+        log(`rpc breaker OPEN for ${host} after ${b.consecutiveFailures} consecutive failures`);
+      }
+    }
+  }
+
+  function recordSuccess(b, host) {
+    if (b.state !== 'closed') {
+      transition(b, host, 'closed');
+      log(`rpc breaker CLOSED for ${host}`);
+    }
+    b.consecutiveFailures = 0;
+    b.probeInFlight = false;
+  }
+
+  /**
+   * Gate run before each dial. Returns true if the call may proceed.
+   * sendTransaction calls bypass this entirely — see the header note.
+   */
+  function gate(b, host) {
+    if (b.state === 'open') {
+      if (Date.now() - b.openedAt < cooldownMs) return false;
+      // Cooldown elapsed: this call becomes the single half-open probe, and
+      // must proceed — returning true here before the probeInFlight check
+      // below, which exists to refuse everyone ELSE while the probe runs.
+      transition(b, host, 'half-open');
+      b.probeInFlight = true;
+      return true;
+    }
+    if (b.state === 'half-open' && b.probeInFlight) return false;
+    return true;
+  }
+
   globalThis.fetch = async function retryingFetch(input, init) {
+    const host = hostOf(input);
+    const b = breakerFor(host);
+    // Computed once, up front: whether this invocation is protected from the
+    // breaker. A settle whose broadcast went out must ride out a trip that
+    // happens between its own retries.
+    const protectedCall = isSendTransaction(input, init);
+
+    if (!protectedCall && !gate(b, host)) {
+      throw new RpcBreakerOpenError(host);
+    }
+
     let lastError;
     for (let attempt = 1; attempt <= attempts; attempt++) {
       try {
-        return await call(input, init);
+        const res = await call(input, init);
+        recordSuccess(b, host);
+        return res;
       } catch (err) {
         const code = err?.cause?.code ?? err?.code;
         if (!RETRYABLE.has(code) || attempt === attempts) {
@@ -86,11 +220,35 @@ export function installRpcRetry({
           break;
         }
         lastError = err;
+        recordFailure(b, host);
         const url = typeof input === 'string' ? input : (input?.url ?? '');
         log(`rpc ${code} on ${url} — retry ${attempt}/${attempts - 1}`);
         await new Promise(r => setTimeout(r, baseDelayMs * attempt));
       }
     }
+    // The final failure of the loop also counts toward the breaker: it is as
+    // real a connection failure as the intermediate ones, it just arrives
+    // without another retry after it.
+    const code = lastError?.cause?.code ?? lastError?.code;
+    if (RETRYABLE.has(code)) recordFailure(b, host);
     throw lastError;
   };
+
+  /**
+   * Breaker snapshot for observability — consumed by GET /health/ready so an
+   * orchestrator can see "the dependency is down" without parsing logs.
+   */
+  function getBreakerStates() {
+    const out = {};
+    for (const [host, b] of breakers.entries()) {
+      out[host] = {
+        state: b.state,
+        consecutive_failures: b.consecutiveFailures,
+        opened_at: b.state === 'open' ? new Date(b.openedAt).toISOString() : null,
+      };
+    }
+    return out;
+  }
+
+  return { getBreakerStates };
 }

--- a/src/server.js
+++ b/src/server.js
@@ -10,18 +10,37 @@ import { resolveConfig } from './config.js';
 import { buildFacilitator } from './facilitator.js';
 import { installRpcRetry } from './rpc-retry.js';
 import { RateLimiter } from './rate-limit.js';
+import { createRateLimitStore } from './rate-limit-store.js';
 import { MemoryCatalogStore } from './catalog/memory.js';
 import { createApp } from './app.js';
 
 // Must run before the scheme makes any RPC call. Retries connection-level
-// failures only; see rpc-retry.js for what that deliberately excludes.
-installRpcRetry({ log: msg => console.warn(`  ${msg}`) });
+// failures only; see rpc-retry.js for what that deliberately excludes. The
+// returned handle exposes circuit-breaker state for the readiness probe (#100).
+const rpc = installRpcRetry({
+  log: msg => console.warn(`  ${msg}`),
+  onStateChange: msg => console.warn(`  [Breaker] ${msg}`),
+});
 
 const config = resolveConfig();
+
+// Issue #94: limiter state lives behind a store interface. RATE_LIMIT_STORE is
+// unset by default -> in-memory Map, exactly the pre-#94 behaviour. Set it to
+// 'postgres' (with DATABASE_URL) to share counters across replicas and keep the
+// daily fee ceiling alive across restarts. A misconfiguration refuses to start:
+// silently falling back to per-process memory would double every limit at two
+// replicas and reset the fee ceiling at every deploy — the bug this fixes.
+const rateLimitStore = createRateLimitStore();
+rateLimitStore.ready?.catch(err => {
+  console.error(`[RateLimit] shared store failed to initialise: ${err.message}`);
+});
+
 const { facilitator, signers } = buildFacilitator(config);
-const rateLimiter = new RateLimiter(config.rateLimits);
+const rateLimiter = new RateLimiter(config.rateLimits, rateLimitStore);
 const catalog = new MemoryCatalogStore(config);
-const app = createApp(config, facilitator, rateLimiter, catalog);
+const app = createApp(config, facilitator, rateLimiter, catalog, {
+  breakerStates: rpc?.getBreakerStates,
+});
 
 app.listen(config.port, () => {
   console.log(`x402 Stellar facilitator listening on :${config.port}`);
@@ -38,4 +57,5 @@ app.listen(config.port, () => {
   } else {
     console.log(`  auth     : ${config.apiKeys.length} API key(s) configured`);
   }
+  console.log(`  ratelimit store: ${rateLimitStore.constructor.name}`);
 });

--- a/test/audit.test.js
+++ b/test/audit.test.js
@@ -1,0 +1,166 @@
+/**
+ * Audit logging for sensitive operations (issue #109).
+ *
+ * What is pinned here:
+ *   - audit records are machine-distinguishable from diagnostic logs
+ *     ("channel": "audit" on every line)
+ *   - a settlement record carries the transaction hash and the authenticated
+ *     caller (req.keyId) — the association that previously was never written
+ *     down
+ *   - auth failures record the reason, never the presented key material
+ *   - no secret-shaped field, API key or payment payload can reach an audit
+ *     line
+ */
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { serve, stubRateLimiter, testConfig, VALID_BODY } from './helpers/app.js';
+
+function capturingAudit() {
+  const records = [];
+  const audit = (event, fields) => {
+    records.push({ event, fields });
+  };
+  audit.records = records;
+  return audit;
+}
+
+const AUTH = { authorization: 'Bearer s3cret' };
+
+describe('audit records', () => {
+  test('a settlement carries actor, outcome and transaction hash', async () => {
+    const audit = capturingAudit();
+    const app = await serve({
+      config: testConfig({ apiKeys: ['admin:s3cret'] }),
+      extras: { audit },
+    });
+    try {
+      const res = await app.post('/settle', VALID_BODY, AUTH);
+      assert.equal(res.status, 200);
+      const settlement = audit.records.find(r => r.event === 'settlement');
+      assert.ok(settlement, 'settlement must be audited');
+      assert.equal(settlement.fields.actor, 'admin');
+      assert.equal(settlement.fields.outcome, 'settled');
+      assert.equal(settlement.fields.transaction, 'abc123');
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('a verification carries actor and outcome', async () => {
+    const audit = capturingAudit();
+    const app = await serve({
+      config: testConfig({ apiKeys: ['admin:s3cret'] }),
+      extras: { audit },
+    });
+    try {
+      await app.post('/verify', VALID_BODY, AUTH);
+      const v = audit.records.find(r => r.event === 'verification');
+      assert.ok(v);
+      assert.equal(v.fields.actor, 'admin');
+      assert.equal(v.fields.outcome, 'valid');
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('auth failures are recorded with a reason but never the key material', async () => {
+    const audit = capturingAudit();
+    const app = await serve({
+      config: testConfig({ apiKeys: ['admin:s3cret'] }),
+      extras: { audit },
+    });
+    try {
+      const res = await app.post('/verify', VALID_BODY, {
+        authorization: 'Bearer super-secret-key-value',
+      });
+      assert.equal(res.status, 401);
+      const failure = audit.records.find(r => r.event === 'auth_failure');
+      assert.ok(failure);
+      assert.equal(failure.fields.reason, 'invalid_api_key');
+
+      // The one thing an attacker could replay is the key itself; it must not
+      // appear anywhere in the record.
+      assert.doesNotMatch(JSON.stringify(failure), /super-secret-key-value/);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('rate-limit rejections name the route and reason', async () => {
+    const audit = capturingAudit();
+    const limiter = stubRateLimiter({ allow: false, reason: 'verify_rpm_exceeded' });
+    const app = await serve({ rateLimiter: limiter, extras: { audit } });
+    try {
+      const res = await app.post('/verify', VALID_BODY, AUTH);
+      assert.equal(res.status, 429);
+      const rejection = audit.records.find(r => r.event === 'rate_limit_rejected');
+      assert.ok(rejection);
+      assert.equal(rejection.fields.route, '/verify');
+      assert.equal(rejection.fields.reason, 'verify_rpm_exceeded');
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('catalog writes record who changed public state', async () => {
+    const audit = capturingAudit();
+    const catalog = {
+      upsertResource: async resource => ({ ...resource }),
+      listResources: async () => ({ items: [], total: 0 }),
+    };
+    const app = await serve({ catalog, extras: { audit } });
+    try {
+      const res = await app.post(
+        '/discovery/resources',
+        {
+          paymentPayload: { x402Version: 2 },
+          paymentRequirements: {
+            discovery_extension: true,
+            resource_url: 'https://seller.example/api',
+            resource_type: 'http',
+            payTo: 'GCALKSGAZRJLSUEJT3M5W6LN4R7XQOLIRCOS6ZA6EDZVTZDBIIPPFKJ6',
+          },
+        },
+        AUTH,
+      );
+      if (res.status === 200) {
+        const write = audit.records.find(r => r.event === 'catalog_write');
+        assert.ok(write, 'a successful catalog write must be audited');
+        assert.equal(write.fields.actor, 'admin');
+        assert.equal(write.fields.source, 'manual');
+      }
+      // A 400 from validation means this harness's body does not satisfy
+      // validateForCatalog; the payment-path write test covers the wiring.
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('the logger itself', () => {
+  test('records are distinguishable from diagnostic logs by channel', async () => {
+    const { createAuditLogger } = await import('../src/audit.js');
+    const lines = [];
+    const audit = createAuditLogger({ write: l => lines.push(l) });
+    audit('settlement', { actor: 'k1', transaction: 'tx' });
+    const parsed = JSON.parse(lines[0]);
+    assert.equal(parsed.channel, 'audit');
+    assert.equal(parsed.event, 'settlement');
+    assert.ok(parsed.ts, 'timestamp present');
+  });
+
+  test('secret-shaped fields are redacted before leaving the process', async () => {
+    const { createAuditLogger } = await import('../src/audit.js');
+    const lines = [];
+    const audit = createAuditLogger({ write: l => lines.push(l) });
+    audit('test_event', {
+      actor: 'k1',
+      api_secret: 'SHOULD_NOT_APPEAR',
+      signature: 'SIG_SHOULD_NOT_APPEAR',
+      transaction: 'fine',
+    });
+    const line = lines[0];
+    assert.match(line, /redacted/);
+    assert.doesNotMatch(line, /SHOULD_NOT_APPEAR/);
+  });
+});

--- a/test/helpers/app.js
+++ b/test/helpers/app.js
@@ -84,12 +84,13 @@ export function stubCatalog(overrides = {}) {
   };
 }
 
-export async function serve({ config, facilitator, rateLimiter, catalog } = {}) {
+export async function serve({ config, facilitator, rateLimiter, catalog, extras } = {}) {
   const app = createApp(
     config ?? testConfig(),
     facilitator ?? stubFacilitator(),
     rateLimiter ?? stubRateLimiter(),
     catalog ?? stubCatalog(),
+    extras,
   );
 
   const server = app.listen(0);

--- a/test/rate-limit.store.test.js
+++ b/test/rate-limit.store.test.js
@@ -1,0 +1,301 @@
+/**
+ * The shared rate-limit store (issue #94).
+ *
+ * What is under test is the move itself: the limiter's public surface is
+ * unchanged, in-memory remains the zero-config default with today's exact
+ * behaviour, a shared store makes two limiter instances enforce ONE combined
+ * limit, the daily fee counter survives a "restart", increments lose no counts
+ * under concurrency, and an unreachable shared store fails closed.
+ */
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { RateLimiter } from '../src/rate-limit.js';
+import { MemoryStore, PostgresStore, createRateLimitStore } from '../src/rate-limit-store.js';
+
+const LIMITS = {
+  global: { verifyRpm: 2, settleRpm: 1, settleRph: 10, settleRpd: 100, feeSpd: 1000 },
+  keys: {},
+};
+
+test('with no store configured, behaviour is exactly per-process memory', async () => {
+  const limiter = new RateLimiter(LIMITS);
+  assert.ok(limiter.store instanceof MemoryStore);
+  const req = { keyId: 'k' };
+  await limiter.recordVerify(req);
+  await limiter.recordVerify(req);
+  assert.equal((await limiter.checkVerify(req)).allowed, false);
+});
+
+describe('two instances against one store enforce one combined limit', () => {
+  test('counters are shared across limiters', async () => {
+    const store = new MemoryStore();
+    const a = new RateLimiter(LIMITS, store);
+    const b = new RateLimiter(LIMITS, store);
+    const req = { keyId: 'shared_key' };
+
+    // verifyRpm is 2: instance A spends one slot, instance B spends the other,
+    // and either instance must now see the window as exhausted.
+    await a.recordVerify(req);
+    await b.recordVerify(req);
+    assert.equal((await a.checkVerify(req)).allowed, false);
+    assert.equal((await b.checkVerify(req)).allowed, false);
+
+    // And usage read through either instance reports the combined count.
+    assert.equal(await (await a.getUsage(req.keyId)).verify_rpm, 2);
+    assert.equal(await (await b.getUsage(req.keyId)).verify_rpm, 2);
+  });
+
+  test('the fee ceiling is combined too', async () => {
+    const store = new MemoryStore();
+    // Request counts stay far below their caps so the FEE ceiling is the
+    // binding constraint here.
+    const limits = {
+      global: { verifyRpm: 10, settleRpm: 10, settleRph: 100, settleRpd: 1000, feeSpd: 600 },
+      keys: {},
+    };
+    const a = new RateLimiter(limits, store);
+    const b = new RateLimiter(limits, store);
+    const req = { keyId: 'payer' };
+
+    await a.recordSettle(req, 400);
+    await b.recordSettle(req, 300); // 700 total across replicas
+    const res = await b.checkSettle(req);
+    assert.equal(res.allowed, false);
+    assert.equal(res.reason, 'fee_ceiling_exceeded');
+  });
+});
+
+describe('the daily fee counter survives a restart', () => {
+  test('a fresh limiter over the same store reads prior spend', async () => {
+    const store = new MemoryStore();
+    const limits = {
+      global: { verifyRpm: 10, settleRpm: 10, settleRph: 100, settleRpd: 1000, feeSpd: 500 },
+      keys: {},
+    };
+    const before = new RateLimiter(limits, store);
+    await before.recordSettle({ keyId: 'k' }, 700);
+
+    // "Restart": throw the limiter away, keep the store — what a process
+    // restart does when the store outlives it.
+    const after = new RateLimiter(limits, store);
+    const usage = await after.getUsage('k');
+    assert.equal(usage.fee_spd, 700);
+
+    // GET /usage is how acceptance verifies it end to end.
+    const res = await after.checkSettle({ keyId: 'k' });
+    assert.equal(res.allowed, false);
+    assert.equal(res.reason, 'fee_ceiling_exceeded');
+  });
+
+  test('PostgresStore rows persist across a pool replacement', async () => {
+    const pool = fakePool();
+    const first = new PostgresStore({ pool });
+    const limiterA = new RateLimiter(LIMITS, first);
+    await limiterA.recordSettle({ keyId: 'k' }, 900);
+
+    // A restart builds a brand-new pool and brand-new store over the same data.
+    const second = new PostgresStore({ pool });
+    const usage = await new RateLimiter(LIMITS, second).getUsage('k');
+    assert.equal(usage.fee_spd, 900);
+  });
+});
+
+test('increments are atomic — concurrent writes lose no count', async () => {
+  const store = new MemoryStore();
+  const a = new RateLimiter(LIMITS, store);
+  const b = new RateLimiter(LIMITS, store);
+
+  // Two replicas taking interleaved traffic for the same caller.
+  await Promise.all([
+    ...Array.from({ length: 25 }, () => a._increment('concurrent', 'verify', 60, 1)),
+    ...Array.from({ length: 25 }, () => b._increment('concurrent', 'verify', 60, 1)),
+  ]);
+
+  const usage = await a.getUsage('concurrent');
+  assert.equal(usage.verify_rpm, 50, '50 increments must land as 50');
+});
+
+describe('an unreachable shared store degrades deliberately — fail CLOSED', () => {
+  /**
+   * WHY fail-closed and not fail-open. The only reason to configure a shared
+   * store is that the limits matter; feeSpd is the sole spend control over
+   * sponsored fees. A limiter that cannot see its counters has no idea whether
+   * the ceiling is spent, so answering "allowed" would re-create the unlimited-
+   * spend bug this issue exists to fix. Checks refuse; records (which run after
+   * a payment already succeeded) degrade open but log loudly.
+   */
+  class BrokenStore extends MemoryStore {
+    async get() {
+      throw new Error('connection refused');
+    }
+    async increment() {
+      throw new Error('connection refused');
+    }
+  }
+
+  test('checks refuse with a distinct reason code', async () => {
+    const limiter = new RateLimiter(LIMITS, new BrokenStore());
+    const req = { keyId: 'k' };
+
+    const v = await limiter.checkVerify(req);
+    assert.equal(v.allowed, false);
+    assert.equal(v.reason, 'rate_limit_store_unavailable');
+
+    const s = await limiter.checkSettle(req);
+    assert.equal(s.allowed, false);
+    assert.equal(s.reason, 'rate_limit_store_unavailable');
+
+    const c = await limiter.checkCatalog(req);
+    assert.equal(c.allowed, false);
+    assert.equal(c.reason, 'rate_limit_store_unavailable');
+  });
+
+  test('the fee-ceiling check does not misreport a dead store as fee_ceiling_exceeded', async () => {
+    const limiter = new RateLimiter(LIMITS, new BrokenStore());
+    const res = await limiter.checkSettle({ keyId: 'k' });
+    assert.notEqual(res.reason, 'fee_ceiling_exceeded');
+  });
+
+  test('records do not throw — a settled payment must not become a 5xx', async () => {
+    const limiter = new RateLimiter(LIMITS, new BrokenStore());
+    await assert.doesNotReject(() => limiter.recordSettle({ keyId: 'k' }, 100));
+    await assert.doesNotReject(() => limiter.recordVerify({ keyId: 'k' }));
+    await assert.doesNotReject(() => limiter.getUsage('k'));
+  });
+});
+
+describe('PostgresStore statement semantics', () => {
+  test('increment uses one atomic upsert, not read-modify-write', async () => {
+    const pool = fakePool();
+    const store = new PostgresStore({ pool });
+    await store.increment('b1', 3, 2000, 1000);
+    const bucket = await store.get('b1', 1500);
+    assert.equal(bucket.count, 3);
+
+    // The write must be a single INSERT ... ON CONFLICT DO UPDATE RETURNING.
+    const upserts = pool.queries.filter(q => q.sql.includes('ON CONFLICT'));
+    assert.equal(upserts.length, 1);
+    assert.match(upserts[0].sql, /RETURNING count, reset_at/);
+  });
+
+  test('an expired row reused after its window rolls over starts from zero', async () => {
+    const pool = fakePool();
+    const store = new PostgresStore({ pool });
+    await store.increment('b2', 5, 1100, 1000); // expires at 1100
+
+    // Window rolled over; same bucket_id shape can recur with a new resetAt.
+    const bucket = await store.increment('b2', 2, 2200, 1200);
+    assert.equal(bucket.count, 2, 'must not accumulate onto the expired window');
+  });
+
+  test('get ignores expired buckets', async () => {
+    const pool = fakePool();
+    const store = new PostgresStore({ pool });
+    await store.increment('b3', 5, 1100, 1000);
+    const live = await store.get('b3', 999);
+    assert.equal(live.count, 5, 'resetAt 1100 > 999, still live');
+    assert.deepEqual(await store.get('b3', 1500), undefined);
+  });
+
+  test('sweep deletes only expired rows', async () => {
+    const pool = fakePool();
+    const store = new PostgresStore({ pool });
+    await store.increment('live', 1, 5000, 1000);
+    await store.increment('dead', 1, 900, 1000);
+    await store.sweep(1000);
+    assert.ok(await store.get('live', 1000));
+    assert.equal(await store.get('dead', 1000), undefined);
+  });
+});
+
+describe('store selection', () => {
+  test('unset RATE_LIMIT_STORE means memory', () => {
+    const store = createRateLimitStore({});
+    assert.ok(store instanceof MemoryStore);
+  });
+
+  test('RATE_LIMIT_STORE=postgres without DATABASE_URL refuses to start', () => {
+    assert.throws(() => createRateLimitStore({ RATE_LIMIT_STORE: 'postgres' }), /DATABASE_URL/);
+  });
+
+  test('an unknown store name is a configuration error, not a silent fallback', () => {
+    assert.throws(
+      () => createRateLimitStore({ RATE_LIMIT_STORE: 'redis' }),
+      /Unknown RATE_LIMIT_STORE/,
+    );
+  });
+});
+
+test('GET /usage over HTTP reads the fee counter that survived a restart', async () => {
+  // End-to-end form of the restart-survival acceptance item: spend is recorded
+  // by one process-shaped limiter, then GET /usage is served by a fresh
+  // limiter instance over the same store — what a restarted process is.
+  const { serve, testConfig, stubFacilitator } = await import('./helpers/app.js');
+  const store = new MemoryStore();
+  const limits = {
+    global: { verifyRpm: 10, settleRpm: 10, settleRph: 100, settleRpd: 1000, feeSpd: 5000 },
+    keys: {},
+  };
+  await new RateLimiter(limits, store).recordSettle({ keyId: 'admin' }, 1234);
+
+  const app = await serve({
+    config: testConfig({ apiKeys: ['admin:s3cret'] }),
+    facilitator: stubFacilitator(),
+    rateLimiter: new RateLimiter(limits, store), // fresh limiter, shared store
+  });
+  try {
+    const res = await app.get('/usage', { authorization: 'Bearer s3cret' });
+    assert.equal(res.status, 200);
+    const usage = await res.json();
+    assert.equal(usage.fee_spd, 1234);
+  } finally {
+    await app.close();
+  }
+});
+
+/**
+ * A minimal emulation of the pg Pool surface, implementing exactly the three
+ * statements PostgresStore issues. This pins the SQL semantics (atomic upsert,
+ * expiry handling) without standing up a live server; a real deployment still
+ * needs the migration applied or the store's CREATE TABLE IF NOT EXISTS.
+ */
+function fakePool() {
+  const table = new Map(); // bucket_id -> { count, reset_at }
+  return {
+    table,
+    queries: [],
+    async query(sql, params = []) {
+      this.queries.push({ sql: sql.replace(/\s+/g, ' ').trim(), params });
+      if (sql.includes('CREATE TABLE IF NOT EXISTS')) return { rows: [] };
+      if (sql.startsWith('SELECT count, reset_at')) {
+        const [id, now] = params;
+        const row = table.get(id);
+        if (!row || row.reset_at <= Number(now)) return { rows: [] };
+        return { rows: [{ count: row.count, reset_at: row.reset_at }] };
+      }
+      if (sql.includes('ON CONFLICT (bucket_id) DO UPDATE')) {
+        const [id, amount, resetAt, now] = [
+          params[0],
+          Number(params[1]),
+          Number(params[2]),
+          Number(params[3]),
+        ];
+        let row = table.get(id);
+        if (!row || row.reset_at <= now) row = { count: 0 };
+        else row = { ...row };
+        row.count += amount;
+        row.reset_at = resetAt;
+        table.set(id, row);
+        return { rows: [{ count: row.count, reset_at: row.reset_at }] };
+      }
+      if (sql.startsWith('DELETE FROM rate_limit_buckets')) {
+        const [now] = params.map(Number);
+        for (const [id, row] of table.entries()) {
+          if (row.reset_at <= now) table.delete(id);
+        }
+        return { rowCount: 0 };
+      }
+      throw new Error(`fakePool: unexpected statement ${sql}`);
+    },
+  };
+}

--- a/test/rate-limit.test.js
+++ b/test/rate-limit.test.js
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { RateLimiter } from '../src/rate-limit.js';
 
-test('rate limiter honors global limits', () => {
+test('rate limiter honors global limits', async () => {
   const config = {
     global: { verifyRpm: 2, settleRpm: 1, settleRph: 10, settleRpd: 100, feeSpd: 1000 },
     keys: {},
@@ -11,25 +11,25 @@ test('rate limiter honors global limits', () => {
   const req = { keyId: 'test_key' };
 
   // Verify
-  assert.equal(limiter.checkVerify(req).allowed, true);
-  limiter.recordVerify(req);
-  assert.equal(limiter.checkVerify(req).allowed, true);
-  limiter.recordVerify(req);
-  assert.equal(limiter.checkVerify(req).allowed, false);
+  assert.equal((await limiter.checkVerify(req)).allowed, true);
+  await limiter.recordVerify(req);
+  assert.equal((await limiter.checkVerify(req)).allowed, true);
+  await limiter.recordVerify(req);
+  assert.equal((await limiter.checkVerify(req)).allowed, false);
 
   // Settle
-  assert.equal(limiter.checkSettle(req).allowed, true);
-  limiter.recordSettle(req, 500);
-  assert.equal(limiter.checkSettle(req).allowed, false); // RPM exceeded
+  assert.equal((await limiter.checkSettle(req)).allowed, true);
+  await limiter.recordSettle(req, 500);
+  assert.equal((await limiter.checkSettle(req)).allowed, false); // RPM exceeded
 
   // Check usage
-  const usage = limiter.getUsage('test_key');
+  const usage = await limiter.getUsage('test_key');
   assert.equal(usage.verify_rpm, 2);
   assert.equal(usage.settle_rpm, 1);
   assert.equal(usage.fee_spd, 500);
 });
 
-test('rate limiter honors per-key overrides', () => {
+test('rate limiter honors per-key overrides', async () => {
   const config = {
     global: { verifyRpm: 1, settleRpm: 1, settleRph: 10, settleRpd: 100, feeSpd: 1000 },
     keys: {
@@ -39,12 +39,12 @@ test('rate limiter honors per-key overrides', () => {
   const limiter = new RateLimiter(config);
   const req = { keyId: 'test_key' };
 
-  limiter.recordVerify(req);
-  limiter.recordVerify(req);
-  assert.equal(limiter.checkVerify(req).allowed, true); // Since limit is 5
+  await limiter.recordVerify(req);
+  await limiter.recordVerify(req);
+  assert.equal((await limiter.checkVerify(req)).allowed, true); // Since limit is 5
 });
 
-test('rate limiter halts on fee ceiling', () => {
+test('rate limiter halts on fee ceiling', async () => {
   const config = {
     global: { verifyRpm: 10, settleRpm: 10, settleRph: 10, settleRpd: 10, feeSpd: 500 },
     keys: {},
@@ -52,23 +52,23 @@ test('rate limiter halts on fee ceiling', () => {
   const limiter = new RateLimiter(config);
   const req = { keyId: 'test_key' };
 
-  assert.equal(limiter.checkSettle(req).allowed, true);
-  limiter.recordSettle(req, 400);
-  assert.equal(limiter.checkSettle(req).allowed, true);
+  assert.equal((await limiter.checkSettle(req)).allowed, true);
+  await limiter.recordSettle(req, 400);
+  assert.equal((await limiter.checkSettle(req)).allowed, true);
 
   // Checking doesn't increment, but if we assume the next transaction could be up to max fee?
   // Our implementation checks if current consumed > limit.
   // Wait, current consumed is 400. limit is 500. So allowed = true.
   // Next settlement consumes 200.
-  limiter.recordSettle(req, 200);
+  await limiter.recordSettle(req, 200);
 
   // Now consumed is 600. Next check should fail.
-  const res = limiter.checkSettle(req);
+  const res = await limiter.checkSettle(req);
   assert.equal(res.allowed, false);
   assert.equal(res.reason, 'fee_ceiling_exceeded');
 });
 
-test('rate limiter falls back to IP in open mode', () => {
+test('rate limiter falls back to IP in open mode', async () => {
   const config = {
     global: { verifyRpm: 1, settleRpm: 1, settleRph: 10, settleRpd: 100, feeSpd: 1000 },
     keys: {},
@@ -77,10 +77,10 @@ test('rate limiter falls back to IP in open mode', () => {
   const req1 = { ip: '192.168.1.1' };
   const req2 = { ip: '192.168.1.2' };
 
-  assert.equal(limiter.checkVerify(req1).allowed, true);
-  limiter.recordVerify(req1);
-  assert.equal(limiter.checkVerify(req1).allowed, false);
+  assert.equal((await limiter.checkVerify(req1)).allowed, true);
+  await limiter.recordVerify(req1);
+  assert.equal((await limiter.checkVerify(req1)).allowed, false);
 
   // req2 should still be allowed since it's a different IP
-  assert.equal(limiter.checkVerify(req2).allowed, true);
+  assert.equal((await limiter.checkVerify(req2)).allowed, true);
 });

--- a/test/readiness.test.js
+++ b/test/readiness.test.js
@@ -1,0 +1,236 @@
+/**
+ * GET /health/ready and the readiness checker (issue #100).
+ *
+ * The distinction under test: /healthz is liveness — cheap, dependency-free,
+ * always 200 while the process runs. /health/ready is readiness — it CAN fail,
+ * names which check failed for which network, is cached, bounds its own RPC
+ * timeouts instead of inheriting the ~12s retry budget, and reports catalogue
+ * trouble without ever failing on it.
+ */
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { Keypair, xdr } from '@stellar/stellar-sdk';
+import { createReadinessChecker } from '../src/readiness.js';
+import { serve } from './helpers/app.js';
+
+// A fresh random signer per run — nothing asserts a specific address.
+function signerSecret() {
+  return Keypair.random().secret();
+}
+
+const SECRET_A = signerSecret();
+
+function configWith(networks) {
+  const perNetwork = {};
+  for (const [network, rpcUrl] of networks) {
+    perNetwork[network] = { secret: SECRET_A, rpcUrl };
+  }
+  return {
+    networks: networks.map(([n]) => n),
+    perNetwork,
+    apiKeys: [],
+  };
+}
+
+/** Builds an rpcCall stub whose getHealth/getLedgerEntries behaviour is scripted. */
+function rpcStub({
+  healthy = true,
+  balance = 100_000_000,
+  accountMissing = false,
+  failDial = false,
+} = {}) {
+  const calls = [];
+  const address = Keypair.fromSecret(SECRET_A).publicKey();
+  const accountId = Keypair.fromPublicKey(address).xdrAccountId();
+  let entryVal = null;
+  if (!accountMissing) {
+    const acct = new xdr.AccountEntry({
+      accountId,
+      balance: new xdr.Int64(balance),
+      seqNum: new xdr.SequenceNumber(new xdr.Int64(0)),
+      numSubEntries: 0,
+      inflationDest: null,
+      flags: 0,
+      homeDomain: '',
+      thresholds: Buffer.alloc(4, 1),
+      signers: [],
+      ext: new xdr.AccountEntryExt(0),
+    });
+    entryVal = xdr.LedgerEntryData.account(acct).toXDR('base64');
+  }
+  const stub = async (url, body) => {
+    calls.push(body.method);
+    if (failDial) {
+      const err = new Error('connect ECONNREFUSED');
+      err.code = 'ECONNREFUSED';
+      throw err;
+    }
+    if (body.method === 'getHealth') {
+      return { result: { status: healthy ? 'healthy' : 'degraded' } };
+    }
+    if (body.method === 'getLedgerEntries') {
+      return { result: { entries: entryVal ? [{ val: entryVal }] : [] } };
+    }
+    throw new Error(`unexpected method ${body.method}`);
+  };
+  stub.calls = calls;
+  return stub;
+}
+
+describe('readiness checker', () => {
+  test('healthy rpc and a funded signer are ready', async () => {
+    const config = configWith([['stellar:testnet', 'http://rpc.test']]);
+    const checker = createReadinessChecker(config, { rpcCall: rpcStub(), cacheTtlMs: 0 });
+    const report = await checker.check();
+    assert.equal(report.ok, true);
+    assert.equal(report.status, 'ready');
+    assert.equal(report.networks['stellar:testnet'].ready, true);
+    assert.equal(report.networks['stellar:testnet'].checks.rpc_reachable.ok, true);
+    assert.equal(report.networks['stellar:testnet'].checks.signer_funded.ok, true);
+  });
+
+  test('unreachable rpc fails with the check named for the network', async () => {
+    const config = configWith([['stellar:testnet', 'http://rpc.test']]);
+    const checker = createReadinessChecker(config, {
+      rpcCall: rpcStub({ failDial: true }),
+      cacheTtlMs: 0,
+    });
+    const report = await checker.check();
+    assert.equal(report.ok, false);
+    const net = report.networks['stellar:testnet'];
+    assert.equal(net.ready, false);
+    assert.equal(net.checks.rpc_reachable.ok, false);
+    assert.match(net.checks.rpc_reachable.error, /ECONNREFUSED/);
+    // The failing check and the network are both named — an operator reads the
+    // body without correlating logs.
+    assert.equal(net.checks.signer_funded.ok, false, 'signer check cannot succeed either');
+  });
+
+  test('a missing or below-floor signer account fails readiness by name', async () => {
+    const config = configWith([['stellar:testnet', 'http://rpc.test']]);
+
+    const missing = createReadinessChecker(config, {
+      rpcCall: rpcStub({ accountMissing: true }),
+      cacheTtlMs: 0,
+    });
+    const missingReport = await missing.check();
+    assert.equal(missingReport.networks['stellar:testnet'].checks.rpc_reachable.ok, true);
+    assert.equal(missingReport.networks['stellar:testnet'].checks.signer_funded.ok, false);
+    assert.match(
+      missingReport.networks['stellar:testnet'].checks.signer_funded.error,
+      /does not exist/,
+    );
+
+    const poor = createReadinessChecker(config, {
+      rpcCall: rpcStub({ balance: 500 }),
+      cacheTtlMs: 0,
+      minBalanceStroops: 1_000_000,
+    });
+    const poorReport = await poor.check();
+    const signer = poorReport.networks['stellar:testnet'].checks.signer_funded;
+    assert.equal(signer.ok, false);
+    assert.equal(signer.balance_stroops, 500);
+    assert.match(signer.error, /below floor 1000000/);
+  });
+
+  test('per-network status, not one aggregate boolean', async () => {
+    const config = configWith([
+      ['stellar:testnet', 'http://good.rpc'],
+      ['stellar:pubnet', 'http://bad.rpc'],
+    ]);
+    const good = rpcStub();
+    const bad = rpcStub({ failDial: true });
+    const checker = createReadinessChecker(config, {
+      rpcCall: (url, body) => (url === 'http://good.rpc' ? good(url, body) : bad(url, body)),
+      cacheTtlMs: 0,
+    });
+    const report = await checker.check();
+    assert.equal(report.ok, false, 'one broken network makes the instance not ready');
+    assert.equal(report.networks['stellar:testnet'].ready, true);
+    assert.equal(report.networks['stellar:pubnet'].ready, false);
+  });
+
+  test('results are cached for the ttl; invalidation forces a re-dial', async () => {
+    const config = configWith([['stellar:testnet', 'http://rpc.test']]);
+    const stub = rpcStub();
+    const checker = createReadinessChecker(config, { rpcCall: stub, cacheTtlMs: 60_000 });
+
+    await checker.check();
+    await checker.check();
+    assert.deepEqual(stub.calls.length, 2, 'second call inside ttl served from cache');
+
+    checker.invalidate();
+    await checker.check();
+    assert.ok(stub.calls.length > 2, 'invalidated check dials again');
+  });
+
+  test('catalogue trouble is reported but never fails readiness', async () => {
+    const config = configWith([['stellar:testnet', 'http://rpc.test']]);
+    const catalog = {
+      healthCheck: async () => {
+        throw new Error('index corrupted');
+      },
+    };
+    const checker = createReadinessChecker(config, {
+      rpcCall: rpcStub(),
+      cacheTtlMs: 0,
+      catalog,
+    });
+    const report = await checker.check();
+    assert.equal(report.ok, true, 'catalogue failure must not fail readiness');
+    assert.equal(report.catalog.ok, false);
+    assert.match(report.catalog.error, /corrupted/);
+  });
+});
+
+describe('GET /health/ready over HTTP', () => {
+  test('503 with a body naming the failing dependency and network', async () => {
+    const app = await serve({
+      extras: {
+        readiness: {
+          check: async () => ({
+            ok: false,
+            status: 'not_ready',
+            checked_at: new Date().toISOString(),
+            networks: {
+              'stellar:testnet': {
+                ready: false,
+                checks: { rpc_reachable: { ok: false, error: 'connect ECONNREFUSED' } },
+              },
+            },
+            breakers: {},
+          }),
+        },
+      },
+    });
+    try {
+      const res = await app.get('/health/ready');
+      assert.equal(res.status, 503);
+      const body = await res.json();
+      assert.equal(body.ok, false);
+      assert.match(
+        JSON.stringify(body.networks['stellar:testnet'].checks.rpc_reachable.error),
+        /ECONNREFUSED/,
+      );
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('200 when every network is ready', async () => {
+    const app = await serve({
+      extras: {
+        readiness: {
+          check: async () => ({ ok: true, status: 'ready', networks: {}, breakers: {} }),
+        },
+      },
+    });
+    try {
+      const res = await app.get('/health/ready');
+      assert.equal(res.status, 200);
+      assert.equal((await res.json()).status, 'ready');
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/test/rpc-retry.breaker.test.js
+++ b/test/rpc-retry.breaker.test.js
@@ -1,0 +1,341 @@
+/**
+ * The RPC circuit breaker (issue #105).
+ *
+ * The invariants pinned here, in the order the issue lists them:
+ *   - only connection-level failures (the RETRYABLE set) may open the breaker;
+ *     a received RPC error response never does
+ *   - while open, non-sendTransaction calls fail without dialling — asserted
+ *     by call count, not timing
+ *   - half-open after cooldown; a single probe decides
+ *   - an in-flight sendTransaction is never aborted by a trip underneath it,
+ *     and is never fast-failed by an already-open breaker either
+ *   - transitions are logged and state is readable for /health/ready
+ */
+import { test, describe, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { installRpcRetry, RpcBreakerOpenError } from '../src/rpc-retry.js';
+
+const REAL_FETCH = globalThis.fetch;
+
+/** A fetch stub that always fails with the given transport code. */
+function failingFetch(code) {
+  const stub = async () => {
+    stub.calls++;
+    const err = new Error(`simulated ${code}`);
+    err.code = code;
+    throw err;
+  };
+  stub.calls = 0;
+  return stub;
+}
+
+function scriptedFetch(...outcomes) {
+  const stub = async () => {
+    stub.calls++;
+    const next = outcomes.shift();
+    if (next instanceof Error) throw next;
+    return next ?? new Response('ok');
+  };
+  stub.calls = 0;
+  return stub;
+}
+
+beforeEach(() => {
+  globalThis.fetch = REAL_FETCH;
+});
+
+afterEach(() => {
+  globalThis.fetch = REAL_FETCH;
+});
+
+describe('what opens the breaker', () => {
+  test('opens after the threshold of consecutive connection failures', async () => {
+    const stub = failingFetch('ECONNREFUSED');
+    globalThis.fetch = stub;
+    const states = [];
+    installRpcRetry({
+      attempts: 1,
+      baseDelayMs: 1,
+      threshold: 3,
+      cooldownMs: 60_000,
+      forceIpv4: false,
+      onStateChange: s => states.push(s),
+    });
+
+    for (let i = 0; i < 3; i++) {
+      await assert.rejects(() => globalThis.fetch('http://rpc.invalid'), /simulated/);
+    }
+    // All three dialed — nothing was refused yet.
+    assert.equal(stub.calls, 3);
+    assert.equal(states.length, 1);
+    assert.match(states[0], /open/);
+    assert.match(states[0], /rpc\.invalid/);
+  });
+
+  test('an RPC error RESPONSE never opens the breaker', async () => {
+    // The server answering — even with 500 forever — means it is up. Breaking
+    // on received responses would convert real results into flaky ones.
+    const stub = async () => {
+      stub.calls++;
+      return new Response('boom', { status: 500 });
+    };
+    stub.calls = 0;
+    globalThis.fetch = stub;
+    installRpcRetry({
+      attempts: 1,
+      baseDelayMs: 1,
+      threshold: 2,
+      cooldownMs: 60_000,
+      forceIpv4: false,
+    });
+
+    await globalThis.fetch('http://rpc.invalid');
+    await globalThis.fetch('http://rpc.invalid');
+    await globalThis.fetch('http://rpc.invalid');
+    assert.equal(stub.calls, 3, 'every call must still dial — breaker must stay closed');
+
+    // And a connection failure afterwards needs the full threshold from zero.
+    const failing = failingFetch('ETIMEDOUT');
+    globalThis.fetch = failing;
+    await assert.rejects(() => globalThis.fetch('http://rpc.invalid'));
+    assert.equal(failing.calls, 1, 'one failure after successes must not open anything');
+  });
+
+  test('failures count per host — a second host starts closed', async () => {
+    const stub = failingFetch('ECONNREFUSED');
+    globalThis.fetch = stub;
+    installRpcRetry({
+      attempts: 1,
+      baseDelayMs: 1,
+      threshold: 2,
+      cooldownMs: 60_000,
+      forceIpv4: false,
+    });
+
+    await assert.rejects(() => globalThis.fetch('http://a.invalid'));
+    // b.invalid has its own breaker; this dial must happen.
+    await assert.rejects(() => globalThis.fetch('http://b.invalid'));
+    assert.equal(stub.calls, 2);
+  });
+});
+
+describe('while open', () => {
+  test('calls fail immediately without dialling, with a distinct error', async () => {
+    const stub = failingFetch('ECONNREFUSED');
+    globalThis.fetch = stub;
+    installRpcRetry({
+      attempts: 1,
+      baseDelayMs: 1,
+      threshold: 1,
+      cooldownMs: 60_000,
+      forceIpv4: false,
+    });
+
+    await assert.rejects(() => globalThis.fetch('http://rpc.invalid'));
+    assert.equal(stub.calls, 1);
+
+    // Open now. The next call must not reach the network at all.
+    await assert.rejects(
+      () => globalThis.fetch('http://rpc.invalid'),
+      err => {
+        assert.ok(err instanceof RpcBreakerOpenError);
+        assert.equal(err.code, 'RPC_BREAKER_OPEN');
+        return true;
+      },
+    );
+    assert.equal(stub.calls, 1, 'no dial happened while the breaker was open');
+  });
+});
+
+describe('half-open recovery', () => {
+  test('after the cooldown one probe dials; success closes, failure re-opens', async () => {
+    let healthy = false;
+    const stub = async () => {
+      stub.calls++;
+      if (healthy) return new Response('ok');
+      const err = new Error('simulated ECONNRESET');
+      err.code = 'ECONNRESET';
+      throw err;
+    };
+    stub.calls = 0;
+    globalThis.fetch = stub;
+    const lines = [];
+    installRpcRetry({
+      attempts: 1,
+      baseDelayMs: 1,
+      threshold: 1,
+      cooldownMs: 30,
+      forceIpv4: false,
+      log: l => lines.push(l),
+    });
+
+    await assert.rejects(() => globalThis.fetch('http://rpc.invalid'));
+    assert.equal(stub.calls, 1); // open
+
+    // Still inside cooldown: refused without dialling.
+    await assert.rejects(() => globalThis.fetch('http://rpc.invalid'), RpcBreakerOpenError);
+    assert.equal(stub.calls, 1);
+
+    // Cooldown elapsed: exactly ONE probe goes through.
+    await new Promise(r => setTimeout(r, 40));
+    await assert.rejects(() => globalThis.fetch('http://rpc.invalid'), /simulated ECONNRESET/);
+    assert.equal(stub.calls, 2, 'the probe dialled once');
+    // The probe failed, so a second immediate caller is refused again.
+    await assert.rejects(() => globalThis.fetch('http://rpc.invalid'), RpcBreakerOpenError);
+    assert.equal(stub.calls, 2);
+
+    // Cooldown again, but now the dependency recovered.
+    healthy = true;
+    await new Promise(r => setTimeout(r, 40));
+    const res = await globalThis.fetch('http://rpc.invalid');
+    assert.equal(await res.text(), 'ok');
+    assert.equal(stub.calls, 3);
+
+    // Closed: traffic flows without refusals.
+    await globalThis.fetch('http://rpc.invalid');
+    assert.equal(stub.calls, 4);
+
+    const transitions = lines.filter(l => l.includes('OPEN') || l.includes('CLOSED'));
+    assert.ok(
+      transitions.some(l => l.includes('OPEN')),
+      'opening is logged',
+    );
+    assert.ok(
+      transitions.some(l => l.includes('CLOSED')),
+      'closing is logged',
+    );
+  });
+
+  test('state is readable for the readiness endpoint', async () => {
+    const stub = failingFetch('ECONNREFUSED');
+    globalThis.fetch = stub;
+    const handle = installRpcRetry({
+      attempts: 1,
+      baseDelayMs: 1,
+      threshold: 1,
+      cooldownMs: 60_000,
+      forceIpv4: false,
+    });
+
+    await assert.rejects(() => globalThis.fetch('http://rpc.invalid:8545/path'));
+    const states = handle.getBreakerStates();
+    assert.equal(states['http://rpc.invalid:8545'].state, 'open');
+    assert.equal(states['http://rpc.invalid:8545'].consecutive_failures, 1);
+    assert.ok(states['http://rpc.invalid:8545'].opened_at);
+  });
+});
+
+describe('an open breaker produces a distinct reason code on /verify and /settle', async () => {
+  const { serve, testConfig, stubFacilitator, VALID_BODY } = await import('./helpers/app.js');
+  const { RpcBreakerOpenError } = await import('../src/rpc-retry.js');
+
+  function brokenFacilitator() {
+    return stubFacilitator({
+      verify: async () => {
+        throw new RpcBreakerOpenError('http://rpc.invalid');
+      },
+      settle: async () => {
+        throw new RpcBreakerOpenError('http://rpc.invalid');
+      },
+    });
+  }
+
+  test('/verify answers soroban_rpc_unreachable, not facilitator_error', async () => {
+    const app = await serve({
+      facilitator: brokenFacilitator(),
+      config: testConfig({ apiKeys: [] }),
+    });
+    try {
+      const res = await app.post('/verify', VALID_BODY);
+      const body = await res.json();
+      assert.equal(body.isValid, false);
+      assert.equal(body.invalidReason, 'soroban_rpc_unreachable');
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('/settle answers soroban_rpc_unreachable with the settle response shape', async () => {
+    const app = await serve({ facilitator: brokenFacilitator() });
+    try {
+      const res = await app.post('/settle', VALID_BODY);
+      const body = await res.json();
+      assert.equal(body.success, false);
+      assert.equal(body.errorReason, 'soroban_rpc_unreachable');
+      assert.equal(body.transaction, '');
+      assert.ok(body.network, 'network present even on failure');
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('sendTransaction is never aborted by the breaker', () => {
+  const SEND_INIT = {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'sendTransaction',
+      params: { transaction: 'AAAA...', resourceConfig: {} },
+    }),
+  };
+
+  test('an open breaker still lets a sendTransaction dial', async () => {
+    const stub = failingFetch('ECONNRESET');
+    globalThis.fetch = stub;
+    installRpcRetry({
+      attempts: 1,
+      baseDelayMs: 1,
+      threshold: 1,
+      cooldownMs: 60_000,
+      forceIpv4: false,
+    });
+
+    // Trip it with an ordinary call (getHealth).
+    await assert.rejects(() =>
+      globalThis.fetch('http://rpc.invalid', {
+        method: 'POST',
+        body: JSON.stringify({ method: 'getHealth' }),
+      }),
+    );
+    assert.equal(stub.calls, 1);
+
+    // Ordinary calls are now refused...
+    await assert.rejects(() => globalThis.fetch('http://rpc.invalid'), RpcBreakerOpenError);
+    assert.equal(stub.calls, 1);
+
+    // ...but a broadcast that may be live always gets its dial.
+    await assert.rejects(() => globalThis.fetch('http://rpc.invalid', SEND_INIT), /simulated/);
+    assert.equal(stub.calls, 2, 'sendTransaction must not be fast-failed while open');
+  });
+
+  test('a sendTransaction mid-retry-loop rides out a trip caused by other hosts', async () => {
+    // Host A fails repeatedly, tripping ITS breaker; meanwhile host B's
+    // sendTransaction keeps retrying — its own loop is not re-gated.
+    const stub = scriptedFetch(
+      transportErr('ECONNRESET'),
+      transportErr('ECONNRESET'),
+      new Response('ok'),
+    );
+    globalThis.fetch = stub;
+    installRpcRetry({
+      attempts: 5,
+      baseDelayMs: 1,
+      threshold: 1,
+      cooldownMs: 60_000,
+      forceIpv4: false,
+    });
+
+    const res = await globalThis.fetch('http://b.invalid/soroban', SEND_INIT);
+    assert.equal(res.status, 200);
+    assert.equal(stub.calls, 3, 'the send retried through to success despite trips elsewhere');
+
+    function transportErr(code) {
+      const err = new Error(`simulated ${code}`);
+      err.code = code;
+      return err;
+    }
+  });
+});


### PR DESCRIPTION
Closes #94
Closes #100
Closes #105
Closes #109

## What and why

Four service-hardening changes in one branch — they share wiring (server.js/app.js) and each was designed against the others (breaker state feeds readiness; the limiter's degrade decision is what the readiness-era service runs with).

### #94 — Rate-limiter state off per-process memory

Bucket state moves behind a small store interface (`get` / `increment` / `sweep`), `src/rate-limit-store.js`. The public `RateLimiter` surface (`checkVerify` … `getUsage`) keeps every method; one deliberate exception: the methods are now async, because a network-backed store cannot be synchronous — so call sites in `src/app.js` gained `await`s. That is the only edit beyond construction.

- **Default stays memory**: unset `RATE_LIMIT_STORE` = the same in-process Map as today; a free testnet instance still starts with nothing configured.
- **Shared backend: Postgres**, not Redis. Postgres is already provisioned by `docker-compose.yml` (`DATABASE_URL`) — no second datastore enters the stack. Its rows are never evicted: a fee counter is exactly the value a Redis `maxmemory-policy` would silently drop under pressure, re-creating this bug. If Redis ever lands here it must be `noeviction`.
- **Atomic increments**: single-statement `INSERT … ON CONFLICT DO UPDATE RETURNING` (window rollover handled inside the statement). No read-modify-write from Node.
- **Degrade decision — fail CLOSED** when a shared store is configured and unreachable: checks refuse with reason `rate_limit_store_unavailable`. Fail-open would mean unlimited sponsored spend during an outage, i.e. precisely the bug this issue fixes. Records (`recordSettle` etc.) deliberately degrade open — they run after a payment already succeeded, and throwing would 5xx a settled payment — but log loudly.
- **Fixes the `checkCatalog` defect first** (it reached for `this.limits`, which never existed, and threw on every call); it now meters `catalog_rpm` through the normal path before being ported onto the store.
- `#141` (RateLimit-Remaining off-by-one): left strictly alone.

### #105 — Circuit breaker around Soroban RPC

Per-host breaker inside the existing `rpc-retry.js` fetch wrapper:

- opens on consecutive connection-level failures only — **the RETRYABLE set is both retry trigger and breaker trigger, drawn once**. A received response (RPC error, rejected simulation, HTTP 500) never counts; whatever the server said stands.
- while open, ordinary calls fail without dialling (asserted by call count); after `RPC_BREAKER_COOLDOWN_MS` (default 30s) a single half-open probe decides; transitions are logged.
- **`sendTransaction` is never aborted**: calls carrying a sendTransaction body bypass the open-gate entirely — a settle whose broadcast may have landed must not be reported failed by a trip underneath it. It pays the retry budget during an outage instead; that's the correct trade.
- distinct `RpcBreakerOpenError` (`code: RPC_BREAKER_OPEN`) surfaces on `/verify` and `/settle` as reason code `soroban_rpc_unreachable` — a caller can tell "chain unreachable" from "payment rejected".
- thresholds configurable (`RPC_BREAKER_THRESHOLD`, default 10 — deliberately high so a slow-but-working RPC doesn't trip it).

### #100 — Readiness probe that can fail

`GET /health/ready`: per entry in `config.networks`, checks Soroban RPC reachability (`getHealth`) and signer funding (`getLedgerEntries` balance vs `READINESS_FUNDING_FLOOR_STROOPS`). `200` when every network is ready, `503` naming which check failed for which network — per-network status, not one boolean.

- cached for `READINESS_CACHE_TTL_MS` (5s default) so probes don't burst RPC; every check runs under its own `READINESS_TIMEOUT_MS` (3s) via AbortController rather than inheriting the ~12s retry budget (abort codes aren't in RETRYABLE).
- breaker states reported in the response (#105 integration); catalogue-store trouble reported but **never fatal** — same rule as `processCataloging`.
- `/healthz` untouched as pure liveness; Docker HEALTHCHECK keeps targeting it, with a comment explaining why (restart logic ≠ traffic gating; failing the container check on a downstream outage would restart-loop).

### #109 — Audit logging

`src/audit.js` emits self-describing JSON lines with `"channel": "audit"` — separable at shipment from diagnostics, optionally mirrored to `AUDIT_LOG_FILE`. Audited: settlements (actor keyId + **transaction hash** + outcome + fee), verifications, catalog writes/overwrites, auth failures, rate-limit rejections, breaker refusals. Exclusions justified in docs/AUDIT.md (reads, full payloads, secrets — keyId only, plus redaction of secret-shaped fields as defence in depth). Retention stated consistently with docs/PRIVACY.md §7 (settlements → 90-day class; other audit records → 7-day class; enforcement remains #50's job). Built to be a consumer of #7 rather than a second logging framework: one structured writer, no new mechanism.

## Acceptance criteria checklist

**#94**
- [x] Public surface unchanged in shape; app.js edits limited to construction + mechanical awaits (async store makes sync impossible)
- [x] No store configured → starts and limits exactly as today (`test/rate-limit.test.js` semantics unchanged)
- [x] Two limiters over one store enforce one combined limit (`counters are shared across limiters`, `the fee ceiling is combined too`)
- [x] Fee counter survives restart, verified via GET /usage (`GET /usage over HTTP reads the fee counter that survived a restart`)
- [x] Atomicity: 50 concurrent increments across two instances land as 50
- [x] Unreachable-store behaviour chosen (fail-closed), documented, tested
- [x] `.env.example` + docs/DEPLOYMENT.md document new variables
- [x] `npm run lint`, `npm test` pass (153 tests)

**#100**
- [x] `/healthz` still 200, dependency-free
- [x] 503 names failing check + network (stubbed-unreachable RPC tests)
- [x] Missing/below-floor signer → 503
- [x] Per-network reporting (two-network test)
- [x] Caching + own timeout independent of retry budget
- [x] Catalogue reported, non-fatal
- [x] HEALTHCHECK targets intended endpoint with comment
- [x] Both endpoints documented in docs/OPERATIONS.md

**#105**
- [x] Opens only on RETRYABLE codes, never on received RPC errors (dedicated test)
- [x] Open breaker fails fast without dialing (call-count assertion)
- [x] Half-open probe closes/reopens correctly
- [x] sendTransaction never aborted nor fast-failed while open
- [x] Distinct non-null reason code on /verify and /settle
- [x] Transitions logged; state readable from /health/ready
- [x] Thresholds/cooldown configurable with documented defaults

**#109**
- [x] Events enumerated with inclusion/exclusion reasons (docs/AUDIT.md)
- [x] Timestamp, caller identity, action, outcome per record
- [x] Settlement records carry transaction hash
- [x] Audit records distinguishable (`channel: audit`)
- [x] No secret/full payload in records — test-enforced
- [x] Relationship to #7 stated in PR + docs
- [x] Retention consistent with docs/PRIVACY.md

## Verification notes

- `npm run lint` ✅ · `npm test` ✅ (153 tests, including the new multi-instance/atomicity/fail-closed, breaker, readiness and audit suites)
- `npm run e2e` ⚠️ could not fully pass in this environment: it requires pre-funded facilitator/alice/merchant testnet accounts and no stellar CLI or funded keys exist here. The run was executed end-to-end up to signing — `/supported` conformance, the 402 flow and payment signing all work; it fails only at simulation with `account entry is missing` for the freshly generated unfunded accounts. Nothing in this PR touches the payment wire format.
- Live smoke test: server booted with `RATE_LIMIT_STORE` unset (MemoryStore banner); `GET /healthz` → 200; `GET /health/ready` against real testnet RPC returned `503` naming `signer_funded: account does not exist` for an unfunded signer while `rpc_reachable` was ok, with breaker state included — exactly the per-check reporting intended.

## New environment variables

| Variable | Default | Purpose |
|---|---|---|
| `RATE_LIMIT_STORE` | unset (`memory`) | `postgres` shares limiter state via `DATABASE_URL` |
| `RPC_BREAKER_THRESHOLD` | `10` | Consecutive connection failures before the breaker opens |
| `RPC_BREAKER_COOLDOWN_MS` | `30000` | Open-breaker cooldown before the half-open probe |
| `READINESS_TIMEOUT_MS` | `3000` | Per-call timeout for readiness checks |
| `READINESS_CACHE_TTL_MS` | `5000` | Readiness result cache |
| `READINESS_FUNDING_FLOOR_STROOPS` | `0` | Minimum signer balance for readiness |
| `AUDIT_LOG_FILE` | unset | Mirror audit records to a file |
