### PR TITLE
fix: implement public surface for src/mcp/index.js

### DIFF
--- a/src/mcp/index.js
+++ b/src/mcp/index.js
@@ -1,0 +1,4 @@
+// Public surface for the x402 MCP server module.
+// Re-exports the core server class so external callers can
+// import from 'src/mcp' without coupling to internal file names.
+export { McpServer } from './server.js';


### PR DESCRIPTION
## Problem

src/mcp/index.js was a zero-byte placeholder that no file imported. It existed but served no purpose, making the module surface undefined.

## Solution

Turn src/mcp/index.js into the **public module surface** for the MCP package by re-exporting McpServer from server.js.

This follows the same pattern already established in src/sdk/index.js:

\\\js
// src/sdk/index.js  (existing convention)
export { validateDiscoveryDeclaration } from './validation.js';
\\\

\\\js
// src/mcp/index.js  (this PR)
export { McpServer } from './server.js';
\\\

External callers can now write:
\\\js
import { McpServer } from './src/mcp/index.js';
\\\
instead of reaching into server.js directly.

## Testing

No tests were broken. The existing cli.js still imports from ./server.js directly (no change needed there since it is the CLI entry point, not a library consumer).

Closes #171