### PR TITLE
fix(eval): replace hardcoded sleep with deterministic flush()

### DIFF
--- a/eval/runner.js
+++ b/eval/runner.js
@@ -72,8 +72,9 @@ async function runEval() {
     }
   }
 
-  // Wait a tick for async background embeddings to finish
-  await new Promise(resolve => setTimeout(resolve, 100));
+  // Wait for all background embeddings to complete before running queries.
+  // flush() is deterministic — no hardcoded sleep needed.
+  await store.flush();
 
   const K = 3;
   let totalPrecision = 0;

--- a/src/catalog/memory.js
+++ b/src/catalog/memory.js
@@ -20,6 +20,9 @@ export class MemoryCatalogStore {
     this.resources = new Map();
     this.embeddingClient = new EmbeddingClient(config.embeddingsUrl);
     this.enableReranking = config.enableReranking;
+    // Track in-flight background embedding promises so callers can await
+    // all of them via flush() instead of relying on a hardcoded sleep.
+    this._pendingEmbeddings = new Set();
   }
 
   _key(resource) {
@@ -62,7 +65,7 @@ export class MemoryCatalogStore {
 
     // Re-embed asynchronously without blocking the upsert (or the payment path)
     if (this.embeddingClient.url) {
-      Promise.resolve().then(async () => {
+      const p = Promise.resolve().then(async () => {
         try {
           const text = this.embeddingClient.composeDocument(entry);
           const vector = await this.embeddingClient.embed(text);
@@ -71,11 +74,24 @@ export class MemoryCatalogStore {
           }
         } catch (err) {
           console.warn(`[Catalog] Failed to re-embed ${key}: ${err.message}`);
+        } finally {
+          this._pendingEmbeddings.delete(p);
         }
       });
+      this._pendingEmbeddings.add(p);
     }
 
     return entry;
+  }
+
+  /**
+   * Await all in-flight background embedding requests.
+   * Use this in tests and eval harnesses instead of a fixed sleep:
+   *
+   *   await store.flush(); // deterministic — no setTimeout needed
+   */
+  async flush() {
+    await Promise.allSettled([...this._pendingEmbeddings]);
   }
 
   async getResource(url, toolName = null) {


### PR DESCRIPTION
## Problem

`eval/runner.js` used a hardcoded 100 ms sleep to wait for background embedding promises to settle before running search queries:

```js
// Wait a tick for async background embeddings to finish
await new Promise(resolve => setTimeout(resolve, 100));
```

This is a **race condition**: on a slow CI runner or under load, 100 ms may not be enough. The eval could run against incompletely-embedded resources, producing non-deterministic scores and hard-to-reproduce failures.

## Solution (two-part)

### 1. `src/catalog/memory.js` — `MemoryCatalogStore`

Added a `_pendingEmbeddings: Set` that tracks every in-flight background embedding promise. Each promise removes itself on settle (via `finally`). A new **`flush()`** method awaits all pending work deterministically:

```js
async flush() {
  await Promise.allSettled([...this._pendingEmbeddings]);
}
```

The hot-path contract is unchanged: `upsertResource` still returns immediately; embedding still runs in a microtask.

### 2. `eval/runner.js`

Replaced the `setTimeout` with `await store.flush()`:

```js
// Before (fragile):
await new Promise(resolve => setTimeout(resolve, 100));

// After (deterministic):
await store.flush();
```

## Testing

Run the existing eval harness — it should produce the same scores as before but now be fully deterministic across environments:

```bash
node eval/runner.js
```

Closes #210
