### PR TITLE
docs: route audit, role-based guides, deployment paths, conformance maintenance (closes #145 #154 #156 #163)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,16 @@ PORT=3402
 # Comma-separated caller API keys. Unset = open, correct for free testnet.
 # FACILITATOR_API_KEYS=
 
+# ── Rate limits and metering (#157) ─────────────────────────────────────────
+# Global defaults as comma-separated metric=value pairs; applied to any caller
+# without a per-key override, and per source IP in open mode. Metrics:
+#   verify_rpm, settle_rpm, settle_rph, settle_rpd,
+#   fee_spd (cumulative sponsored fee per day, in stroops — the spend cap),
+#   catalog_rpm
+# RATE_LIMIT_GLOBAL="verify_rpm=60,settle_rpm=10,settle_rph=100,settle_rpd=1000,fee_spd=5000000,catalog_rpm=10"
+# Per-key overrides: RATE_LIMIT_<keyId> (keyId from FACILITATOR_API_KEYS).
+# RATE_LIMIT_admin="verify_rpm=500,settle_rpm=50,fee_spd=10000000"
+
 # Pubnet is opt-in and needs its own secret or secret pool.
 # ENABLE_PUBNET=false
 # FACILITATOR_SECRET_PUBNET=
@@ -71,9 +81,14 @@ PORT=3402
 # ── Horizon/RPC connection pooling and circuit breaker (#120) ─────────────
 # Max keep-alive sockets per origin.
 # HORIZON_MAX_SOCKETS=64
-# Idle socket lifetime / hard socket lifetime cap (ms).
+# Idle socket lifetime / hard socket lifetime cap / response header timeout (ms).
 # HORIZON_KEEP_ALIVE_TIMEOUT_MS=4000
 # HORIZON_KEEP_ALIVE_MAX_TIMEOUT_MS=10000
+# HORIZON_HEADERS_TIMEOUT_MS=30000
+# Force IPv4 for outbound RPC/Horizon connections (default true; friendbot and
+# Soroban RPC advertise AAAA records that hang on IPv4-only hosts). Set to
+# "false" to let the OS resolve normally.
+# RPC_FORCE_IPV4=true
 # Circuit breaker: request timeout, failure percentage that trips it, and how
 # long it stays open before probing recovery (ms). Complements the RPC-level
 # breaker (#105): this one also trips on slow responses and covers every
@@ -107,3 +122,10 @@ PORT=3402
 # limit rejections, catalog writes) in addition to stdout, as one JSON line
 # per event. Unset = stdout only.
 # AUDIT_LOG_FILE=/var/log/facilitator/audit.jsonl
+
+# ── Bazaar search quality (#153) ───────────────────────────────────────────
+# Optional embedding endpoint used by /discovery/search for semantic retrieval.
+# Unset = lexical search only. ENABLE_RERANKING turns on the second-pass
+# reranker when an endpoint is available.
+# EMBEDDINGS_URL=https://embeddings.example.com/v1
+# ENABLE_RERANKING=false

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -8,8 +8,37 @@ The x402 facilitator provides a thin HTTP transport. Authentication in this serv
 
 The facilitator operates as a sponsored fee-payer and transaction submitter on behalf of known, trusted resource servers.
 
-- **`/supported` and `/healthz`**: These routes are completely open by design. `/supported` is a discovery endpoint that clients must be able to read before establishing any relationship with the service.
-- **`/verify` and `/settle`**: These routes sponsor transaction fees and consume resources. They require a valid API key (unless running in open mode on testnet).
+Everything else in this document is the route inventory: what is authenticated, what is not, and why.
+
+## Route Inventory
+
+This table is the authoritative answer to "what is authenticated here". It is audited against `src/app.js` route by route, and the audit is enforced by `test/docs-routes.test.js` — adding a route to the app without updating this table fails the test suite, so the next omission is a CI failure rather than a documentation drift.
+
+| Route | Authentication | Rate limited | Open mode (no API keys configured) | Why |
+| --- | --- | --- | --- | --- |
+| `GET /healthz` | none | no | open | Liveness probe; answers `{ ok: true }` while the process runs. |
+| `GET /readyz` | none | no | open | Readiness probe; names the failing dependency per network when unhealthy. |
+| `GET /metrics` | none | no | open | Prometheus text exposition for the operator; no caller data. |
+| `GET /supported` | none | no | open **by design** | Discovery endpoint: clients must read it before establishing any relationship with the service, so it cannot be gated behind a key they do not have yet. |
+| `GET /discovery/resources` | none | no¹ | open **by design** | Catalog read: agents and sellers browse the Bazaar before they hold a key. |
+| `GET /discovery/search` | none | no¹ | open **by design** | Catalog search — same rationale as the listing read, but the more expensive of the two. |
+| `POST /discovery/resources` | API key | yes (catalog bucket) | open | Catalog write: creates or overwrites a public listing, so it is metered and audited. |
+| `POST /verify` | API key | yes (verify bucket) | open | Sponsors verification work; consumes resources, so it is metered. |
+| `POST /settle` | API key | yes (settle bucket) | open | Sponsors transaction fees; the expensive, money-moving route, so it is metered and audited. |
+| `GET /settlements/:idempotencyKey` | API key | no | open | Settlement status read, scoped to the caller's `keyId`. |
+| `GET /usage` | API key — **strict** | n/a (reads the meter) | **refused** | The one route that refuses open mode: it exists to meter authenticated callers, and with no keys there is nothing to meter. Returns `401` with reason `open_mode_usage_forbidden`. |
+| `OPTIONS <cors-enabled route>` | none | no | open | CORS preflight; cannot carry an API key, so it is answered before credentials matter. |
+| anything else | n/a | n/a | n/a | `404` with reason `route_not_found`. |
+
+¹ The discovery read routes are **unauthenticated and unmetered today**. Whether reads should be rate limited — and whether they stay open at all — is tracked in [#135](https://github.com/accensa/x402-facilitator-stellar/issues/135). If that issue only adds metering, the posture here stays "unauthenticated but metered"; if it changes authentication, this table changes with it.
+
+### Open mode means "open, except /usage"
+
+When `FACILITATOR_API_KEYS` is unset or empty, the facilitator runs in **open mode**: every route above that says "open" is truly unauthenticated, and the server logs a loud warning at boot.
+
+The one deliberate refusal is `GET /usage`, which requires `requireApiKeyStrict` — stricter than the `requireApiKey` used everywhere else. In open mode it answers `401` with reason `open_mode_usage_forbidden` instead of serving a meter nobody is metered against.
+
+Open mode is acceptable (and often desired) for **public testnet deployments** to allow frictionless developer onboarding. It is strongly discouraged on pubnet, where unauthenticated callers can drain the signer's funds by submitting valid but abusive transactions.
 
 ## Configuring API Keys
 
@@ -42,13 +71,6 @@ A caller authenticates by providing a key in the HTTP `Authorization` header. Tw
 
 Malformed headers or unrecognized keys will return a `401 Unauthorized` with a distinct `reason` code (e.g., `invalid_api_key`, `missing_auth_header`, `malformed_auth_header`).
 
-## Open Mode
-
-If `FACILITATOR_API_KEYS` is unset or empty, the facilitator runs in **open mode**.
-This means all routes are unauthenticated. The server logs a loud warning at boot when running in this mode.
-
-Open mode is acceptable (and often desired) for **public testnet deployments** to allow frictionless developer onboarding. It is strongly discouraged on pubnet, where unauthenticated callers can drain the signer's funds by submitting valid but abusive transactions.
-
 ## CORS
 
 Cross-origin access is decided **per route class**, because the two classes carry opposite risk:
@@ -70,3 +92,4 @@ Notes:
 
 - `Authorization` is not a CORS-safelisted request header, so every browser call to `/verify` or `/settle` triggers a preflight (`OPTIONS`). The preflight is answered with `Authorization` and `Content-Type` in `Access-Control-Allow-Headers`; without a grant the browser blocks the actual request.
 - `RateLimit-*`, `Retry-After` and `EXTENSION-RESPONSES` are named in `Access-Control-Expose-Headers`, so rate-limit state and the Bazaar cataloguing outcome are readable from browser JavaScript.
+- `/healthz`, `/readyz` and `/metrics` carry no CORS configuration at all: they are operator endpoints, not browser surfaces.

--- a/docs/BUYER.md
+++ b/docs/BUYER.md
@@ -1,10 +1,290 @@
-# Buyer / Agent Guide
+# Buyer / Agent Guide: discover, pay, and call paid endpoints on Stellar testnet
 
-1. **Fund a testnet account:** Use the Stellar laboratory or CLI to create and fund a keypair.
-2. **Discover a resource:** Query the Bazaar (`GET /discovery/search`) or use the MCP server.
-3. **Pay for a call:** 
-   ```bash
-   curl -X POST -H "Authorization: X402 ..." <resource_url>
-   ```
-4. **Spending controls:** Ensure your agent checks the `402 Payment Required` terms before signing any payload.
-5. **Smart-account payers:** Use multi-sig or smart accounts for policy-based spending.
+This guide is for anyone whose agent (or code) needs to find and pay for x402-protected
+resources on Stellar testnet. It covers the full agent loop — discover, pay, retry —
+with a copy-pasteable script, what to do with **every** rejection code the facilitator
+can emit, and the MCP route for agent runtimes.
+
+By the end you will have:
+
+1. A funded Stellar testnet account that can pay.
+2. A working discover-pay-retry loop against a live paid endpoint.
+3. The MCP server wired up so any MCP-capable agent can find and call paid resources.
+
+---
+
+## 0. Prerequisites
+
+- **Node.js ≥ 20**.
+- **A facilitator to query.** `http://localhost:3402` if you run the one in this repo
+  ([`docs/DEPLOYMENT.md`](./DEPLOYMENT.md)), or a hosted URL.
+- **Something paid to call.** Either run the seller example
+  ([`examples/http-seller`](../examples/http-seller)) so its `/api/joke` endpoint is
+  live and catalogued, or search the facilitator's catalog for whatever you want.
+
+Testnet accounts are free via friendbot; nothing on this page spends real money.
+
+---
+
+## 1. Fund a testnet account
+
+Your agent pays with a Stellar account that holds the payment asset. Friendbot funds
+XLM instantly:
+
+```bash
+stellar keys generate agent --network testnet --fund
+stellar keys show agent --secret   # the S... secret, used everywhere below
+```
+
+The buyer guide's examples use the environment variable `AGENT_PAYER_SECRET_KEY` for
+that secret. If the resource you are buying is priced in USDC, your account also needs
+a USDC trustline and a few USDC — see the trustline snippet in
+[`docs/SELLER.md`](./SELLER.md#2-trustlines-what-your-account-must-hold) (it applies to
+the payer too). Friendbot does not fund USDC, so for USDC-priced testnet resources you
+need testnet USDC from Circle's faucet or a friend who has it.
+
+---
+
+## 2. Discover a resource
+
+Discovery is unauthenticated and open by design — agents browse before they hold any
+key ([`docs/AUTHENTICATION.md`](./AUTHENTICATION.md)).
+
+**Search** (lexical full-text, ranked by provenance and recency):
+
+```bash
+curl -s "http://localhost:3402/discovery/search?query=joke" | jq '.resources[] | {url, serviceName, pricing}'
+```
+
+**List with filters** (type, payTo, scheme, network, extensions):
+
+```bash
+curl -s "http://localhost:3402/discovery/resources?type=http&network=stellar:testnet&limit=10" | jq '.items[] | {url, serviceName, pricing}'
+```
+
+The catalog is populated automatically off the payment path when a seller's endpoint
+declares the `bazaar` extension, so a listing here means real money has already moved
+for that resource — payment-verified listings outrank manually registered ones
+([`docs/BAZAAR.md`](./BAZAAR.md) for the ranking model).
+
+Read the returned `pricing` before you pay: `asset` is the SEP-41 contract, `amount` is
+in **stroops** (1 XLM = 10,000,000 stroops).
+
+---
+
+## 3. The discover-pay-retry loop
+
+The protocol: your first request is unpaid and comes back `402 Payment Required` with
+terms; you sign a payment authorization for exactly those terms; you retry with the
+signature and get the resource. The facilitator verifies and settles on-chain — and
+sponsors the fee, so you only need the payment asset.
+
+This script is the whole loop, using the same client API the repo's own MCP server uses
+([`src/mcp/cli.js`](../src/mcp/cli.js)):
+
+```bash
+# pay-and-call.mjs — run with:
+#   AGENT_PAYER_SECRET_KEY=S... RESOURCE_URL=http://localhost:3401/api/joke node pay-and-call.mjs
+import { x402Client, x402HTTPClient } from '@x402/core/client';
+import { ExactStellarScheme as ExactStellarClient } from '@x402/stellar/exact/client';
+import { createEd25519Signer } from '@x402/stellar';
+
+const FACILITATOR_URL = process.env.FACILITATOR_URL || 'http://localhost:3402';
+const NETWORK = 'stellar:testnet';
+const SECRET = process.env.AGENT_PAYER_SECRET_KEY;
+const URL = process.env.RESOURCE_URL;
+// The seller example prices in XLM; the XLM SAC must be opted into the SDK's
+// client-side spend controls (default assets like USDC are allowed out of the
+// box). List any other asset you intend to pay for here.
+const XLM_SAC = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC';
+if (!SECRET || !URL) {
+  console.error('AGENT_PAYER_SECRET_KEY and RESOURCE_URL are required');
+  process.exit(1);
+}
+
+// 1. Wire the client: payer signer -> exact scheme -> HTTP transport.
+const payer = createEd25519Signer(SECRET, NETWORK);
+const client = new x402Client()
+  .register(NETWORK, new ExactStellarClient(payer))
+  .setSpendControls({ allowedAssets: [{ network: NETWORK, asset: XLM_SAC }] });
+const httpClient = new x402HTTPClient(client);
+
+// 2. Unpaid request — expect 402 with terms.
+const unpaid = await fetch(URL);
+if (unpaid.status !== 402) {
+  console.log(`Not gated (HTTP ${unpaid.status}) — nothing to pay.`);
+  process.exit(0);
+}
+
+// 3. Parse the payment requirements out of the 402.
+const paymentRequired = httpClient.getPaymentRequiredResponse(
+  name => unpaid.headers.get(name),
+  await unpaid.clone().json(),
+);
+const req0 = paymentRequired.accepts?.[0];
+console.log('Terms:', JSON.stringify(req0, null, 2));
+
+// 4. Sign a payment authorization for those terms.
+const paymentPayload = await httpClient.createPaymentPayload(paymentRequired);
+
+// 5. Retry with the payment signature.
+const paid = await fetch(URL, {
+  headers: httpClient.encodePaymentSignatureHeader(paymentPayload),
+});
+
+// 6. Read the settlement outcome the facilitator reported.
+const settle = httpClient.getPaymentSettleResponse(name => paid.headers.get(name));
+console.log('Settlement:', JSON.stringify(settle, null, 2));
+
+if (paid.status !== 200) {
+  console.error(`Paid request failed: HTTP ${paid.status} — ${settle?.errorReason ?? 'unknown'}`);
+  process.exit(1);
+}
+console.log('Resource:', await paid.text());
+console.log('Tx: https://stellar.expert/explorer/testnet/tx/' + (settle?.transaction ?? ''));
+```
+
+Run it against the seller example:
+
+```bash
+AGENT_PAYER_SECRET_KEY=S... RESOURCE_URL=http://localhost:3401/api/joke node pay-and-call.mjs
+```
+
+You should see the 402 terms, then a settlement object with a transaction hash, then the
+joke. The transaction hash is the receipt — verify it yourself:
+
+```bash
+curl -s https://horizon-testnet.stellar.org/transactions/<tx-hash> | jq '{successful, ledger, created_at}'
+```
+
+### The retry discipline
+
+The loop is **verify-then-settle**: the resource server calls the facilitator's
+`/verify` first (is this authorization valid?), then `/settle` (submit it on-chain).
+Your client only sees the final response. If the first `POST /verify` says
+`isValid: false`, the payment never reached the chain — fix what the reason code names
+and retry. If `/settle` succeeds, the money moved; if it reports
+`submitted_outcome_unknown`, the outcome is unknowable from the response — check the
+transaction hash on-chain before you ever resubmit (resubmitting a settled payment is
+how double-payment bugs happen).
+
+---
+
+## 4. Handling every rejection code
+
+Every non-success response carries a stable reason code — the facilitator's own, or one
+forwarded from the upstream `@x402/stellar` scheme. This is the decision table, grouped
+by what your agent should do. The full taxonomy lives in
+[`docs/REASONS.md`](./REASONS.md).
+
+### Retryable — back off and retry
+
+| Code | When | Action |
+| --- | --- | --- |
+| `rate_limited` | Exceeded a rate limit on `/verify`/`/settle` | Read `Retry-After` (seconds) from the response headers and wait exactly that long. |
+| `catalog_rate_limited` | Exceeded the cataloguing bucket | Wait and retry. |
+| `soroban_rpc_unreachable` | The chain is unreachable or the RPC circuit breaker is open | Exponential backoff and retry; this is an infrastructure outage, not a payment problem. |
+| `request_timeout` | The facilitator gave up waiting for the chain | Retry. |
+| `lock_timeout` | Settlement serialization lock was busy | Retry the `/settle` request. |
+| `facilitator_error` | Internal error above the scheme layer | Check server logs if you operate it; backoff and retry. |
+| `internal_error` | Unhandled server error | Backoff and retry. |
+| `invalid_exact_stellar_payload_simulation_failed` | The simulated transaction failed on the RPC node | Review balances and trustlines (the common cause: missing trustline for the priced asset), then retry. |
+
+### Not retryable — the request is wrong, fix it
+
+| Code | Meaning | Action |
+| --- | --- | --- |
+| `invalid_request` | Body malformed or missing required fields | Fix the request payload format. |
+| `missing_auth_header` / `malformed_auth_header` / `invalid_api_key` | Caller-authentication problem (for the API-key routes) | Provide a valid key in the `Authorization` header in the documented form. |
+| `open_mode_usage_forbidden` | `/usage` called while the facilitator runs open | Only relevant if you operate the facilitator; it refuses to meter nobody. |
+| `invalid_x402_version` | Unsupported protocol version | Upgrade/downgrade the payload version. |
+| `invalid_network` | Network not served by this instance | Target a supported network (`stellar:testnet` or `stellar:pubnet`). |
+| `invalid_exact_stellar_payload_malformed` | The Stellar payload cannot be parsed | Fix the base64 XDR. |
+| `invalid_exact_stellar_payload_wrong_operation` | Wrong operation type | Only `InvokeHostFunction` is accepted. |
+| `invalid_exact_stellar_payload_unsafe_tx_or_op_source` | Unsafe source account | The source must be the payer. |
+| `invalid_exact_stellar_payload_wrong_asset` | Wrong asset transferred | Transfer exactly the asset in the payment requirements. |
+| `invalid_exact_stellar_payload_wrong_function_name` | Wrong Soroban function | Must be `transfer`. |
+| `invalid_exact_stellar_payload_facilitator_is_payer` | Facilitator set as payer | Payer must be the client's own address. |
+| `invalid_exact_stellar_payload_wrong_recipient` | Wrong recipient | Transfer exactly to the requested `payTo`. |
+| `invalid_exact_stellar_payload_wrong_amount` | Wrong amount | Transfer exactly the requested amount. |
+| `invalid_exact_stellar_payload_fee_exceeds_maximum` | Simulated fee over the maximum | Rebuild with lower fee requirements. |
+| `invalid_exact_stellar_payload_event_*` | Simulated events did not match a single expected transfer (wrong contract, asset, from, to, amount, multiple transfers, missing transfer) | The transaction must transfer the priced asset exactly once, exactly as declared. |
+| `invalid_exact_stellar_payload_no_auth_entries` | Invocation unsigned | Sign the invocation. |
+| `invalid_exact_stellar_payload_unsupported_credential_type` | Bad credential | Use a standard Soroban credential. |
+| `invalid_exact_stellar_payload_facilitator_in_auth` | Facilitator in auth entries | The facilitator adds its own; don't include it. |
+| `invalid_exact_stellar_signature_expiration_too_far` | Expiration beyond the maximum ledger | Lower the expiration ledger. |
+| `invalid_exact_stellar_payload_has_subinvocations` | Sub-invocations present | Remove them. |
+| `invalid_exact_stellar_payload_missing_payer_signature` | Payer did not sign | Sign the authorization. |
+| `invalid_exact_stellar_payload_unexpected_pending_signatures` | Extra pending signatures | Only the payer's should be pending. |
+| `invalid_exact_stellar_payload_authorization_not_signed` | Authorization not signed | Provide the auth signature. |
+| `invalid_resource` / `catalog_error` | Cataloguing problems on manual registration | Fix the resource payload / check logs. |
+
+### Special: do not blindly resubmit
+
+| Code | Meaning | Action |
+| --- | --- | --- |
+| `submitted_outcome_unknown` | Settlement submitted to the network but the facilitator timed out waiting for confirmation | **Do NOT resubmit blindly.** Look up the returned `transaction` hash on-chain; if it settled, you are done — resubmitting risks paying twice. |
+
+---
+
+## 5. The MCP route for agent runtimes
+
+Rather than writing the loop yourself, an MCP-capable agent can use this repo's
+standalone MCP server ([`src/mcp/cli.js`](../src/mcp/cli.js),
+[`docs/MCP.md`](./MCP.md)). It exposes three tools:
+
+- **`search_resources`** (free) — search the facilitator catalog with natural language.
+- **`get_resource`** (free) — full metadata and pricing for a specific URL.
+- **`call_paid_resource`** (paid) — does the entire 402 negotiation and payment
+  automatically, **spending money up to your configured caps**.
+
+Configure it for Claude Desktop:
+
+```json
+{
+  "mcpServers": {
+    "x402-stellar": {
+      "command": "node",
+      "args": ["/path/to/x402-facilitator-stellar/src/mcp/cli.js"],
+      "env": {
+        "AGENT_PAYER_SECRET_KEY": "S...YOUR_TESTNET_KEY...",
+        "MAX_FEE_PER_CALL_STROOPS": "1000",
+        "MAX_SESSION_SPEND_STROOPS": "50000",
+        "FACILITATOR_URL": "http://localhost:3402"
+      }
+    }
+  }
+}
+```
+
+The **hard spending controls** are the part to trust: `MAX_FEE_PER_CALL_STROOPS`
+(default `1000` stroops = 0.0001 XLM) bounds any single call, `MAX_SESSION_SPEND_STROOPS`
+(default `10000`) bounds the session, and a refusal happens **before** any money moves.
+The worked example [`examples/mcp-agent`](../examples/mcp-agent) runs the whole loop —
+discover, refused call (deliberately under-budgeted), successful call — and prints the
+settled transaction hash:
+
+```bash
+cd examples/mcp-agent
+npm install
+npm start   # requires the facilitator AND the http-seller example running
+```
+
+---
+
+## 6. Going further
+
+- **Spending controls in your own loop** — the script in §3 signs exactly the terms the
+  server offered; never sign terms you did not read. Check `maxAmountRequired` against
+  your budget before signing (that is what the MCP server's `assertCanSpend` does).
+- **Smart-account payers** — multi-sig and smart accounts work; see
+  [`docs/REASONS.md`](./REASONS.md) for how the scheme treats auth entries.
+- **Operator's view** — why some of the codes above look the way they do, and what the
+  facilitator does when its RPC is down, is in [`docs/OPERATIONS.md`](./OPERATIONS.md).
+
+## Reference
+
+- [`examples/mcp-agent`](../examples/mcp-agent) — the worked MCP agent loop.
+- [`docs/MCP.md`](./MCP.md) — MCP server configuration and tools.
+- [`docs/BAZAAR.md`](./BAZAAR.md) — catalog endpoints, filters, ranking.
+- [`docs/REASONS.md`](./REASONS.md) — the exhaustive rejection taxonomy.

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -301,3 +301,94 @@ only inputs are a network connection and Node 22+; the accounts fund themselves.
 If you get a different result, that is a bug report worth filing — the README
 says a conformance failure is the most useful contribution to this repo, and it
 means it.
+
+## 7. Post-grant maintenance commitment
+
+This section is the stated commitment the SCF RFP §3.6 asks for: how spec and
+`@x402/*` drift is tracked after the grant, what triggers a conformance re-run, how a
+breaking upstream change is handled, and how long conformance is maintained. The
+mechanism below is not aspirational — it is the drift-monitoring work tracked in
+[#15](https://github.com/accensa/x402-facilitator-stellar/issues/15), whose
+implementation (PR [#254](https://github.com/accensa/x402-facilitator-stellar/pull/254))
+configures the automation and writes the reviewed-baseline policy this section commits
+to.
+
+### What is watched, and by what mechanism
+
+Two distinct things drift, and they are watched by two mechanisms:
+
+1. **The wire protocol and the `@x402/*` packages** (conformance). Renovate groups
+   `@x402/*` into a single PR per release (they release together); the nightly
+   conformance job
+   (`.github/workflows/conformance.yml`, daily `0 6 * * *`, also `workflow_dispatch`)
+   runs the upstream x402 e2e suite against our facilitator. The upstream SHA under
+   test is recorded, and the last manually-reviewed SHA is held in `docs/UPSTREAM.md`
+   so every diff is against a known baseline.
+2. **Discovery / Bazaar conventions** (a separate obligation, §3.2). The Bazaar
+   extension schema and the catalog filters come from `@x402/extensions`, which is in
+   the same Renovate group — but the *conventions* (what the catalog must accept, how
+   listing validation behaves) are judged by the same upstream suite plus the
+   search-evaluation harness (`npm run eval`, run in CI). Convention drift is tracked
+   in the same drift issue as wire drift, because the two surface through the same
+   upgrade, but the response differs: a wire break fails the conformance job; a
+   convention break fails the eval gate or the Bazaar conformance scenarios.
+
+### Cadence and triggers
+
+| Trigger | Action | Responsible | SLA |
+| --- | --- | --- | --- |
+| Nightly (daily) | Conformance run against `x402-foundation/x402@main` | CI, no human in the loop | Failure opens/updates a tracking issue with the run URL (workflow change tracked in [#192](https://github.com/accensa/x402-facilitator-stellar/issues/192)) |
+| Weekly | Spec-drift job diffs tracked spec files against `docs/UPSTREAM.md` baseline; opens an issue on change | CI opens; a maintainer reviews within the week | Issue triaged within 5 working days |
+| `@x402/*` bump PR | Conformance job runs against the PR; the PR is blocked on its failure | CI gate; maintainer merges or reverts | Before merge — a red conformance build never merges |
+| Upstream release notice | Release notes / npm advisory | Maintainer review | Reviewed before the next scheduled run |
+
+Ownership: the drift issue is assigned to a named maintainer at all times; an
+unassigned alert is a log line, so the assignment is part of the mechanism, not an
+afterthought.
+
+### Breaking-change response
+
+When an upstream change invalidates current behaviour (a renamed field, a tightened
+validation rule, a new required header):
+
+1. **Detect** — the nightly job or the bump-PR gate goes red and names the upstream
+   SHA; the drift issue records it.
+2. **Assess** — determine whether the break is wire-level (clients must change) or
+   service-level (only we must change). Wire-level breaks are the ones that matter to
+   integrators.
+3. **Communicate** — sellers and agents already integrated are told through the drift
+   issue, the release notes, and — for wire-level breaks — a
+   `docs/CONFORMANCE.md` entry dated with the affected upstream SHA and the support
+   window below. Integrators who do not read the issue tracker are reached via the
+   dependency upgrade path: a grouped `@x402/*` bump carries the break, so anyone who
+   upgrades gets the documentation with it.
+4. **Adopt or hold** — adopt within the support window, or pin the previous `@x402/*`
+   version for the remainder of the window while the break is worked. The pin is a
+   documented, deliberate state, not a silent one.
+
+### Maintenance horizon
+
+Conformance is maintained for **24 months after the grant ends**, and the commitment
+is bounded: after that horizon, this repository's conformance posture will be
+re-assessed and stated explicitly rather than assumed. During the horizon:
+
+- the nightly conformance job and the drift watch keep running on the published
+  schedule;
+- `@x402/*` bumps are adopted within the support window above;
+- the protocol version this service speaks is supported for **one minor version back**
+  from the latest `@x402/*` release, matching the upstream package's own support
+  window.
+
+A bounded commitment that will be kept is worth more than an unbounded one that will
+not; the re-assessment at the horizon is part of the commitment, not a loophole.
+
+### Where this is enforced
+
+- `.github/workflows/conformance.yml` — the nightly run (and its failure notification,
+  [#192](https://github.com/accensa/x402-facilitator-stellar/issues/192)).
+- [#15](https://github.com/accensa/x402-facilitator-stellar/issues/15) — the
+  drift-monitoring issue this section implements; PR
+  [#254](https://github.com/accensa/x402-facilitator-stellar/pull/254) is its
+  automation and policy.
+- `docs/UPSTREAM.md` — the reviewed-baseline SHA and the full review policy (created
+  by the drift-monitoring implementation).

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -35,6 +35,70 @@ Properties of this mechanism, and why it is wired this way:
   manager injected.
 - **`.env` is gitignored.** `FACILITATOR_SECRET` is a signing key.
 
+### Validated cold-start path
+
+On 2026-08-26 the documented path was walked from a clean clone, following only this
+file and `.env.example`, against live Stellar testnet:
+
+```bash
+git clone <this repo>
+npm ci
+stellar keys generate facilitator --network testnet --fund   # or any funded S... key
+export FACILITATOR_SECRET="$(stellar keys show facilitator --secret)"
+npm start
+```
+
+Result: the process boots, `GET /healthz` returns `{ ok: true }`, `GET /supported`
+advertises `extra.areFeesSponsored: true`, and `GET /readyz` reports `ready` with
+`signer_funded: true` once the account is funded. The full `npm run e2e` conformance
+run (unmodified canonical client, real testnet payment) also passes against the
+locally-run facilitator.
+
+Two things broke during that walk and were fixed in the same change:
+
+- **`GET /readyz` always failed `signer_funded`** with a cryptic "Received undefined"
+  error, even for funded accounts: the checker read `getLedgerEntries` responses as
+  `entry.val`, but Soroban RPC returns the ledger data under `entry.xdr`. Fixed in
+  `src/readiness.js`; the test stubs were updated to the real wire shape so the bug
+  cannot ship again.
+- **The e2e path could not start**: `npm ci` resolved an incoherent `@x402/*` set
+  (`@x402/express@2.23` with `@x402/stellar@2.21`), and the newer express expected a
+  `paymentFlows` API the older stellar did not expose. The `@x402/*` set was aligned
+  to `2.23.0` (the drift this repo commits to tracking in
+  [`docs/CONFORMANCE.md`](./CONFORMANCE.md)); the e2e script and MCP client were then
+  updated for the client-side `spendControls` the new core enforces.
+
+### Hosted deployment
+
+**There is no publicly hosted instance of this facilitator today.** No URL is
+operated, no availability commitment is made, and the README says so explicitly. The
+hosted path — where it runs, its availability target and status page, and how a seller
+obtains credentials — is tracked in
+[#19](https://github.com/accensa/x402-facilitator-stellar/issues/19); until it lands,
+teams wanting a hosted facilitator should run their own from this file or use the
+upstream ecosystem's hosted option (see
+[Stellar's x402 docs](https://developers.stellar.org/docs/build/agentic-payments/x402)).
+
+What a hosted offering will need to state, per the RFP: testnet free and frictionless
+(open mode is the default), mainnet pricing configurable rather than hardwired (fee
+ceilings and per-key limits — see below), and an availability commitment that is
+actually measured rather than claimed.
+
+### Testnet and mainnet posture
+
+| | Testnet (default) | Pubnet (opt-in) |
+| --- | --- | --- |
+| Enable | nothing to do | `ENABLE_PUBNET=true` **and** its own secret **and** its own RPC URL |
+| Signer | `FACILITATOR_SECRET` / `FACILITATOR_SECRETS` | `FACILITATOR_SECRET_PUBNET` / `FACILITATOR_SECRETS_PUBNET` — never the testnet key |
+| RPC | public endpoint by default | `STELLAR_RPC_URL_PUBNET` required; boot refuses the public endpoint |
+| Caller auth | unset keys = open mode (free, frictionless; per-IP limits apply) | API keys strongly recommended; open mode discouraged |
+| Fees | `MAX_TX_FEE_STROOPS` (default 50000) | `MAX_TX_FEE_STROOPS_PUBNET` (default 50000) — configurable, not hardwired |
+| Rate limits | `RATE_LIMIT_GLOBAL`, per-key `RATE_LIMIT_<keyId>` | same, per deployment |
+
+Boot enforces the separation: `ENABLE_PUBNET=true` without an independent pubnet
+secret, or without `STELLAR_RPC_URL_PUBNET`, fails at startup rather than serving
+mainnet with a testnet-shaped config.
+
 ### Deployment topology and client IP resolution
 
 Whether the service can see the real client IP depends on what sits in front of
@@ -80,9 +144,15 @@ keeps open-mode callers out of each other's buckets.
 | `RPC_BREAKER_THRESHOLD` | No | Consecutive connection failures that open the RPC circuit breaker (default `10`). |
 | `RPC_BREAKER_COOLDOWN_MS` | No | How long an open breaker waits before a half-open probe (default `30000`). |
 | `READINESS_TIMEOUT_MS` | No | Per-call timeout for readiness checks, independent of the RPC retry budget (default `3000`). |
-| `READINESS_CACHE_TTL_MS` | No | How long GET /health/ready serves a cached result (default `5000`). |
+| `READINESS_CACHE_TTL_MS` | No | How long GET /readyz serves a cached result (default `5000`). |
 | `READINESS_FUNDING_FLOOR_STROOPS` | No | Minimum signer balance reported by the readiness probe (default `0` = must exist). |
 | `AUDIT_LOG_FILE` | No | File that receives audit records in addition to stdout. |
+| `RATE_LIMIT_GLOBAL` | No | Global default limits as comma-separated `metric=value` pairs (`verify_rpm`, `settle_rpm`, `settle_rph`, `settle_rpd`, `fee_spd`, `catalog_rpm`); applies per IP in open mode. |
+| `RATE_LIMIT_<keyId>` | No | Per-key overrides; any metric omitted falls back to the global. |
+| `HORIZON_HEADERS_TIMEOUT_MS` | No | Response header timeout for Horizon/RPC sockets (default `30000`). |
+| `RPC_FORCE_IPV4` | No | Force IPv4 for outbound RPC/Horizon connections (default `true`; set `false` to let the OS resolve). |
+| `EMBEDDINGS_URL` | No | Embedding endpoint used by `/discovery/search` for semantic retrieval; unset = lexical only. |
+| `ENABLE_RERANKING` | No | `true` turns on the second-pass reranker when an endpoint is available. |
 
 ## Shared Rate-Limit State
 
@@ -119,7 +189,7 @@ during an outage.
 
 - `GET /healthz` — liveness. Always `{ ok: true }` while the process runs; no
   dependency checks. Point container/orchestrator **restart** logic here.
-- `GET /health/ready` — readiness. Checks each configured network's Soroban RPC
+- `GET /readyz` — readiness. Checks each configured network's Soroban RPC
   reachability and the signer account's funded balance; returns `503` naming the
   failing check per network when any is unhealthy. Results are cached
   (`READINESS_CACHE_TTL_MS`) and each check runs under its own timeout

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -13,7 +13,7 @@ dependency checks**, deliberately: a liveness probe that fails on a downstream
 outage triggers restart loops that make the outage worse (and a restart cannot
 fix someone else's RPC). The Docker `HEALTHCHECK` targets this endpoint.
 
-### `GET /health/ready` — readiness
+### `GET /readyz` — readiness
 
 Returns `200 { status: "ready", ... }` when the instance can settle right now,
 or `503 { ok: false, status: "not_ready", networks: {...} }` naming which check
@@ -34,7 +34,7 @@ become an RPC burst, and every underlying call runs under its own
 ~12s retry budget.
 
 **Probe wiring rule:** restart logic → `/healthz`; traffic gating (load
-balancers, Kubernetes `readinessProbe`) → `/health/ready`.
+balancers, Kubernetes `readinessProbe`) → `/readyz`.
 
 ## Rate Limit Store
 
@@ -151,3 +151,97 @@ If a specific signer's `x402_signer_selected_total` counter stops incrementing w
 ### Adding Signers
 
 To add a new signer to the pool, generate and fund a new Stellar account, append its secret key to `FACILITATOR_SECRETS`, and restart the facilitator process. Boot validation ensures that malformed or duplicate secret keys are rejected before accepting traffic.
+
+## Monitoring
+
+### What is observed
+
+| Source | What it answers | Notes |
+| --- | --- | --- |
+| `GET /healthz` | liveness | Always `{ ok: true }` while the process runs; wire it to restart logic only. |
+| `GET /readyz` | readiness | Per-network RPC reachability and signer funding; names the failing check. Wire to traffic gating. |
+| `GET /metrics` | Prometheus text | Settlement/verification counters, signer selection and in-flight gauges, circuit-breaker state. |
+| Audit log | who did what | Settlements (with tx hash), auth failures, rate-limit rejections, catalog writes — one JSON line per event (`AUDIT_LOG_FILE` to mirror to a file). |
+| Request log | one redacted line per request | Headers redacted; the body is never logged. |
+
+### What to alert on
+
+| Alert | Signal | Runbook step |
+| --- | --- | --- |
+| Instance not ready | `/readyz` 503 | [RPC outage](#runbook-responding-to-an-rpc-outage) / [signer underfunded](#runbook-settlement-starting-to-fail) |
+| RPC unreachable | `soroban_rpc_unreachable` reason codes, breaker open | [RPC outage](#runbook-responding-to-an-rpc-outage) |
+| Signer balance low | readiness `signer_funded` failing | [Settlement starting to fail](#runbook-settlement-starting-to-fail) |
+| Stuck signer | `x402_signer_inflight` non-zero past max latency; selection counter stalled | [Stuck signer](#stuck-signer) |
+| Fee ceiling near cap | `fee_spd` approaching the limit | [Settlement starting to fail](#runbook-settlement-starting-to-fail) |
+
+### The uptime evidence
+
+The RFP asks for a 99%+ availability target evidenced, not asserted. This repo makes
+**no availability claim today**: no instance is operated, so there is nothing to
+measure, and self-reported uptime from the service itself is exactly the kind of
+evidence that does not count. External probes (liveness, readiness, a synthetic
+testnet payment, signer balance) with a named alert owner and a public status page are
+the deliverable, tracked in
+[#19](https://github.com/accensa/x402-facilitator-stellar/issues/19) — this section is
+the monitoring contract that issue will implement, not a claim that it exists yet.
+
+## Runbook
+
+### Runbook: deploying
+
+1. Build and tag the image by digest; push to your registry.
+2. Apply migrations before the process binds the port
+   (`psql "$DATABASE_URL" -f migrations/001_bazaar_catalog.sql`, then
+   `002_idempotency_keys.sql`).
+3. Start; gate traffic on `GET /readyz` going 200.
+4. Smoke-test with a real payment (the buyer guide's script in
+   [`docs/BUYER.md`](./BUYER.md) is a ready-made smoke test).
+
+### Runbook: upgrading
+
+1. Check `docs/CONFORMANCE.md` and the diff of `package.json` for wire-format changes
+   before upgrading — a bump of `@x402/*` can change response shapes.
+2. Rolling restart; both old and new must serve `/verify` during cutover.
+3. If a migration shipped, verify the previous image can still read the new schema
+   before finishing the roll.
+
+### Runbook: rotating keys
+
+1. Generate a new keypair, fund it, append it to `FACILITATOR_SECRETS` (pool mode)
+   alongside the old one; restart; confirm `/readyz` passes and a settlement works.
+2. Remove the old key from the pool; restart again.
+3. For a fee-bump signer, repeat with `FEE_BUMP_SECRET`, funding the new account before
+   the old one is drained.
+
+### Runbook: responding to an RPC outage
+
+1. **Detect:** `/readyz` reports `rpc_reachable: false`; clients see
+   `soroban_rpc_unreachable` and back off themselves.
+2. **Contain:** traffic gating on `/readyz` stops routing new traffic; the circuit
+   breaker refuses fast rather than hanging.
+3. **Diagnose:** check the RPC provider's status; confirm `STELLAR_RPC_URL` /
+   `STELLAR_RPC_URL_PUBNET` point where you think they do.
+4. **Recover:** switch the RPC URL (env change + restart) or wait for the provider; the
+   breaker half-opens probes and closes once the backend heals.
+5. **Do not** restart-loop on `/healthz` — a restart cannot fix someone else's RPC.
+
+### Runbook: settlement starting to fail
+
+1. **Detect:** `/readyz` `signer_funded` fails, or `fee_spd` sits at the ceiling.
+2. **Underfunded signer:** fund the account(s) above `READINESS_FUNDING_FLOOR_STROOPS`;
+   readiness clears on the next check.
+3. **Fee ceiling reached:** the meter working as designed. Raise `fee_spd` for the
+   affected key or accept the cap — the ceiling bounds what an abusive caller can drain.
+4. **Stuck signer:** remove the stuck account from `FACILITATOR_SECRETS`, restart,
+   reconcile the sequence number, re-add once healthy.
+5. **`submitted_outcome_unknown` callers:** tell them to look up the transaction hash
+   on-chain before resubmitting — resubmitting a settled payment risks paying twice.
+
+### Runbook: rollback
+
+Revert to the previously known-good image tag/digest. If a migration shipped in the
+failed deploy, verify the old image's schema compatibility before restarting it (see
+[`docs/DEPLOYMENT.md`](./DEPLOYMENT.md) § Rollback Procedure).
+
+The same runbook, framed for the operator persona with the diagnosis steps spelled out,
+is in [`docs/OPERATOR.md`](./OPERATOR.md) § 7.

--- a/docs/OPERATOR.md
+++ b/docs/OPERATOR.md
@@ -1,7 +1,318 @@
-# Operator Guide
+# Operator Guide: run, configure, and operate an x402 facilitator
 
-1. **Run the facilitator:** See `docker-compose.yml` for self-hosting.
-2. **Configure signers:** Set up `FACILITATOR_SECRET` and fee ceilings.
-3. **Monitoring and alerting:** Ensure logs are shipped to your observability stack.
-4. **Going to pubnet:** Follow key custody best practices when `ENABLE_PUBNET=true`.
-5. **Runbooks:** Refer to [OPERATIONS.md](./OPERATIONS.md) for more details.
+This guide is for the person running a facilitator — for a product, for a team, or for
+themselves. It covers both deployment paths (self-hosted and hosted), every
+configuration knob, key management, rate limiting and metering, monitoring, and the
+operational runbook. Detail lives in [`docs/DEPLOYMENT.md`](./DEPLOYMENT.md) (how to
+deploy) and [`docs/OPERATIONS.md`](./OPERATIONS.md) (how to operate); this page is the
+path through both.
+
+By the end you will have:
+
+1. A running facilitator, self-hosted or pointed at a hosted one, serving `stellar:testnet`.
+2. It configured for your environment: keys, limits, fee ceilings, CORS, proxies.
+3. A monitoring and alerting setup with a runbook for the failure modes that matter.
+
+---
+
+## 0. Decide: hosted or self-hosted
+
+| | Self-hosted | Hosted |
+| --- | --- | --- |
+| What it is | You run the container / process | You point clients at a facilitator someone else runs |
+| Getting started | §1 below | **Not yet offered publicly.** No hosted instance of *this* facilitator is operated at a URL anyone can reach today; the deployment, availability targets and status page are tracked in [#19](https://github.com/accensa/x402-facilitator-stellar/issues/19). Until then, teams that want a hosted facilitator can use the upstream ecosystem's hosted option (see [Stellar's x402 docs](https://developers.stellar.org/docs/build/agentic-payments/x402) for the OpenZeppelin Relayer plugin) or run their own from this repo. |
+| Testnet | Free; open mode is fine | Free and frictionless is the requirement — see §3 |
+| Mainnet | Fee ceilings and a dedicated RPC provider required | Pricing is operator-configurable, not hardwired — see §3 |
+
+**Decision rule:** if you need a hosted instance today, you are self-hosting until
+[#19](https://github.com/accensa/x402-facilitator-stellar/issues/19) lands. This
+document states that plainly rather than implying a hosted offering exists.
+
+---
+
+## 1. Self-hosted: from clone to serving traffic
+
+### Quickstart (local / evaluation)
+
+```bash
+git clone https://github.com/accensa/x402-facilitator-stellar.git
+cd x402-facilitator-stellar
+
+# The only required variable for testnet is a signer secret. Any S... key works;
+# generate one that is actually funded so readiness passes:
+stellar keys generate facilitator --network testnet --fund
+
+export FACILITATOR_SECRET="$(stellar keys show facilitator --secret)"
+npm ci
+npm start
+```
+
+Verify from another terminal:
+
+```bash
+curl -s localhost:3402/healthz            # {"ok":true}
+curl -s localhost:3402/readyz | jq .      # 200 with networks -> ready
+curl -s localhost:3402/supported | jq '.extra.areFeesSponsored'   # true
+```
+
+`/readyz` checks each network's RPC reachability and the signer's funded balance; a
+freshly funded account passes. If it reports `not_ready`, see the
+[troubleshooting section](#7-troubleshooting-and-runbook).
+
+### Docker / docker-compose
+
+```bash
+export FACILITATOR_SECRET="$(stellar keys show facilitator --secret)"
+docker compose up --build
+```
+
+`docker-compose.yml` ships the backing services (Postgres for shared rate-limit state
+and idempotency, Redis + Redlock quorum, Kafka for webhook delivery) and wires the URLs.
+The Docker `HEALTHCHECK` targets `/healthz` (liveness); point orchestrator traffic
+gating at `/readyz`.
+
+### Production deployment
+
+- **Image:** build from the pinned multi-stage `Dockerfile` (Node 20-alpine, non-root
+  user). Tag by digest; never by `latest`-style floating tag.
+- **Migrations:** when `DATABASE_URL` is set, apply `migrations/*.sql` before the
+  process binds the port (init container or deploy step). They are forward-compatible.
+- **Proxies:** set `TRUST_PROXY` (a hop count or explicit proxy list — never `true`) so
+  rate limiting keys on the real client IP, not the proxy's.
+- **Secrets:** from a secrets manager injected at runtime. Never baked into the image.
+- **Multi-instance:** `REDIS_URL` (or `RATE_LIMIT_STORE=postgres`) for one combined rate
+  limit across replicas; `DATABASE_URL` for durable idempotency; `REDIS_NODES` for
+  distributed locking. In-memory stores are single-instance only.
+
+The complete env-var table and topology guidance are in
+[`docs/DEPLOYMENT.md`](./DEPLOYMENT.md).
+
+---
+
+## 2. Every environment variable
+
+`docs/DEPLOYMENT.md` has the full table; `examples/.env.example` at the repo root is the
+checklist. The groups:
+
+| Group | Variables |
+| --- | --- |
+| **Signers** (testnet) | `FACILITATOR_SECRET` or `FACILITATOR_SECRETS` (pool), optional `FEE_BUMP_SECRET` |
+| **Signers** (pubnet, opt-in) | `ENABLE_PUBNET=true`, `FACILITATOR_SECRET_PUBNET` / `FACILITATOR_SECRETS_PUBNET`, optional `FEE_BUMP_SECRET_PUBNET`, required `STELLAR_RPC_URL_PUBNET` |
+| **Network / fees** | `STELLAR_RPC_URL` (testnet RPC, defaults to public), `MAX_TX_FEE_STROOPS`, `MAX_TX_FEE_STROOPS_PUBNET` |
+| **Caller auth** | `FACILITATOR_API_KEYS` (unset = open mode) |
+| **Rate limits / metering** | `RATE_LIMIT_GLOBAL`, `RATE_LIMIT_<keyId>` per-key overrides, `RATE_LIMIT_STORE`, `DATABASE_URL`, `REDIS_URL` |
+| **HTTP / CORS / proxy** | `PORT`, `CORS_ALLOWED_ORIGINS`, `TRUST_PROXY`, `NODE_ENV` |
+| **Shared stores** | `REDIS_URL`, `REDIS_NODES`, `DATABASE_URL`, `KAFKA_BROKERS`, `KAFKA_CLIENT_ID`, `KAFKA_WEBHOOK_TOPIC`, `KAFKA_WEBHOOK_GROUP_ID`, `WEBHOOK_URL` |
+| **Resilience** | `BREAKER_TIMEOUT_MS`, `BREAKER_ERROR_THRESHOLD_PERCENTAGE`, `BREAKER_RESET_TIMEOUT_MS`, `RPC_BREAKER_THRESHOLD`, `RPC_BREAKER_COOLDOWN_MS`, `RPC_FORCE_IPV4`, `HORIZON_MAX_SOCKETS`, `HORIZON_KEEP_ALIVE_TIMEOUT_MS`, `HORIZON_KEEP_ALIVE_MAX_TIMEOUT_MS`, `HORIZON_HEADERS_TIMEOUT_MS`, `REQUEST_TIMEOUT_MS`, `SHUTDOWN_GRACE_MS` |
+| **Readiness** | `READINESS_TIMEOUT_MS`, `READINESS_CACHE_TTL_MS`, `READINESS_FUNDING_FLOOR_STROOPS` |
+| **Audit / Bazaar** | `AUDIT_LOG_FILE`, `EMBEDDINGS_URL`, `ENABLE_RERANKING` |
+
+**House rule:** a variable the code reads and `.env.example` does not document is a bug
+— if you find one, fix `.env.example` in the same PR that touches the code.
+
+---
+
+## 3. Testnet vs mainnet posture
+
+The RFP requires testnet be free and frictionless while mainnet pricing is
+configurable, not hardwired. That distinction maps to configuration, and it is enforced
+at boot:
+
+**Testnet (default):**
+- Free and frictionless: `FACILITATOR_API_KEYS` unset runs **open mode** — no keys
+  needed, per-IP rate limits from `RATE_LIMIT_GLOBAL` still apply so one abusive client
+  cannot drain the faucet. The server logs a loud warning at boot so the choice is
+  never silent.
+- Public RPC is fine: `STELLAR_RPC_URL` defaults to the public testnet endpoint.
+- Fees: `MAX_TX_FEE_STROOPS` (default 50000 stroops = 0.005 XLM) is a ceiling, not a
+  hardwired price.
+
+**Pubnet (opt-in, and deliberately hard to trip into):**
+- `ENABLE_PUBNET=true` **and** its own `FACILITATOR_SECRET_PUBNET` **and** its own
+  `STELLAR_RPC_URL_PUBNET`. Boot refuses to serve pubnet with a testnet-shaped config
+  or the public RPC endpoint — running a mainnet facilitator against the public
+  endpoint is not something to run an availability target against.
+- **Separate keys, always.** The testnet signer must never be reused on pubnet; config
+  fails at boot if `ENABLE_PUBNET=true` without an independent pubnet secret.
+- Pricing stays configurable per deployment via `MAX_TX_FEE_STROOPS_PUBNET` and the
+  per-key rate-limit and fee-ceiling overrides — nothing is hardwired.
+
+---
+
+## 4. Key management
+
+The signer keys are the crown jewels: they sponsor transaction fees, and a leaked
+pubnet signer can be drained. Rules:
+
+1. **Testnet and pubnet keys are different accounts.** Always. Enforced at boot.
+2. **Inject at runtime** from a secrets manager (AWS Secrets Manager, Vault, K8s
+   Secrets). Never `ENV FACILITATOR_SECRET=...` in the image, never in git, never in
+   shell history (`docker run -e FACILITATOR_SECRET=...`).
+3. **Separate the fee payer from the pool** with `FEE_BUMP_SECRET` when you want one
+   funded account for fees while pool signers only manage sequence numbers. Trade-off:
+   the fee-bump account becomes a single point of failure if its balance runs dry.
+4. **Rotate by changing the env var and restarting** — key rotation and revocation
+   require a process restart (no stateful sessions). Plan for a rolling restart.
+5. **Fund every signer** above `READINESS_FUNDING_FLOOR_STROOPS`. `/readyz` checks all
+   pool signers and the fee-bump account and goes 503 if any is underfunded.
+6. **Watch for stuck signers.** `GET /metrics` exposes
+   `x402_signer_selected_total{signer=...}` and `x402_signer_inflight{signer=...}`; a
+   signer whose selection counter stops advancing while others continue has a
+   desynchronized sequence number (see [`docs/OPERATIONS.md`](./OPERATIONS.md) §
+   Multi-Signer Pool).
+
+Caller API keys (`FACILITATOR_API_KEYS`) are a separate class: `name:secret` pairs,
+held in memory as SHA-256 digests, never logged, compared in constant time. Unset =
+open mode (testnet default).
+
+---
+
+## 5. Rate limiting and metering
+
+The facilitator meters every paid route and enforces a **daily cumulative fee ceiling**
+— the ceiling that caps how much sponsored spend your signers can be drained of in a
+day.
+
+**Global defaults** (`RATE_LIMIT_GLOBAL`, comma-separated `metric=value`):
+
+```
+RATE_LIMIT_GLOBAL="verify_rpm=60,settle_rpm=10,settle_rph=100,settle_rpd=1000,fee_spd=5000000,catalog_rpm=10"
+```
+
+| Metric | Meaning |
+| --- | --- |
+| `verify_rpm` | `/verify` requests per minute |
+| `settle_rpm` | settlements per minute |
+| `settle_rph` / `settle_rpd` | settlements per hour / per day |
+| `fee_spd` | cumulative sponsored fee per day, in stroops — **the spend cap** |
+| `catalog_rpm` | cataloguing operations per minute (also per-IP in open mode) |
+
+**Per-key overrides** — `RATE_LIMIT_<keyId>`:
+
+```
+FACILITATOR_API_KEYS=admin:secret1
+RATE_LIMIT_admin="verify_rpm=500,settle_rpm=50,fee_spd=10000000"
+```
+
+Unset metrics fall back to the global. In open mode, `RATE_LIMIT_GLOBAL` is enforced
+per source IP instead of per key.
+
+**Shared state across replicas:** in-memory counters mean N replicas enforce N limits
+and a restart resets the fee ceiling. Set `REDIS_URL` (fails open to per-instance
+counters) or `RATE_LIMIT_STORE=postgres` with `DATABASE_URL` (fails closed with reason
+`rate_limit_store_unavailable` — a limiter that cannot see its counters must not answer
+"allowed").
+
+**What callers see:** `429` with a reason code and `RateLimit-Limit` /
+`RateLimit-Remaining` / `RateLimit-Reset` / `Retry-After` headers. `GET /usage` (API
+key required — the one route that refuses open mode) shows a caller their own meters.
+Full detail: [`docs/OPERATIONS.md`](./OPERATIONS.md).
+
+---
+
+## 6. Monitoring
+
+### What the service exposes
+
+| Endpoint | What it answers | Wire it to |
+| --- | --- | --- |
+| `GET /healthz` | liveness — `{ok:true}` while the process runs, no dependencies | container restart / process supervisor |
+| `GET /readyz` | readiness — per-network RPC reachability + signer funding, 503 naming the failure | load balancer traffic gating, K8s readinessProbe |
+| `GET /metrics` | Prometheus text: request/verify/settle counters, signer selection and in-flight gauges, circuit-breaker state | Prometheus + alerting |
+
+### What to alert on (minimum viable set)
+
+| Alert | Signal | Why it matters |
+| --- | --- | --- |
+| `/readyz` 503 | readiness check fails for any network | Every `/settle` will fail; stop routing traffic there |
+| Signer balance below floor | readiness `signer_funded` fail, or a balance probe | No settlement can be sponsored; fund before the pool runs dry |
+| `soroban_rpc_unreachable` in logs/audit | RPC circuit breaker open | Chain unreachable — the degraded-mode reason code is how clients distinguish this from a payment rejection |
+| Stuck signer | `x402_signer_inflight` non-zero past max latency, or selection counter stalled | Sequence-number desync; throughput collapses silently |
+| Fee ceiling near cap | `fee_spd` approaching the ceiling | The facilitator will start refusing settlements |
+
+### The honest part
+
+**This repo does not operate a monitored instance today**, so it makes no availability
+claim — and **external monitoring, alert routing to a named owner, and a public status
+page are open work tracked in [#19](https://github.com/accensa/x402-facilitator-stellar/issues/19)**,
+which this document coordinates with rather than duplicates. What you can do *today*
+for a self-hosted instance: scrape `/metrics`, probe `/readyz` from outside your
+infrastructure on a schedule, alert on the signals above, and record the incident
+history. The runbook below is written so an on-call engineer has a path even before the
+status page exists.
+
+---
+
+## 7. Troubleshooting and runbook
+
+### Deploying
+
+1. Build and tag the image by digest; push to your registry.
+2. Apply migrations before the process binds (`psql "$DATABASE_URL" -f migrations/001_bazaar_catalog.sql`, then `002_idempotency_keys.sql`).
+3. Start, then gate traffic on `/readyz` going 200.
+4. Smoke-test with a real payment before declaring the deploy done (the buyer guide's
+   script in [`docs/BUYER.md`](./BUYER.md) is a ready-made smoke test).
+
+### Upgrading
+
+1. Check `docs/CONFORMANCE.md` and the diff of `package.json` for wire-format
+   changes before upgrading — a bump of `@x402/*` can change response shapes
+   (a CHANGELOG is tracked in [#212](https://github.com/accensa/x402-facilitator-stellar/issues/212)).
+2. Rolling restart; both old and new must be able to serve `/verify` during the cutover.
+3. If a database migration shipped, verify forward compatibility (the repo's migrations
+   are designed to be; verify the previous image can still read the schema).
+
+### Rotating keys
+
+1. Generate a new keypair, fund it, add it to `FACILITATOR_SECRETS` alongside the old
+   one (pool mode), restart, confirm `/readyz` passes and settlements work.
+2. Remove the old key from the pool, restart again.
+3. For a fee-bump signer, repeat with `FEE_BUMP_SECRET`, keeping the new account funded
+   before the old one is drained of fees.
+
+### Responding to an RPC outage
+
+1. **Detect:** `/readyz` reports `rpc_reachable: false`; clients see
+   `soroban_rpc_unreachable` with `Retry-After`-style backoff in their own retry loops.
+2. **Contain:** traffic gating on `/readyz` stops routing new traffic; the circuit
+   breaker refuses fast rather than hanging.
+3. **Diagnose:** check the RPC provider's status page; confirm `STELLAR_RPC_URL` /
+   `STELLAR_RPC_URL_PUBNET` point where you think they do.
+4. **Recover:** switch the RPC URL (env change + restart) or wait for the provider; the
+   breaker half-opens probes and closes once the backend heals.
+5. **Do not:** restart-loop on `/healthz` — a restart cannot fix someone else's RPC.
+
+### When settlement starts failing
+
+1. **Detect:** `/readyz` `signer_funded` fails, or `fee_spd` is at the ceiling.
+2. **Underfunded signer:** fund the account(s) above `READINESS_FUNDING_FLOOR_STROOPS`;
+   readiness clears itself on the next check.
+3. **Fee ceiling reached:** this is the meter working as designed. Decide whether to
+   raise `fee_spd` for the affected key or accept the cap; the ceiling exists to bound
+   what an abusive caller can drain.
+4. **Stuck signer:** rotate the stuck account out of the pool (remove from
+   `FACILITATOR_SECRETS`, restart), investigate the sequence-number desync, re-add once
+   reconciled.
+5. **`submitted_outcome_unknown` from a caller:** that is a client-side question — tell
+   them to look up the transaction hash on-chain before resubmitting (see
+   [`docs/BUYER.md`](./BUYER.md) § retry discipline).
+
+### Rollback
+
+Revert to the previously known-good image tag/digest. If a migration shipped in the
+failed deploy, verify the old image's compatibility with the new schema before
+restarting it (see [`docs/DEPLOYMENT.md`](./DEPLOYMENT.md) § Rollback).
+
+---
+
+## Reference
+
+- [`docs/DEPLOYMENT.md`](./DEPLOYMENT.md) — the full deployment guide: topology, env
+  vars, shared stores, sizing, rollback.
+- [`docs/OPERATIONS.md`](./OPERATIONS.md) — rate limiting, metering, multi-signer pool,
+  health endpoints in depth.
+- [`docs/AUTHENTICATION.md`](./AUTHENTICATION.md) — caller auth, open mode, CORS.
+- [`docs/CONFORMANCE.md`](./CONFORMANCE.md) — what "conforms" means and how it is kept
+  honest.
+- [`docs/THREAT-MODEL.md`](./THREAT-MODEL.md) — what the service assumes and defends.
+- [`.env.example`](../.env.example) — the configuration checklist.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,47 @@
 # X402 Facilitator Documentation Hub
 
-Welcome to the X402 Facilitator documentation. Please choose the path that best matches your role:
+Welcome to the X402 Facilitator documentation. Choose the path that best matches your role:
 
-- [Seller Guide](./SELLER.md): "I have an API and I want to charge agents for it"
-- [Buyer / Agent Guide](./BUYER.md): "I want my agent to find and pay for services"
-- [Operator Guide](./OPERATOR.md): "I want to run my own facilitator"
+- [Seller Guide](./SELLER.md): "I have an API and I want to charge agents for it" — from zero
+  to a paid, catalogued endpoint on testnet: account setup, trustlines, the x402 endpoint,
+  the Bazaar listing, and what to do when cataloguing is rejected.
+- [Buyer / Agent Guide](./BUYER.md): "I want my agent to find and pay for services" — the
+  discover-pay-retry loop with a copy-pasteable script, every rejection code the service
+  can emit, and the MCP route for agent runtimes.
+- [Operator Guide](./OPERATOR.md): "I want to run my own facilitator" — hosted vs
+  self-hosted, every environment variable, key management, rate limiting and metering,
+  monitoring, and the operational runbook.
 
 **Reference:**
 - [Architecture](./ARCHITECTURE.md): System design, components, and the discovery path
 - [Glossary](./GLOSSARY.md): Terminology (Stellar, X402, and Facilitator concepts)
+- [Deployment](./DEPLOYMENT.md): Containers, topology, environment variables, shared stores
+- [Operations](./OPERATIONS.md): Rate limiting, metering, multi-signer pools, health endpoints
+- [Authentication](./AUTHENTICATION.md): What is authenticated, what is open, and why
+- [Bazaar](./BAZAAR.md): The discovery catalog — data model, endpoints, validation policy
+- [MCP](./MCP.md): The standalone MCP server for agent runtimes
+- [Reasons](./REASONS.md): The exhaustive rejection-reason taxonomy
+- [Conformance](./CONFORMANCE.md): Wire-level conformance evidence and the maintenance commitment
+
+## Contributing these guides to Stellar Developer Docs
+
+The SCF RFP names a role-based developer guide "contributed to Stellar Developer Docs"
+as a deliverable. These three guides are the in-repo source of that contribution.
+
+- **Where:** Stellar Developer Docs are maintained in the
+  [`stellar/stellar-docs`](https://github.com/stellar/stellar-docs) repository; the
+  x402 section lives under
+  `developers.stellar.org/docs/build/agentic-payments/x402`.
+- **How:** contributions are PRs to that repository. Follow
+  [`stellar-docs/CONTRIBUTING.md`](https://github.com/stellar/stellar-docs/blob/main/CONTRIBUTING.md)
+  for their conventions; the existing
+  [x402 page](https://developers.stellar.org/docs/build/agentic-payments/x402) is the
+  landing point a seller/buyer/operator set of guides would attach to.
+- **Upstream constraints:** the docs site is community-governed, so content must be
+  protocol-generic where possible (the facilitator is one implementation among several),
+  must not advertise this repository as the only option, and must be validated against
+  testnet before submission — the same standard these in-repo guides hold.
+- **Status:** the contribution is planned as a follow-up PR against `stellar/stellar-docs`
+  once the in-repo guides have been exercised by a second reader; tracked with the
+  rest of the wave deliverables. The in-repo guides are the living source of truth in
+  the meantime.

--- a/docs/SELLER.md
+++ b/docs/SELLER.md
@@ -1,36 +1,362 @@
-# Seller Guide
+# Seller Guide: from zero to a paid, discoverable endpoint on Stellar testnet
 
-1. **Add X402 to an existing Express API:** Add the `@x402/core` middleware to intercept requests.
-2. **Choose an asset and price:** Setup a trustline for USDC receipt. (See our demo-merchant example).
-3. **Declare discovery metadata:** Provide metadata on your endpoints using our Stellar-shaped SDK helpers:
-   
-   *Before:*
-   ```javascript
-   // Manual declaration without helpers (error-prone stroop conversion)
-   app.get('/api/resource', x402({
-       pricing: { amount: '25000000', asset: 'XLM' },
-       network: 'stellar:testnet',
-       scheme: 'exact'
-   }), (req, res) => { /* ... */ });
-   ```
-   
-   *After:*
-   ```javascript
-   // With discovery helpers
-   import { createStellarDiscoveryResource } from 'x402-facilitator-stellar/sdk';
-   
-   app.get('/api/resource/{id}', x402(createStellarDiscoveryResource({
-       routeTemplate: '/api/resource/{id}',
-       parameters: { id: 'The resource ID' },
-       pricing: { amount: '2.5', asset: 'XLM' }
-   })), (req, res) => { /* ... */ });
-   ```
-   
-   You can also validate your metadata offline without making payments:
-   ```bash
-   npx validate-discovery metadata.json
-   ```
-4. **Verify listing:** Check the Bazaar endpoint to ensure you are listed.
-5. **Troubleshooting:**
-   - *Error: Trustline missing.* Ensure you have an active trustline for the asset.
-   - *Error: Invalid signature.* Ensure the agent signs with the correct private key.
+This guide walks a seller from nothing to a live, paid, **catalogued** API endpoint on
+Stellar testnet — the same path the RFP's "under an hour to a paid, discoverable
+endpoint" claim rests on. Everything here is runnable on testnet today; the worked
+example lives in [`examples/http-seller`](../examples/http-seller) and is what the
+commands below walk through.
+
+By the end you will have:
+
+1. A Stellar testnet account that receives payment.
+2. An HTTP endpoint that answers `402 Payment Required` with x402 terms, then serves
+   the resource once those terms are paid.
+3. A listing in the facilitator's discovery catalog (the Bazaar) that agents can find
+   with `GET /discovery/search`.
+
+Time: about 30 minutes, most of it installing packages.
+
+---
+
+## 0. Prerequisites
+
+- **Node.js ≥ 20** (`node -v`).
+- **A facilitator to point at.** Either the one in this repo, run locally
+  ([`docs/DEPLOYMENT.md`](./DEPLOYMENT.md) — `FACILITATOR_SECRET` plus `npm start`
+  serves it on `http://localhost:3402`), or a hosted facilitator URL if one is
+  available to you. For testnet onboarding, open mode (no API keys) is the default and
+  is fine.
+- **A wallet tool or the `stellar` CLI** for account creation and trustlines. The
+  example auto-creates and funds a fresh testnet account for you, but you should
+  understand the account it is creating.
+
+No mainnet funds, no payment card, nothing to sign up for. Testnet accounts are free
+via friendbot.
+
+---
+
+## 1. The account that gets paid
+
+Every paid resource declares a `payTo` address — the Stellar account that receives the
+payment asset. In the example this is your merchant account, and the example creates
+and funds it automatically:
+
+```bash
+cd examples/http-seller
+npm install
+npm start
+```
+
+On first run you will see something like:
+
+```
+No merchant account configured. Generating a new one and funding via friendbot...
+Successfully funded GA4Z... via Friendbot.
+Saved secret to .merchant-secret for future runs.
+🚀 Paid API running at http://localhost:3401/api/joke
+```
+
+To create and fund such an account yourself (the CLI equivalent of what the example
+does):
+
+```bash
+stellar keys generate seller --network testnet --fund
+stellar keys show seller      # prints the public address; use it as payTo
+stellar keys show seller --secret   # the S... secret, for .merchant-secret
+```
+
+The example reads `MERCHANT_SECRET` if set, then `.merchant-secret`, then generates.
+If you want to reuse a specific account, set `MERCHANT_SECRET=S...` before `npm start`.
+
+> **Testnet only.** Everything in this guide is testnet. The `S...` secrets here hold
+> play money; the same steps on pubnet hold real money and the operational posture is
+> different (see [OPERATOR.md](./OPERATOR.md) and
+> [`docs/DEPLOYMENT.md`](./DEPLOYMENT.md)).
+
+---
+
+## 2. Trustlines: what your account must hold
+
+The payment asset is what the buyer's authorization transfers. **Native XLM needs no
+trustline** — every Stellar account can hold it. The example prices in XLM
+(`0.00025 XLM`), which is why it runs with a fresh friendbot account and zero setup.
+
+A SEP-41 token such as **USDC does require a trustline** on the receiving account, and
+the payer's account needs one too. Testnet USDC parameters:
+
+| | Value |
+|---|---|
+| Asset | `USDC` |
+| Issuer | `GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5` |
+| SEP-41 contract (what you put in `pricing.asset`) | `CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA` |
+
+Create the trustline once, from the seller account:
+
+```bash
+# trustline-usdc.mjs — run with: SELLER_SECRET=S... node trustline-usdc.mjs
+import { Asset, BASE_FEE, Horizon, Keypair, Networks, Operation, TransactionBuilder } from '@stellar/stellar-sdk';
+
+const SECRET = process.env.SELLER_SECRET;
+const kp = Keypair.fromSecret(SECRET);
+const usdc = new Asset('USDC', 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5');
+const server = new Horizon.Server('https://horizon-testnet.stellar.org');
+
+const account = await server.loadAccount(kp.publicKey());
+const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: Networks.TESTNET })
+  .addOperation(Operation.changeTrust({ asset: usdc, limit: '1000000' }))
+  .setTimeout(60)
+  .build();
+tx.sign(kp);
+const res = await server.submitTransaction(tx);
+console.log('Trustline created:', res.hash);
+```
+
+If you ever see `invalid_exact_stellar_payload_simulation_failed` with a
+`trustline entry is missing for account` error underneath, this is the cause: either
+the seller or the payer lacks the trustline for the priced asset.
+
+---
+
+## 3. Declare the endpoint and its price
+
+The x402 contract has three moving parts, all visible in
+[`examples/http-seller/index.js`](../examples/http-seller/index.js):
+
+1. **A resource server** that speaks the x402 payment protocol,
+2. **a facilitator client** that points at your facilitator, and
+3. **an Express app** with the paid route and its discovery metadata.
+
+```js
+import express from 'express';
+import {
+  paymentMiddlewareFromHTTPServer,
+  x402ResourceServer,
+  x402HTTPResourceServer,
+} from '@x402/express';
+import { HTTPFacilitatorClient } from '@x402/core/server';
+import { ExactStellarScheme as ExactStellarServer } from '@x402/stellar/exact/server';
+
+const NETWORK = 'stellar:testnet';
+const XLM_SAC = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC'; // native XLM on testnet
+const PRICE_STROOPS = '2500'; // 0.00025 XLM  (1 XLM = 10_000_000 stroops)
+const FACILITATOR_URL = process.env.FACILITATOR_URL || 'http://localhost:3402';
+
+const resourceServer = new x402ResourceServer([
+  new HTTPFacilitatorClient({ url: FACILITATOR_URL }),
+]);
+resourceServer.register(NETWORK, new ExactStellarServer());
+
+const httpServer = new x402HTTPResourceServer(resourceServer, {
+  '/api/joke': {
+    title: 'Dad Joke Generator',
+    description: 'Generates a random, completely unpredictable dad joke.',
+    extensions: ['bazaar'],
+    iconUrl: 'https://cdn-icons-png.flaticon.com/512/3260/3260838.png',
+    parameters: {
+      type: 'object',
+      properties: {
+        category: { type: 'string', description: 'Optional category. Ignored in this example.' },
+      },
+    },
+    accepts: {
+      scheme: 'exact',
+      price: { asset: XLM_SAC, amount: PRICE_STROOPS },
+      network: NETWORK,
+      payTo: merchantAddress,
+    },
+  },
+});
+
+const app = express();
+app.use(paymentMiddlewareFromHTTPServer(httpServer));
+
+app.get('/api/joke', (req, res) => {
+  res.json({ joke: 'Why do programmers prefer dark mode? Because light attracts bugs.' });
+});
+
+app.listen(3401, () => console.log('Paid API running at http://localhost:3401/api/joke'));
+```
+
+Key points:
+
+- **`price.amount` is in stroops**, not XLM. `2500` stroops = `0.00025` XLM. Getting the
+  decimal place wrong either prices your endpoint at 1/10,000,000th of what you meant
+  or scares every buyer off. The SDK helper below converts for you.
+- **`payTo` must be your account** — the one that holds (or will hold) the asset.
+- **`extensions: ['bazaar']`** opts the route into automatic cataloguing. Without it,
+  the payment still works but the resource is not listed for discovery.
+
+The middleware intercepts the request, and if no valid payment accompanies it, answers
+`402 Payment Required` with the terms from `accepts` — the buyer reads those terms,
+signs an authorization, and retries with the signature, at which point the request
+reaches your handler.
+
+### Verify it answers 402 before you go further
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3401/api/joke   # expect 402
+curl -s http://localhost:3401/api/joke | head -c 400                       # the terms JSON
+```
+
+A `402` here means the whole payment flow is wired: the resource server is speaking
+x402, and the facilitator URL it points at is reachable.
+
+---
+
+## 4. Declare discovery metadata (the Bazaar extension)
+
+Cataloguing is what turns a paid endpoint into a **discoverable** one. The facilitator
+reads the `bazaar` extension on the payment payload and, on a successful verify or
+settle, asynchronously upserts the listing — never on the payment's critical path, and
+never able to fail the payment.
+
+The route declaration above is the primary path. You can also build the declaration
+with this repo's SDK helper, which validates and converts human amounts to stroops:
+
+```js
+import { createStellarDiscoveryResource } from 'x402-facilitator-stellar/sdk';
+
+const declaration = createStellarDiscoveryResource({
+  routeTemplate: '/api/joke',
+  title: 'Dad Joke Generator',
+  description: 'Generates a random dad joke.',
+  parameters: { category: { type: 'string', description: 'Optional category.' } },
+  pricing: { amount: '0.00025', asset: XLM_SAC }, // 0.00025 XLM — stroops conversion handled
+  network: 'stellar:testnet',
+  scheme: 'exact',
+});
+```
+
+Validate a declaration offline, without paying anyone, with the bundled CLI:
+
+```bash
+npx validate-discovery metadata.json
+```
+
+The same validation runs server-side before anything is catalogued; what is rejected
+there is described in the next section.
+
+### Confirm the listing landed
+
+Two ways to confirm, in increasing order of ceremony:
+
+**1. Search the catalog** (this is what agents do):
+
+```bash
+curl -s "http://localhost:3402/discovery/search?query=joke" | jq '.resources[0] | {url, serviceName, pricing}'
+```
+
+**2. Read the `EXTENSION-RESPONSES` header on a successful payment.** Every
+`/verify` and `/settle` response that carried a discovery extension reports the
+cataloguing outcome in a base64-encoded header, so a seller can confirm the listing
+without a separate round trip:
+
+```bash
+curl -s -D - -o /dev/null -X POST http://localhost:3402/verify \
+  -H "content-type: application/json" \
+  -d '{"paymentPayload":{...},"paymentRequirements":{...}}' \
+  | grep -i EXTENSION-RESPONSES
+# decode:
+echo "<header value>" | base64 -d
+# -> {"bazaar":{"status":"landed","code":"catalog_success"}}
+```
+
+Possible outcomes, and what they mean for you:
+
+| `status` | `code` | Meaning |
+| --- | --- | --- |
+| `landed` | `catalog_success` | Listed. Agents can now find the resource. |
+| `partially landed` | `catalog_partial` | Listed, but optional fields were dropped (see the soft-drop table below). |
+| `rejected` | e.g. `invalid_routeTemplate`, `catalog_rate_limited` | Not listed. See the next section. |
+| `not attempted` | — | The payload carried no usable discovery extension, so nothing was catalogued. |
+
+Manual registration also exists for cases where you want a listing without a payment
+driving it: `POST /discovery/resources` with the same payment-shaped body, authenticated
+with an API key (see [`docs/AUTHENTICATION.md`](./AUTHENTICATION.md)).
+
+---
+
+## 5. When cataloguing is rejected
+
+The catalog validates every submitted resource. Failures come in three severities,
+each with a different action:
+
+### Hard drop — the resource is discarded
+
+| Reason | Cause | Fix |
+| --- | --- | --- |
+| `invalid_routeTemplate` | `routeTemplate` is unparseable, uses double-encoded traversal, or fails the security boundary (SSRF / path traversal protection) | Use a clean route template like `/api/joke` or `/api/resource/{id}` |
+| `missing_or_invalid_discovery_extension` | The `bazaar` extension was absent or malformed on the payload | Declare `extensions: ['bazaar']` and a valid resource body |
+| `invalid_resource` | The resource body failed structural validation | Check the error body's `reason` field for the exact validator complaint |
+
+### Soft drop — the resource lands, the field does not
+
+| Field | What happens | Why |
+| --- | --- | --- |
+| `routeTemplate` (bare wildcard `*`) | Field removed, resource still listed | Upstream's own SDK registers wildcards by default; a seller on stock defaults should not vanish from discovery. Use a concrete template to keep it. |
+| `serviceName` | Field removed | Invalid or oversized. |
+| `iconUrl` | Field removed | Invalid URL or a private-IP address (SSRF protection). |
+| `description` | Truncated to 200 chars | HTML stripped and length capped. |
+| `tags` | Invalid tags dropped | Tag flooding protection. |
+
+A soft drop reports `status: "partially landed"` with the dropped fields named in the
+`reason`. The listing is live; you can fix the fields on the next payment.
+
+### Rate limited
+
+Cataloguing shares a per-IP bucket (`catalog_rpm`, default 10/min; there is also a cap
+of 50 resources per `payTo` address). Exceeding it returns
+`catalog_rate_limited`, which is **retryable** — wait for `Retry-After` and retry.
+
+---
+
+## 6. Getting paid, end to end
+
+With the facilitator running, the endpoint declared, and the first payment through, the
+whole loop is:
+
+1. Agent requests `GET /api/joke` → **402** with terms (`asset`, `amount`, `payTo`).
+2. Agent signs a Soroban authorization transferring `amount` to `payTo`, wrapped in the
+   x402 `payload: {transaction}` shape.
+3. Agent retries with the payment signature; your server calls the facilitator's
+   `/verify`, then `/settle`.
+4. Facilitator verifies the authorization on-chain, submits the settlement (sponsoring
+   the fee), and returns the transaction hash.
+5. Your handler runs; the buyer got the resource, your account got the payment.
+
+Watch it happen on the seller side:
+
+```bash
+# in the example's terminal
+[x402] Payment successful: <tx-hash> from <payer-address>
+```
+
+Inspect the settlement on a testnet explorer:
+
+```
+https://stellar.expert/explorer/testnet/tx/<tx-hash>
+```
+
+---
+
+## 7. Going further
+
+- **SDK validation** — `npx validate-discovery metadata.json` checks a declaration
+  before it is ever submitted; the server runs the same checks again.
+- **MCP tooling** — agents find you through the catalog the same way the MCP server
+  does; see [`docs/MCP.md`](./MCP.md) and the buyer guide
+  ([`docs/BUYER.md`](./BUYER.md)).
+- **Mainnet** — same code, different `network` (`stellar:pubnet`), a real account with
+  a trustline, real USDC (`CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75`),
+  and a facilitator configured for pubnet — see
+  [`docs/OPERATOR.md`](./OPERATOR.md) for the operational differences (key separation,
+  RPC provider, fee ceilings).
+
+## Reference
+
+- [`examples/http-seller`](../examples/http-seller) — the worked example this guide
+  walks through.
+- [`docs/BAZAAR.md`](./BAZAAR.md) — catalog data model, filters, validation policy.
+- [`docs/REASONS.md`](./REASONS.md) — every rejection code the service can emit.
+- [`docs/AUTHENTICATION.md`](./AUTHENTICATION.md) — what is authenticated, what is open.
+- [`docs/DEPLOYMENT.md`](./DEPLOYMENT.md) — running your own facilitator.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@stellar/stellar-sdk": "^16.2.0",
-        "@x402/core": "^2.21.0",
+        "@x402/core": "^2.23.0",
         "@x402/extensions": "^2.23.0",
-        "@x402/stellar": "^2.21.0",
+        "@x402/stellar": "^2.23.0",
         "dotenv": "^17.4.2",
         "fastify": "^5.12.1",
         "ioredis": "^6.0.0",
@@ -739,9 +739,9 @@
       "license": "MIT"
     },
     "node_modules/@x402/core": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/@x402/core/-/core-2.21.0.tgz",
-      "integrity": "sha512-0djKE7V5/JKDMrjRe5he3DoMFzlbVnUcvMmLAb2j6OoAJDamupkFh6fFrXeoHwjkBIxOFUzjGI4FVixz2dMxSA==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@x402/core/-/core-2.23.0.tgz",
+      "integrity": "sha512-EFeV0nXbTPPe5FXaD6y9vMgqc+k/ujLXCrUPrQXkmHjHyjC3Ir5tTL1e2FPSkx2+GUGzfpt1wVZb36639ygkWw==",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.24.2"
@@ -767,16 +767,6 @@
         }
       }
     },
-    "node_modules/@x402/express/node_modules/@x402/core": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/@x402/core/-/core-2.23.0.tgz",
-      "integrity": "sha512-EFeV0nXbTPPe5FXaD6y9vMgqc+k/ujLXCrUPrQXkmHjHyjC3Ir5tTL1e2FPSkx2+GUGzfpt1wVZb36639ygkWw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "zod": "^3.24.2"
-      }
-    },
     "node_modules/@x402/extensions": {
       "version": "2.23.0",
       "resolved": "https://registry.npmjs.org/@x402/extensions/-/extensions-2.23.0.tgz",
@@ -794,23 +784,14 @@
         "zod": "^3.24.2"
       }
     },
-    "node_modules/@x402/extensions/node_modules/@x402/core": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/@x402/core/-/core-2.23.0.tgz",
-      "integrity": "sha512-EFeV0nXbTPPe5FXaD6y9vMgqc+k/ujLXCrUPrQXkmHjHyjC3Ir5tTL1e2FPSkx2+GUGzfpt1wVZb36639ygkWw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "zod": "^3.24.2"
-      }
-    },
     "node_modules/@x402/stellar": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/@x402/stellar/-/stellar-2.21.0.tgz",
-      "integrity": "sha512-Kuq1C0OJB+K8caDinXGRhUYQYBaJnv2flxho5swARe/8tRoDrDCckV5hz8wN0Lje/Nyc5v6O04WpZdHNZZpFTw==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@x402/stellar/-/stellar-2.23.0.tgz",
+      "integrity": "sha512-WMhiTN3k0O2lO4T7g0DcUVF9Sh/YIzY4NMNFqyiRRN2bP3zEZZUmJBx4haH1H6HjgKON6V5ALeBwRDq6E+JLOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@stellar/stellar-sdk": "^16.0.1",
-        "@x402/core": "~2.21.0"
+        "@x402/core": "~2.23.0"
       },
       "engines": {
         "node": ">=22.0.0"

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^16.2.0",
-    "@x402/core": "^2.21.0",
+    "@x402/core": "^2.23.0",
     "@x402/extensions": "^2.23.0",
-    "@x402/stellar": "^2.21.0",
+    "@x402/stellar": "^2.23.0",
     "dotenv": "^17.4.2",
     "fastify": "^5.12.1",
     "ioredis": "^6.0.0",

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -133,7 +133,14 @@ await new Promise(r => server.once('listening', r));
 // ---------------------------------------------------------------------------
 
 const payer = createEd25519Signer(aliceSecret, NETWORK);
-const client = new x402Client().register(NETWORK, new ExactStellarClient(payer));
+const client = new x402Client()
+  .register(NETWORK, new ExactStellarClient(payer))
+  // @x402/core >= 2.22 enforces client-side spend controls: by default only
+  // "default" assets (USDC on Stellar) are payable. This script prices its own
+  // route in XLM, so the XLM SAC must be opted in explicitly — with the control
+  // left on rather than disabled, since this is a wire-conformance check, not a
+  // spend-policy sandbox.
+  .setSpendControls({ allowedAssets: [{ network: NETWORK, asset: XLM_SAC }] });
 const http = new x402HTTPClient(client);
 
 const RESOURCE = `http://localhost:${RESOURCE_PORT}/api/quote`;
@@ -162,7 +169,7 @@ try {
   const paymentRequired = http.getPaymentRequiredResponse(name => unpaid.headers.get(name), body);
   const req0 = paymentRequired.accepts?.[0];
   console.log(`    asset=${req0?.asset}`);
-  console.log(`    amount=${req0?.maxAmountRequired}  payTo=${req0?.payTo}`);
+  console.log(`    amount=${req0?.maxAmountRequired ?? req0?.price?.amount}  payTo=${req0?.payTo}`);
 
   step(3, 'Client signs the auth entry (payer never sees a transaction)');
   const paymentPayload = await withTransportRetry('sign', () =>

--- a/src/mcp/cli.js
+++ b/src/mcp/cli.js
@@ -25,7 +25,16 @@ let x402HttpClient = null;
 if (AGENT_PAYER_SECRET_KEY) {
   try {
     const payer = createEd25519Signer(AGENT_PAYER_SECRET_KEY, NETWORK);
-    const client = new x402Client().register(NETWORK, new ExactStellarClient(payer));
+    const client = new x402Client()
+      .register(NETWORK, new ExactStellarClient(payer))
+      // @x402/core >= 2.22 enforces client-side spend controls and by default
+      // only pays "default" assets (USDC on Stellar). The MCP is a general
+      // agent wallet whose real caps are MAX_FEE_PER_CALL_STROOPS /
+      // MAX_SESSION_SPEND_STROOPS below — assertCanSpend refuses before any
+      // money moves — so the SDK-level default would wrongly reject XLM-priced
+      // resources (e.g. the repo's own seller example). Disable the SDK
+      // controls; the MCP's own are the ones that matter here.
+      .setSpendControls(false);
     x402HttpClient = new x402HTTPClient(client);
   } catch (err) {
     console.error(`Failed to initialize payer signer: ${err.message}`);

--- a/src/readiness.js
+++ b/src/readiness.js
@@ -100,7 +100,9 @@ export function createReadinessChecker(
       if (entries.length === 0) {
         return { ok: false, address, error: `signer account ${address} does not exist (unfunded)` };
       }
-      const entryData = xdr.LedgerEntryData.fromXDR(entries[0].val, 'base64');
+      // Soroban RPC's getLedgerEntries returns each entry's ledger data under
+      // the `xdr` field (key/xdr/lastModifiedLedgerSeq/extXdr), not `val`.
+      const entryData = xdr.LedgerEntryData.fromXDR(entries[0].xdr, 'base64');
       const balance = Number(entryData.account().balance());
       if (balance < minBalanceStroops) {
         return {

--- a/test/docs-routes.test.js
+++ b/test/docs-routes.test.js
@@ -1,0 +1,155 @@
+/**
+ * Enforces docs/AUTHENTICATION.md's route inventory against the real app
+ * (issue #145: "AUTHENTICATION.md's list of open routes omits both discovery
+ * endpoints").
+ *
+ * The point of this test is that the *next* omission is a CI failure rather
+ * than documentation drift: build the app from src/app.js, enumerate every
+ * route Fastify actually registered, and require each one to appear in the
+ * document's route-inventory table — and require every documented route to
+ * exist in the app, so a typo cannot silently document a route that does not
+ * exist.
+ *
+ * It also asserts the two specifics the issue called out: both discovery read
+ * routes are documented as open, and /usage's strict (open-mode-refusing)
+ * behaviour is documented.
+ */
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import { createApp } from '../src/app.js';
+import { stubCatalog, stubFacilitator, stubRateLimiter, testConfig } from './helpers/app.js';
+
+/** Enumerates `METHOD /path` for every route the app registers. */
+function registeredRoutes() {
+  const app = createApp(
+    testConfig({ apiKeys: ['key_0:secret'] }),
+    stubFacilitator(),
+    stubRateLimiter(),
+    stubCatalog(),
+    undefined,
+    {},
+  );
+
+  const tree = app.printRoutes({ commonPrefix: false });
+  const routes = new Set();
+
+  // The tree is indented one 4-char level per depth; a level is either four
+  // spaces (non-last sibling) or "│   " (continuation under a parent). Track
+  // the accumulated path per depth so a split segment like
+  // "/settle" + "ments/:idempotencyKey" rejoins into "/settlements/...".
+  const stack = [];
+  for (const raw of tree.split('\n')) {
+    const line = raw.replace(/\s+$/, '');
+    if (!line) continue;
+
+    let depth = 0;
+    let i = 0;
+    while (i + 4 <= line.length) {
+      const level = line.slice(i, i + 4);
+      if (level === '    ' || level === '│   ') {
+        depth += 1;
+        i += 4;
+      } else {
+        break;
+      }
+    }
+
+    const match = line.slice(i).match(/^[├└]──\s(.+)$/);
+    if (!match) continue;
+
+    const label = match[1];
+    const paren = label.lastIndexOf(' (');
+    const path = paren === -1 ? label : label.slice(0, paren);
+    const methods = paren === -1 ? [] : label.slice(paren + 2, -1).split(', ');
+
+    stack.length = depth;
+    stack[depth] = path;
+    const fullPath = stack.join('');
+
+    for (const method of methods) {
+      // Fastify auto-registers HEAD for every GET; the doc does not enumerate it.
+      if (method === 'HEAD') continue;
+      routes.add(`${method} ${fullPath}`);
+    }
+  }
+
+  return routes;
+}
+
+/** Reads the route-inventory table rows out of the document. */
+function documentedRoutes() {
+  const doc = readFileSync(new URL('../docs/AUTHENTICATION.md', import.meta.url), 'utf8');
+  const section = doc.split('## Route Inventory')[1] ?? '';
+  const table = section.split('##')[0] ?? '';
+
+  const routes = new Set();
+  for (const line of table.split('\n')) {
+    // Rows are backtick-quoted: `GET /healthz`. The path capture excludes the
+    // closing backtick so it cannot be swallowed by the greedy `[^|]+`.
+    const match = line.match(/^\|\s*`?(GET|POST|PUT|PATCH|DELETE|OPTIONS)\s+(\/[^|`]+)`?\s*\|/);
+    if (match) routes.add(`${match[1]} ${match[2].trim()}`);
+  }
+  return routes;
+}
+
+test('every route registered by src/app.js is documented in AUTHENTICATION.md', () => {
+  const app = registeredRoutes();
+  const doc = documentedRoutes();
+
+  // The five OPTIONS preflights are documented as one row — `OPTIONS
+  // <cors-enabled route>` — because they all share a posture. Accept that row
+  // as covering each individual preflight.
+  const section = readFileSync(new URL('../docs/AUTHENTICATION.md', import.meta.url), 'utf8');
+  const coversPreflights = /`OPTIONS <cors-enabled route>`/.test(section);
+
+  const missing = [...app].filter(route => {
+    if (route.startsWith('OPTIONS ') && coversPreflights) return false;
+    return !doc.has(route);
+  });
+  assert.deepEqual(
+    missing,
+    [],
+    'Routes registered in app.js but missing from the AUTHENTICATION.md route inventory — ' +
+      'add them to the table so the open surface is not under-reported',
+  );
+});
+
+test('every route documented in AUTHENTICATION.md is registered by src/app.js', () => {
+  const app = registeredRoutes();
+  const doc = documentedRoutes();
+
+  const phantom = [...doc].filter(route => !app.has(route));
+  assert.deepEqual(
+    phantom,
+    [],
+    'Routes documented in AUTHENTICATION.md but not registered by app.js — ' +
+      'either the doc has a typo or the route was removed without updating the table',
+  );
+});
+
+test('both discovery read routes are documented as open by design', () => {
+  const doc = readFileSync(new URL('../docs/AUTHENTICATION.md', import.meta.url), 'utf8');
+  const inventory = doc.split('## Route Inventory')[1] ?? '';
+
+  for (const route of ['GET /discovery/resources', 'GET /discovery/search']) {
+    const row = inventory.split('\n').find(line => line.includes(`| \`${route}\``));
+    assert.ok(row, `no inventory row for ${route}`);
+    assert.match(row, /open \*\*by design\*\*/, `${route} must be documented as open by design`);
+  }
+});
+
+test("GET /usage's open-mode refusal is documented", () => {
+  const doc = readFileSync(new URL('../docs/AUTHENTICATION.md', import.meta.url), 'utf8');
+
+  assert.match(
+    doc,
+    /open_mode_usage_forbidden/,
+    'the /usage open-mode refusal reason must be documented',
+  );
+  assert.match(
+    doc,
+    /strict/,
+    'the doc must say that /usage uses the strict key check, distinct from requireApiKey',
+  );
+});

--- a/test/multi-signer.test.js
+++ b/test/multi-signer.test.js
@@ -126,7 +126,9 @@ describe('Multi-Signer Pool & Fee-Bump Signer (#9)', () => {
         const entry = xdr.LedgerEntryData.account(acct);
         return {
           result: {
-            entries: [{ val: entry.toXDR('base64') }],
+            // Soroban RPC's getLedgerEntries returns the ledger data under
+            // `xdr`, matching src/readiness.js — see test/readiness.test.js.
+            entries: [{ xdr: entry.toXDR('base64') }],
           },
         };
       }

--- a/test/readiness.test.js
+++ b/test/readiness.test.js
@@ -69,7 +69,10 @@ function rpcStub({
       return { result: { status: healthy ? 'healthy' : 'degraded' } };
     }
     if (body.method === 'getLedgerEntries') {
-      return { result: { entries: entryVal ? [{ val: entryVal }] : [] } };
+      // Soroban RPC returns the entry's ledger data under `xdr` (shape:
+      // key/xdr/lastModifiedLedgerSeq/extXdr). The stub must mirror the real
+      // wire shape or the checker can pass tests while failing in production.
+      return { result: { entries: entryVal ? [{ xdr: entryVal }] : [] } };
     }
     throw new Error(`unexpected method ${body.method}`);
   };


### PR DESCRIPTION
## What changed

Documentation and ops hardening across four issues: the route inventory in
AUTHENTICATION.md is now complete and enforced by a test, the three role-based
guides were written to the RFP's standard, the hosted/self-hosted deployment
paths are documented and the self-hosted path was validated cold against live
testnet (fixing two real bugs found along the way), and the post-grant
conformance maintenance commitment is stated in CONFORMANCE.md.

## Why

Closes #145 — AUTHENTICATION.md's route list omitted both discovery read
endpoints and the /usage open-mode refusal; the page answering "what is
authenticated here" under-reported the open surface.
Closes #154 — the seller/buyer/operator guides were 53 lines of stubs against
an RFP deliverable that names substantial role-based paths with live testnet
examples.
Closes #156 — the self-hosted path had never been validated from nothing (cold
validation found /readyz's signer_funded check always failing and an incoherent
@x402/* version set), and the hosted path was undefined.
Closes #163 — the repository had the conformance machinery but never stated the
maintenance commitment the RFP asks for.

## How it was verified

- `npm test`: 285 pass / 0 fail (4 new tests enforce AUTHENTICATION.md ↔ app.js parity)
- `npx eslint .`: clean
- `npx prettier --check .`: clean
- `npm run e2e`: **PASS** — an unmodified canonical client completed a real
  testnet payment; tx `53d2bed449bf8602fecc0d00782d54b1020773d79578a0a4487c35911d0562c4`
  verified `successful` on Horizon
- Cold-start walk from a clean clone with a friendbot-funded signer: boots,
  `/healthz` ok, `/supported` advertises `areFeesSponsored`, `/readyz` reports ready
- `examples/http-seller` and `examples/mcp-agent` import cleanly after the `@x402/*` bump

## Wire format

No — `/readyz`'s response body shape is unchanged; only its `signer_funded`
check now succeeds for funded accounts (it previously errored). The x402
payment surface is byte-for-byte untouched.
