### PR TITLE
docs: build RFP requirements traceability matrix

### DIFF
--- a/docs/RFP-TRACEABILITY-MATRIX.md
+++ b/docs/RFP-TRACEABILITY-MATRIX.md
@@ -1,0 +1,38 @@
+# RFP Requirements Traceability Matrix
+
+This document is the single authoritative assessment mapping the [SCF RFP](https://stellar.gitbook.io/scf-handbook/scf-awards/build-award/rfp-track#x402-facilitator-with-bazaar-discovery-support-1) requirements and deliverables to their implementations across the project. 
+
+**It explicitly supersedes all earlier RFP gap assessments (such as `RFP-ALIGNMENT.md`), which are now retired.** An earlier assessment concluded that the facilitator, Bazaar discovery layer, and MCP interface were absent because this repository did not yet exist. Those capabilities are now implemented here.
+
+## Funded Deliverable vs. Supporting Evidence
+- **Funded Deliverable:** `x402-facilitator-stellar` (this repository). This is the conformance spike and the primary deliverable for the grant.
+- **Supporting Evidence:** `accensa-app` and `accensa-contracts`. These provide context and validation for the facilitator but are not the primary deliverables. 
+
+**Critical Distinction:** The receipt verification endpoint in `accensa-app` is **not** x402 `verify`. The two must never be conflated in a submission. Real x402 `verify` lives exclusively within the `x402-facilitator-stellar` conformance spike (delegating to `@x402/stellar`).
+
+## Maintenance
+This matrix is maintained by the Accensa engineering team. It must be updated prior to every milestone submission and any major architectural change.
+
+## Requirements Traceability
+
+| Ref | Requirement | Status | Implementation | Evidence | Owning Issue |
+|-----|-------------|--------|----------------|----------|--------------|
+| §3.1 | Implement HTTP transport for `verify` | Complete | `src/server.js`, `src/app.js` | HTTP endpoints exist | #158 (scheme contribution) |
+| §3.1 | Implement HTTP transport for `settle` | Complete | `src/server.js`, `src/app.js` | HTTP endpoints exist | #166 (Fee metering) |
+| §3.2 | Bazaar Discovery support | Partial | `src/app.js` | `/discovery/resources` endpoint | #164, #65 |
+| §3.2 | `routeTemplate` percent-decoding | Absent | TBD | Code inspection | #226 |
+| §3.2 | Discovery index spoofing prevention | Partial | `src/app.js` validation | `docs/BAZAAR.md`, tests | #217 |
+| §3.3 | Trustline documentation | Absent | TBD | N/A | #160 |
+| §3.4 | Resource-limit measurement | Partial | `src/rate-limit.js` | Limit buckets implemented | #224 |
+| §3.5 | Security and Auditability | Complete | `src/logger.js`, `docs/THREAT-MODEL.md` | Audit logging, threat model | #78 (Error boundary) |
+| §3.6 | MCP (Model Context Protocol) Support | Partial | `src/server.js` | MCP CLI | #233 |
+
+## Deliverables Traceability
+
+| Ref | Deliverable | Status | Implementation | Evidence | Owning Issue |
+|-----|-------------|--------|----------------|----------|--------------|
+| §5 | Facilitator software package | Complete | Root package | `package.json`, codebase | N/A |
+| §5 | Documentation of deployment | Partial | `README.md` | Dockerfile, `docker-compose.yml` | #156 |
+| §5 | Demonstration environment | Partial | TBD | Testnet configuration | N/A |
+| §5 | Security assessment / Threat model | Complete | `docs/THREAT-MODEL.md` | Document in repo | N/A |
+


### PR DESCRIPTION
This PR introduces `docs/RFP-TRACEABILITY-MATRIX.md`, mapping every §3 requirement and §5 deliverable from the SCF RFP to its implementation and evidence within this repository.

- Explicitly supersedes the older `RFP-ALIGNMENT.md` and records that the facilitator, Bazaar, and MCP interfaces are indeed implemented here.
- Documents the distinction between the funded deliverable (`x402-facilitator-stellar`) and supporting evidence (`accensa-app`, `accensa-contracts`).
- Explicitly states that receipt verification in `accensa-app` is NOT x402 `verify`.
- Clarifies maintenance responsibilities for the matrix.
- Accurately reports missing requirements (e.g., `routeTemplate` percent-decoding, trustline documentation) and links to tracking issues for transparency.

Closes #162.