### PR TITLE
feat: event-sourced settlement state machine for full auditability (#…

### DIFF
--- a/docs/EVENT-SOURCING.md
+++ b/docs/EVENT-SOURCING.md
@@ -1,0 +1,114 @@
+# Event-Sourced Settlement State Machine (#130)
+
+## Problem
+
+Before this change, a settlement record (`settlements` table, migrations/003)
+was overwritten in place: `save()` inserted it, `updateState()` ran an
+`UPDATE ... SET state = $2, ...`. Each write destroyed the row it replaced.
+Reconstructing *how* a settlement reached `failed` — was it submitted once and
+timed out, or retried three times against a flapping RPC endpoint before the
+final rejection? — was impossible, because only the final state survived.
+That is a problem the moment a settlement is disputed or a regulator asks for
+the sequence of transitions, not just the outcome.
+
+This is distinct from [`docs/AUDIT.md`](AUDIT.md)'s audit trail (`src/audit.js`),
+which logs one JSON line per HTTP-level action to a side channel. That log can
+be shipped, rotated, or dropped independently of the database — it is
+evidence *about* the request, not the record a client's `GET
+/settlements/:idempotencyKey` reads. The state machine itself needed to become
+the source of truth for its own history.
+
+## Design
+
+### Events are the only way state changes
+
+Every settlement is a stream of append-only events (`src/eventstore/events.js`):
+
+| Event | Recorded when |
+|---|---|
+| `SettlementInitiated` | A `/settle` request is first seen for an idempotency key, or a retryable failure (`rate_limited`, `soroban_rpc_unreachable`, `lock_timeout`, `request_timeout`, …) is retried under the same key |
+| `SettlementSettled` | The scheme's `settle()` call reports success |
+| `SettlementFailed` | The scheme's `settle()` call reports failure, or an unrecoverable error is caught |
+| `SettlementOutcomeUnknown` | The request timed out after the transaction was already submitted — success or failure cannot be determined without asking the chain |
+
+Each event carries `event_version` (currently `1` for all four types). A
+future breaking change to a payload's shape bumps that type's version;
+`projectSettlement` branches on it, so old events already on disk keep folding
+correctly rather than being invalidated by a schema change.
+
+`createSettlementEvent()` rejects an unknown type or a payload missing a
+field its version requires — an event that cannot be folded can never be
+appended.
+
+### Projections are derived, never authoritative
+
+`src/eventstore/projection.js` exports one pure function, `projectSettlement(events)`,
+that folds an ordered event stream into the shape the rest of the service
+already expected (`state`, `tx_hash`, `error_reason`, …). It is the single
+definition of "what does this settlement look like now" — every read path
+uses it, directly or indirectly:
+
+- **`MemorySettlementStore`** (`src/store/memory.js`) keeps only the event
+  log (`Map<idempotency_key, event[]>`) and calls `projectSettlement` on every
+  read. There is no separate mutable record to drift from the log — reading
+  *is* replaying.
+- **`PostgresSettlementStore`** (`src/store/postgres.js`) keeps a
+  `settlement_projections` read model so a read is an indexed `SELECT`, not a
+  full replay on every request. That table is written only inside the same
+  statement that appends the event producing the new row — a single CTE
+  (`INSERT INTO settlement_events ... RETURNING ...` feeding an
+  `INSERT ... ON CONFLICT DO UPDATE` / `UPDATE ... FROM`) — so there is no
+  window where an event exists without its projection or vice versa.
+- **`rebuildProjection(idempotencyKey)`** replays a stream through the exact
+  same `projectSettlement` fold and overwrites the cached row. It is not on
+  the hot write path; it exists to repair or verify a read model against the
+  event log, and it is what proves the projection is reconstructible rather
+  than merely consistent by convention. `test/settlement-events.test.js`
+  exercises this by deleting a projection row out from under a live store and
+  confirming `rebuildProjection` reproduces it.
+
+### Public interface is unchanged
+
+`get`, `save`, `updateState`, `listUnknown` and `deriveIdempotencyKey` keep
+their existing signatures and behaviour — `src/app.js`'s `/settle` and
+`GET /settlements/:idempotencyKey` routes did not change. Internally, `save()`
+now appends `SettlementInitiated` and `updateState()` appends the terminal
+event matching the requested state; nothing calls a raw setter.
+
+Two capabilities are new:
+
+- `getEventLog(idempotencyKey)` — the full ordered history for one settlement.
+- `exportAuditLog({ since, until, limit })` — every transition ever recorded,
+  across all settlements, in chronological order.
+
+`GET /settlements/:idempotencyKey/events` exposes the first of these over
+HTTP, scoped to the caller's `keyId` exactly like the existing state endpoint.
+
+### What a retry looks like
+
+A `/settle` retry against a `failed` settlement whose `error_reason` is
+retryable (see `src/app.js`) calls `save()` again on the same idempotency key.
+That appends a second `SettlementInitiated` event rather than resetting the
+first one — the failed attempt stays in the log. `created_at` on the
+projection is the *first* event's timestamp; `updated_at` moves with each new
+event. `test/settlement-events.test.js` pins this for both stores.
+
+## Migration
+
+`migrations/004_settlement_events.sql` adds `settlement_events` (append-only,
+`UNIQUE (idempotency_key, seq)`) and `settlement_projections` (the read
+model, primary-keyed on `idempotency_key`). It does not touch or drop the
+`settlements` table from migrations/003 — nothing reads that table once this
+store is deployed, but a non-destructive migration leaves it in place rather
+than assuming no other consumer depends on it.
+
+## Acceptance criteria
+
+- [x] Event schemas are strictly defined and versioned — `src/eventstore/events.js`.
+- [x] State mutations only occur by appending events — both stores' `save`/`updateState`
+      insert an event before any projection write; `updateState` on an aggregate
+      with no prior event appends nothing and returns `null`.
+- [x] Projections successfully build current state from event history — `projectSettlement`,
+      and `rebuildProjection` demonstrably reconstructs a deleted read-model row.
+- [x] Full audit log of all transitions can be exported — `exportAuditLog()` and
+      `GET /settlements/:idempotencyKey/events`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,4 +8,5 @@ Welcome to the X402 Facilitator documentation. Please choose the path that best 
 
 **Reference:**
 - [Architecture](./ARCHITECTURE.md): System design, components, and the discovery path
+- [Event Sourcing](./EVENT-SOURCING.md): The append-only settlement state machine and its audit trail
 - [Glossary](./GLOSSARY.md): Terminology (Stellar, X402, and Facilitator concepts)

--- a/migrations/004_settlement_events.sql
+++ b/migrations/004_settlement_events.sql
@@ -1,0 +1,50 @@
+-- migrations/004_settlement_events.sql
+-- Event-sourced settlement state machine for full auditability (issue #130).
+--
+-- settlement_events is the append-only source of truth: every settlement
+-- state transition is a row here and rows are never updated or deleted.
+-- settlement_projections is a read model folded from that stream — written
+-- only in the same statement that appends the event producing it (see
+-- src/store/postgres.js) — kept for fast, index-backed reads instead of
+-- replaying the full event log on every request.
+--
+-- This is additive: it does not touch the pre-existing `settlements` table
+-- from migrations/003_settlement_store.sql. Nothing reads that table once
+-- this migration's store is deployed, but it is left in place rather than
+-- dropped.
+
+CREATE TABLE IF NOT EXISTS settlement_events (
+    id BIGSERIAL PRIMARY KEY,
+    idempotency_key TEXT NOT NULL,
+    seq INTEGER NOT NULL,
+    event_type TEXT NOT NULL,
+    event_version INTEGER NOT NULL DEFAULT 1,
+    payload JSONB NOT NULL,
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (idempotency_key, seq)
+);
+
+CREATE INDEX IF NOT EXISTS idx_settlement_events_key ON settlement_events(idempotency_key, seq);
+CREATE INDEX IF NOT EXISTS idx_settlement_events_recorded_at ON settlement_events(recorded_at);
+
+CREATE TABLE IF NOT EXISTS settlement_projections (
+    idempotency_key TEXT PRIMARY KEY,
+    network TEXT NOT NULL,
+    scheme TEXT NOT NULL,
+    payer TEXT,
+    pay_to TEXT,
+    asset TEXT,
+    amount TEXT,
+    state TEXT NOT NULL CHECK (state IN ('submitted', 'settled', 'failed', 'unknown')),
+    tx_hash TEXT,
+    error_reason TEXT,
+    error_message TEXT,
+    response JSONB,
+    key_id TEXT,
+    version INTEGER NOT NULL DEFAULT 1,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_settlement_projections_key_id ON settlement_projections(key_id);
+CREATE INDEX IF NOT EXISTS idx_settlement_projections_state ON settlement_projections(state);

--- a/src/app.js
+++ b/src/app.js
@@ -915,6 +915,34 @@ export function createApp(config, facilitator, rateLimiter, catalog, idempotency
   );
 
   /**
+   * GET /settlements/:idempotencyKey/events — full, ordered event history for
+   * one settlement (#130). The projection above answers "what is the current
+   * state"; this answers "how did it get there" — the record a regulatory
+   * audit needs. Scoped identically to the settlement it belongs to.
+   */
+  app.get(
+    '/settlements/:idempotencyKey/events',
+    {
+      onRequest: cors('authenticated'),
+      preHandler: requireApiKey,
+    },
+    async (req, reply) => {
+      const { idempotencyKey } = req.params;
+      const record = await settlementStore.get(idempotencyKey);
+      if (!record) {
+        return reply.code(404).send({ error: 'not_found', message: 'Settlement record not found' });
+      }
+
+      if (req.keyId && record.key_id && record.key_id !== req.keyId) {
+        return reply.code(404).send({ error: 'not_found', message: 'Settlement record not found' });
+      }
+
+      const events = await settlementStore.getEventLog(idempotencyKey);
+      return reply.send({ ok: true, idempotencyKey, events });
+    },
+  );
+
+  /**
    * Manual registration, the secondary path.
    *
    * Automatic cataloging off the payment path is the primary one — anything

--- a/src/eventstore/events.js
+++ b/src/eventstore/events.js
@@ -1,0 +1,80 @@
+/**
+ * Event schema for the settlement state machine (#130).
+ *
+ * A settlement is never mutated in place. It is a stream of these events,
+ * appended in order; the current state is a projection over that stream
+ * (see projection.js). Every event carries its own `event_version` so a
+ * future breaking change to a payload shape can be introduced without
+ * invalidating history already on disk — `projectSettlement` branches on
+ * version, it never assumes the latest shape.
+ */
+
+export const SETTLEMENT_EVENT_TYPES = Object.freeze({
+  INITIATED: 'SettlementInitiated',
+  SETTLED: 'SettlementSettled',
+  FAILED: 'SettlementFailed',
+  OUTCOME_UNKNOWN: 'SettlementOutcomeUnknown',
+});
+
+/** Current schema version for every event type below. Bump per-type when a payload shape changes. */
+const CURRENT_VERSION = Object.freeze({
+  [SETTLEMENT_EVENT_TYPES.INITIATED]: 1,
+  [SETTLEMENT_EVENT_TYPES.SETTLED]: 1,
+  [SETTLEMENT_EVENT_TYPES.FAILED]: 1,
+  [SETTLEMENT_EVENT_TYPES.OUTCOME_UNKNOWN]: 1,
+});
+
+/** Fields a v1 payload must carry for the event to be meaningful. */
+const REQUIRED_FIELDS_V1 = Object.freeze({
+  [SETTLEMENT_EVENT_TYPES.INITIATED]: ['idempotency_key', 'network', 'scheme'],
+  [SETTLEMENT_EVENT_TYPES.SETTLED]: ['idempotency_key'],
+  [SETTLEMENT_EVENT_TYPES.FAILED]: ['idempotency_key'],
+  [SETTLEMENT_EVENT_TYPES.OUTCOME_UNKNOWN]: ['idempotency_key'],
+});
+
+/** The state a projection moves to when it applies each event type (#130). */
+const STATE_BY_EVENT_TYPE = Object.freeze({
+  [SETTLEMENT_EVENT_TYPES.INITIATED]: 'submitted',
+  [SETTLEMENT_EVENT_TYPES.SETTLED]: 'settled',
+  [SETTLEMENT_EVENT_TYPES.FAILED]: 'failed',
+  [SETTLEMENT_EVENT_TYPES.OUTCOME_UNKNOWN]: 'unknown',
+});
+
+const STATE_TO_EVENT_TYPE = Object.freeze({
+  settled: SETTLEMENT_EVENT_TYPES.SETTLED,
+  failed: SETTLEMENT_EVENT_TYPES.FAILED,
+  unknown: SETTLEMENT_EVENT_TYPES.OUTCOME_UNKNOWN,
+});
+
+/**
+ * Builds a schema-checked event envelope. Throws on an unknown type or a
+ * payload missing a field that type's current version requires — the store
+ * layer must never be able to append something the projection can't fold.
+ *
+ * @param {string} type - one of SETTLEMENT_EVENT_TYPES
+ * @param {object} payload
+ * @returns {{event_type: string, event_version: number, payload: object}}
+ */
+export function createSettlementEvent(type, payload = {}) {
+  const version = CURRENT_VERSION[type];
+  if (!version) {
+    throw new Error(`Unknown settlement event type: ${type}`);
+  }
+  for (const field of REQUIRED_FIELDS_V1[type]) {
+    if (payload[field] === undefined || payload[field] === null) {
+      throw new Error(`${type} event requires field "${field}"`);
+    }
+  }
+  return { event_type: type, event_version: version, payload };
+}
+
+/** Maps a projected `state` string back to the event type that produces it (for updateState()). */
+export function eventTypeForState(state) {
+  const type = STATE_TO_EVENT_TYPE[state];
+  if (!type) {
+    throw new Error(`No settlement event type is mapped to state "${state}"`);
+  }
+  return type;
+}
+
+export { STATE_BY_EVENT_TYPE };

--- a/src/eventstore/projection.js
+++ b/src/eventstore/projection.js
@@ -1,0 +1,90 @@
+/**
+ * Projection engine for the settlement event stream (#130).
+ *
+ * `projectSettlement` is the single, pure definition of "what does this
+ * settlement currently look like" — every read path (in-memory store,
+ * Postgres-backed store, and its repair/rebuild path) folds the same way
+ * through this function. Nothing else may derive settlement state; if a
+ * store's read model disagrees with this fold, the read model is wrong.
+ */
+import { SETTLEMENT_EVENT_TYPES, STATE_BY_EVENT_TYPE } from './events.js';
+
+/**
+ * Folds one event onto the previous projection (or none, for the first event).
+ * Unknown event types and versions are skipped rather than thrown on, so a
+ * projector reading a stream written by a newer version of this service
+ * degrades gracefully instead of crashing a read.
+ */
+function applyEvent(projection, event) {
+  const { event_type: type, payload = {}, recorded_at: recordedAt } = event;
+  const state = STATE_BY_EVENT_TYPE[type];
+  if (!state) return projection;
+
+  if (type === SETTLEMENT_EVENT_TYPES.INITIATED) {
+    return {
+      idempotency_key: payload.idempotency_key,
+      network: payload.network ?? '',
+      scheme: payload.scheme ?? '',
+      payer: payload.payer ?? null,
+      pay_to: payload.pay_to ?? null,
+      asset: payload.asset ?? null,
+      amount: payload.amount ?? null,
+      state,
+      tx_hash: payload.tx_hash ?? null,
+      error_reason: null,
+      error_message: null,
+      response: null,
+      key_id: payload.key_id ?? null,
+      // A retry re-appends Initiated on an existing aggregate (see store/memory.js);
+      // the first-ever event's timestamp is the creation time, not the retry's.
+      created_at: projection?.created_at ?? recordedAt,
+      updated_at: recordedAt,
+    };
+  }
+
+  // A terminal event with no prior Initiated event is a partial/corrupt
+  // history; tolerate it by seeding a minimal aggregate rather than throwing,
+  // so a single bad stream can't take down an audit-log export.
+  const base = projection ?? {
+    idempotency_key: payload.idempotency_key ?? null,
+    network: '',
+    scheme: '',
+    payer: null,
+    pay_to: null,
+    asset: null,
+    amount: null,
+    state: 'submitted',
+    tx_hash: null,
+    error_reason: null,
+    error_message: null,
+    response: null,
+    key_id: null,
+    created_at: recordedAt,
+    updated_at: recordedAt,
+  };
+
+  return {
+    ...base,
+    state,
+    tx_hash: payload.tx_hash ?? base.tx_hash,
+    error_reason: payload.error_reason ?? base.error_reason,
+    error_message: payload.error_message ?? base.error_message,
+    response: payload.response ?? base.response,
+    updated_at: recordedAt,
+  };
+}
+
+/**
+ * Reduces an ordered event stream (oldest first) into the current settlement
+ * projection, or `null` for an empty stream.
+ *
+ * @param {Array<{event_type: string, event_version: number, payload: object, recorded_at: string}>} events
+ * @returns {object|null}
+ */
+export function projectSettlement(events) {
+  let projection = null;
+  for (const event of events) {
+    projection = applyEvent(projection, event);
+  }
+  return projection;
+}

--- a/src/store/memory.js
+++ b/src/store/memory.js
@@ -1,12 +1,24 @@
 import crypto from 'node:crypto';
+import {
+  createSettlementEvent,
+  eventTypeForState,
+  SETTLEMENT_EVENT_TYPES,
+} from '../eventstore/events.js';
+import { projectSettlement } from '../eventstore/projection.js';
 
 /**
- * In-memory settlement store fallback for single-instance or test runs (#10).
+ * In-memory, event-sourced settlement store (#10, #130).
+ *
+ * State is never written directly: every transition is an appended event,
+ * and `get`/`listUnknown` read a projection folded over that event stream
+ * (see eventstore/projection.js). This is also the process-local fallback a
+ * PostgresSettlementStore degrades to, and single-instance/test runs use it
+ * directly.
  */
 export class MemorySettlementStore {
   constructor() {
-    /** @type {Map<string, object>} */
-    this.records = new Map();
+    /** @type {Map<string, object[]>} idempotency_key -> ordered, append-only event log */
+    this.events = new Map();
   }
 
   /**
@@ -33,59 +45,91 @@ export class MemorySettlementStore {
     );
   }
 
+  /** Appends one event to an aggregate's stream. The only way state changes. */
+  _append(idempotencyKey, type, payload) {
+    const stream = this.events.get(idempotencyKey) ?? [];
+    const event = {
+      ...createSettlementEvent(type, { idempotency_key: idempotencyKey, ...payload }),
+      seq: stream.length + 1,
+      recorded_at: new Date().toISOString(),
+    };
+    stream.push(event);
+    this.events.set(idempotencyKey, stream);
+    return event;
+  }
+
+  _projection(idempotencyKey) {
+    const stream = this.events.get(idempotencyKey);
+    if (!stream || stream.length === 0) return null;
+    return projectSettlement(stream);
+  }
+
   async get(idempotencyKey) {
-    const rec = this.records.get(idempotencyKey);
-    return rec ? { ...rec } : null;
+    const projection = this._projection(idempotencyKey);
+    return projection ? { ...projection } : null;
   }
 
   async save(record) {
-    const now = new Date().toISOString();
-    const existing = this.records.get(record.idempotency_key);
-    const entry = {
-      idempotency_key: record.idempotency_key,
+    this._append(record.idempotency_key, SETTLEMENT_EVENT_TYPES.INITIATED, {
       network: record.network ?? '',
       scheme: record.scheme ?? '',
       payer: record.payer ?? null,
       pay_to: record.pay_to ?? null,
       asset: record.asset ?? null,
       amount: record.amount ?? null,
-      state: record.state ?? 'submitted',
       tx_hash: record.tx_hash ?? null,
-      error_reason: record.error_reason ?? null,
-      error_message: record.error_message ?? null,
-      response: record.response ?? null,
       key_id: record.key_id ?? null,
-      created_at: existing?.created_at ?? now,
-      updated_at: now,
-    };
-    this.records.set(record.idempotency_key, entry);
-    return { ...entry };
+    });
+    return this.get(record.idempotency_key);
   }
 
   async updateState(idempotencyKey, state, details = {}) {
-    const existing = this.records.get(idempotencyKey);
-    if (!existing) return null;
-
-    const updated = {
-      ...existing,
-      state,
-      tx_hash: details.tx_hash ?? existing.tx_hash,
-      error_reason: details.error_reason ?? existing.error_reason,
-      error_message: details.error_message ?? existing.error_message,
-      response: details.response ?? existing.response,
-      updated_at: new Date().toISOString(),
-    };
-    this.records.set(idempotencyKey, updated);
-    return { ...updated };
+    if (!this.events.has(idempotencyKey)) return null;
+    this._append(idempotencyKey, eventTypeForState(state), {
+      tx_hash: details.tx_hash ?? null,
+      error_reason: details.error_reason ?? null,
+      error_message: details.error_message ?? null,
+      response: details.response ?? null,
+    });
+    return this.get(idempotencyKey);
   }
 
   async listUnknown() {
     const results = [];
-    for (const rec of this.records.values()) {
-      if (rec.state === 'unknown') {
-        results.push({ ...rec });
-      }
+    for (const key of this.events.keys()) {
+      const projection = this._projection(key);
+      if (projection?.state === 'unknown') results.push(projection);
     }
     return results;
+  }
+
+  /** Full, ordered event history for one settlement — the audit trail (#130). */
+  async getEventLog(idempotencyKey) {
+    return (this.events.get(idempotencyKey) ?? []).map(e => ({ ...e }));
+  }
+
+  /**
+   * Cross-aggregate, chronologically ordered export of every transition ever
+   * recorded, for regulatory export (#130).
+   */
+  async exportAuditLog({ since, until, limit } = {}) {
+    const all = [];
+    for (const stream of this.events.values()) all.push(...stream);
+    all.sort((a, b) => a.recorded_at.localeCompare(b.recorded_at) || a.seq - b.seq);
+
+    let filtered = all;
+    if (since) filtered = filtered.filter(e => e.recorded_at >= since);
+    if (until) filtered = filtered.filter(e => e.recorded_at <= until);
+    if (limit) filtered = filtered.slice(0, limit);
+    return filtered.map(e => ({ ...e }));
+  }
+
+  /**
+   * Rebuilds the projection for one aggregate strictly from its event log.
+   * In-memory reads already do this on every call; the Postgres store uses
+   * the identical fold to repair its cached read model from source of truth.
+   */
+  async rebuildProjection(idempotencyKey) {
+    return this.get(idempotencyKey);
   }
 }

--- a/src/store/postgres.js
+++ b/src/store/postgres.js
@@ -1,5 +1,77 @@
 import { MemorySettlementStore } from './memory.js';
+import { eventTypeForState } from '../eventstore/events.js';
+import { projectSettlement } from '../eventstore/projection.js';
 
+const PROJECTION_COLUMN_NAMES = [
+  'idempotency_key',
+  'network',
+  'scheme',
+  'payer',
+  'pay_to',
+  'asset',
+  'amount',
+  'state',
+  'tx_hash',
+  'error_reason',
+  'error_message',
+  'response',
+  'key_id',
+  'version',
+  'created_at',
+  'updated_at',
+];
+const PROJECTION_COLUMNS = PROJECTION_COLUMN_NAMES.join(', ');
+const QUALIFIED_PROJECTION_COLUMNS = PROJECTION_COLUMN_NAMES.map(
+  c => `settlement_projections.${c}`,
+).join(', ');
+
+function mapProjectionRow(r) {
+  return {
+    idempotency_key: r.idempotency_key,
+    network: r.network,
+    scheme: r.scheme,
+    payer: r.payer,
+    pay_to: r.pay_to,
+    asset: r.asset,
+    amount: r.amount,
+    state: r.state,
+    tx_hash: r.tx_hash,
+    error_reason: r.error_reason,
+    error_message: r.error_message,
+    response: r.response,
+    key_id: r.key_id,
+    version: r.version,
+    created_at: new Date(r.created_at).toISOString(),
+    updated_at: new Date(r.updated_at).toISOString(),
+  };
+}
+
+function mapEventRow(r) {
+  return {
+    idempotency_key: r.idempotency_key,
+    seq: r.seq,
+    event_type: r.event_type,
+    event_version: r.event_version,
+    payload: r.payload,
+    recorded_at: new Date(r.recorded_at).toISOString(),
+  };
+}
+
+/**
+ * Postgres-backed, event-sourced settlement store (#10, #130).
+ *
+ * `settlement_events` is the append-only source of truth; `settlement_projections`
+ * is a read model, derived and never written to except as the same statement
+ * that appends the event which produced it. Every write below is one round
+ * trip: a CTE inserts the event, then upserts the projection from it, so the
+ * two can never observably disagree — there is no window where an event
+ * exists without its projection, or vice versa.
+ *
+ * Reads never replay the log — they hit `settlement_projections` directly, an
+ * index-backed table. `rebuildProjection` is the deliberately-separate slow
+ * path that replays a stream through the same fold `MemorySettlementStore`
+ * uses, for repair or verification.
+ */
 export class PostgresSettlementStore extends MemorySettlementStore {
   /**
    * @param {string} databaseUrl - postgres connection string
@@ -18,13 +90,13 @@ export class PostgresSettlementStore extends MemorySettlementStore {
         .then(({ default: pg }) => {
           this.pool = new pg.Pool({ connectionString: databaseUrl, max: 5 });
           this.pool.on('error', err => this._degrade(`Postgres error: ${err.message}`));
-          this.ready = this._ensureTable();
+          this.ready = this._ensureSchema();
         })
         .catch(err =>
           this._degrade(`pg unavailable (${err.message}); using memory settlement store`),
         );
     } else {
-      this.ready = this._ensureTable();
+      this.ready = this._ensureSchema();
     }
   }
 
@@ -35,11 +107,24 @@ export class PostgresSettlementStore extends MemorySettlementStore {
     }
   }
 
-  async _ensureTable() {
+  async _ensureSchema() {
     if (!this.pool || this.degraded) return;
     try {
       await this.pool.query(`
-        CREATE TABLE IF NOT EXISTS settlements (
+        CREATE TABLE IF NOT EXISTS settlement_events (
+            id BIGSERIAL PRIMARY KEY,
+            idempotency_key TEXT NOT NULL,
+            seq INTEGER NOT NULL,
+            event_type TEXT NOT NULL,
+            event_version INTEGER NOT NULL DEFAULT 1,
+            payload JSONB NOT NULL,
+            recorded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            UNIQUE (idempotency_key, seq)
+        );
+        CREATE INDEX IF NOT EXISTS idx_settlement_events_key ON settlement_events(idempotency_key, seq);
+        CREATE INDEX IF NOT EXISTS idx_settlement_events_recorded_at ON settlement_events(recorded_at);
+
+        CREATE TABLE IF NOT EXISTS settlement_projections (
             idempotency_key TEXT PRIMARY KEY,
             network TEXT NOT NULL,
             scheme TEXT NOT NULL,
@@ -53,14 +138,15 @@ export class PostgresSettlementStore extends MemorySettlementStore {
             error_message TEXT,
             response JSONB,
             key_id TEXT,
+            version INTEGER NOT NULL DEFAULT 1,
             created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
             updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
         );
-        CREATE INDEX IF NOT EXISTS idx_settlements_key_id ON settlements(key_id);
-        CREATE INDEX IF NOT EXISTS idx_settlements_state ON settlements(state);
+        CREATE INDEX IF NOT EXISTS idx_settlement_projections_key_id ON settlement_projections(key_id);
+        CREATE INDEX IF NOT EXISTS idx_settlement_projections_state ON settlement_projections(state);
       `);
     } catch (err) {
-      this._degrade(`failed to create table: ${err.message}`);
+      this._degrade(`failed to create schema: ${err.message}`);
     }
   }
 
@@ -69,28 +155,10 @@ export class PostgresSettlementStore extends MemorySettlementStore {
     try {
       await this.ready;
       const { rows } = await this.pool.query(
-        'SELECT idempotency_key, network, scheme, payer, pay_to, asset, amount, state, tx_hash, error_reason, error_message, response, key_id, created_at, updated_at FROM settlements WHERE idempotency_key = $1',
+        `SELECT ${PROJECTION_COLUMNS} FROM settlement_projections WHERE idempotency_key = $1`,
         [idempotencyKey],
       );
-      if (rows.length === 0) return null;
-      const r = rows[0];
-      return {
-        idempotency_key: r.idempotency_key,
-        network: r.network,
-        scheme: r.scheme,
-        payer: r.payer,
-        pay_to: r.pay_to,
-        asset: r.asset,
-        amount: r.amount,
-        state: r.state,
-        tx_hash: r.tx_hash,
-        error_reason: r.error_reason,
-        error_message: r.error_message,
-        response: r.response,
-        key_id: r.key_id,
-        created_at: new Date(r.created_at).toISOString(),
-        updated_at: new Date(r.updated_at).toISOString(),
-      };
+      return rows.length ? mapProjectionRow(rows[0]) : null;
     } catch (err) {
       this._degrade(`get failed: ${err.message}`);
       return super.get(idempotencyKey);
@@ -102,51 +170,64 @@ export class PostgresSettlementStore extends MemorySettlementStore {
     try {
       await this.ready;
       const { rows } = await this.pool.query(
-        `INSERT INTO settlements (
-          idempotency_key, network, scheme, payer, pay_to, asset, amount, state, tx_hash, error_reason, error_message, response, key_id, created_at, updated_at
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NOW(), NOW())
+        `WITH next_seq AS (
+          SELECT COALESCE(MAX(seq), 0) + 1 AS seq
+          FROM settlement_events WHERE idempotency_key = $1
+        ),
+        ins_event AS (
+          INSERT INTO settlement_events (idempotency_key, seq, event_type, event_version, payload, recorded_at)
+          SELECT $1, next_seq.seq, 'SettlementInitiated', 1, $2::jsonb, NOW()
+          FROM next_seq
+          RETURNING idempotency_key, seq, recorded_at
+        )
+        INSERT INTO settlement_projections (
+          idempotency_key, network, scheme, payer, pay_to, asset, amount, state,
+          tx_hash, error_reason, error_message, response, key_id, version, created_at, updated_at
+        )
+        SELECT
+          ins_event.idempotency_key, $3, $4, $5, $6, $7, $8, 'submitted',
+          $9, NULL, NULL, NULL, $10, ins_event.seq, ins_event.recorded_at, ins_event.recorded_at
+        FROM ins_event
         ON CONFLICT (idempotency_key) DO UPDATE SET
-          state = EXCLUDED.state,
-          tx_hash = COALESCE(EXCLUDED.tx_hash, settlements.tx_hash),
-          error_reason = COALESCE(EXCLUDED.error_reason, settlements.error_reason),
-          error_message = COALESCE(EXCLUDED.error_message, settlements.error_message),
-          response = COALESCE(EXCLUDED.response, settlements.response),
-          updated_at = NOW()
-        RETURNING idempotency_key, network, scheme, payer, pay_to, asset, amount, state, tx_hash, error_reason, error_message, response, key_id, created_at, updated_at`,
+          network = EXCLUDED.network,
+          scheme = EXCLUDED.scheme,
+          payer = EXCLUDED.payer,
+          pay_to = EXCLUDED.pay_to,
+          asset = EXCLUDED.asset,
+          amount = EXCLUDED.amount,
+          state = 'submitted',
+          tx_hash = EXCLUDED.tx_hash,
+          error_reason = NULL,
+          error_message = NULL,
+          response = NULL,
+          key_id = EXCLUDED.key_id,
+          version = EXCLUDED.version,
+          updated_at = EXCLUDED.updated_at
+        RETURNING ${PROJECTION_COLUMNS}`,
         [
           record.idempotency_key,
+          JSON.stringify({
+            idempotency_key: record.idempotency_key,
+            network: record.network ?? '',
+            scheme: record.scheme ?? '',
+            payer: record.payer ?? null,
+            pay_to: record.pay_to ?? null,
+            asset: record.asset ?? null,
+            amount: record.amount ?? null,
+            tx_hash: record.tx_hash ?? null,
+            key_id: record.key_id ?? null,
+          }),
           record.network ?? '',
           record.scheme ?? '',
           record.payer ?? null,
           record.pay_to ?? null,
           record.asset ?? null,
           record.amount ?? null,
-          record.state ?? 'submitted',
           record.tx_hash ?? null,
-          record.error_reason ?? null,
-          record.error_message ?? null,
-          record.response ? JSON.stringify(record.response) : null,
           record.key_id ?? null,
         ],
       );
-      const r = rows[0];
-      const entry = {
-        idempotency_key: r.idempotency_key,
-        network: r.network,
-        scheme: r.scheme,
-        payer: r.payer,
-        pay_to: r.pay_to,
-        asset: r.asset,
-        amount: r.amount,
-        state: r.state,
-        tx_hash: r.tx_hash,
-        error_reason: r.error_reason,
-        error_message: r.error_message,
-        response: r.response,
-        key_id: r.key_id,
-        created_at: new Date(r.created_at).toISOString(),
-        updated_at: new Date(r.updated_at).toISOString(),
-      };
+      const entry = mapProjectionRow(rows[0]);
       await super.save(entry);
       return entry;
     } catch (err) {
@@ -159,18 +240,40 @@ export class PostgresSettlementStore extends MemorySettlementStore {
     if (this.degraded || !this.pool) return super.updateState(idempotencyKey, state, details);
     try {
       await this.ready;
+      const eventType = eventTypeForState(state);
       const { rows } = await this.pool.query(
-        `UPDATE settlements SET
-          state = $2,
-          tx_hash = COALESCE($3, tx_hash),
-          error_reason = COALESCE($4, error_reason),
-          error_message = COALESCE($5, error_message),
-          response = COALESCE($6, response),
-          updated_at = NOW()
-        WHERE idempotency_key = $1
-        RETURNING idempotency_key, network, scheme, payer, pay_to, asset, amount, state, tx_hash, error_reason, error_message, response, key_id, created_at, updated_at`,
+        `WITH next_seq AS (
+          SELECT COALESCE(MAX(seq), 0) + 1 AS seq
+          FROM settlement_events WHERE idempotency_key = $1
+        ),
+        ins_event AS (
+          INSERT INTO settlement_events (idempotency_key, seq, event_type, event_version, payload, recorded_at)
+          SELECT $1, next_seq.seq, $2, 1, $3::jsonb, NOW()
+          FROM next_seq
+          WHERE EXISTS (SELECT 1 FROM settlement_projections WHERE idempotency_key = $1)
+          RETURNING idempotency_key, seq, recorded_at
+        )
+        UPDATE settlement_projections SET
+          state = $4,
+          tx_hash = COALESCE($5, settlement_projections.tx_hash),
+          error_reason = COALESCE($6, settlement_projections.error_reason),
+          error_message = COALESCE($7, settlement_projections.error_message),
+          response = COALESCE($8, settlement_projections.response),
+          version = ins_event.seq,
+          updated_at = ins_event.recorded_at
+        FROM ins_event
+        WHERE settlement_projections.idempotency_key = ins_event.idempotency_key
+        RETURNING ${QUALIFIED_PROJECTION_COLUMNS}`,
         [
           idempotencyKey,
+          eventType,
+          JSON.stringify({
+            idempotency_key: idempotencyKey,
+            tx_hash: details.tx_hash ?? null,
+            error_reason: details.error_reason ?? null,
+            error_message: details.error_message ?? null,
+            response: details.response ?? null,
+          }),
           state,
           details.tx_hash ?? null,
           details.error_reason ?? null,
@@ -179,23 +282,7 @@ export class PostgresSettlementStore extends MemorySettlementStore {
         ],
       );
       if (rows.length === 0) return null;
-      const r = rows[0];
-      const entry = {
-        idempotency_key: r.idempotency_key,
-        network: r.network,
-        scheme: r.scheme,
-        payer: r.payer,
-        pay_to: r.pay_to,
-        asset: r.asset,
-        amount: r.amount,
-        state: r.state,
-        tx_hash: r.tx_hash,
-        error_reason: r.error_reason,
-        error_message: r.error_message,
-        key_id: r.key_id,
-        created_at: new Date(r.created_at).toISOString(),
-        updated_at: new Date(r.updated_at).toISOString(),
-      };
+      const entry = mapProjectionRow(rows[0]);
       await super.updateState(idempotencyKey, state, details);
       return entry;
     } catch (err) {
@@ -209,28 +296,103 @@ export class PostgresSettlementStore extends MemorySettlementStore {
     try {
       await this.ready;
       const { rows } = await this.pool.query(
-        'SELECT idempotency_key, network, scheme, payer, pay_to, asset, amount, state, tx_hash, error_reason, error_message, key_id, created_at, updated_at FROM settlements WHERE state = $1',
+        `SELECT ${PROJECTION_COLUMNS} FROM settlement_projections WHERE state = $1`,
         ['unknown'],
       );
-      return rows.map(r => ({
-        idempotency_key: r.idempotency_key,
-        network: r.network,
-        scheme: r.scheme,
-        payer: r.payer,
-        pay_to: r.pay_to,
-        asset: r.asset,
-        amount: r.amount,
-        state: r.state,
-        tx_hash: r.tx_hash,
-        error_reason: r.error_reason,
-        error_message: r.error_message,
-        key_id: r.key_id,
-        created_at: new Date(r.created_at).toISOString(),
-        updated_at: new Date(r.updated_at).toISOString(),
-      }));
+      return rows.map(mapProjectionRow);
     } catch (err) {
       this._degrade(`listUnknown failed: ${err.message}`);
       return super.listUnknown();
+    }
+  }
+
+  /** Full, ordered event history for one settlement — the audit trail (#130). */
+  async getEventLog(idempotencyKey) {
+    if (this.degraded || !this.pool) return super.getEventLog(idempotencyKey);
+    try {
+      await this.ready;
+      const { rows } = await this.pool.query(
+        `SELECT idempotency_key, seq, event_type, event_version, payload, recorded_at
+         FROM settlement_events WHERE idempotency_key = $1 ORDER BY seq ASC`,
+        [idempotencyKey],
+      );
+      return rows.map(mapEventRow);
+    } catch (err) {
+      this._degrade(`getEventLog failed: ${err.message}`);
+      return super.getEventLog(idempotencyKey);
+    }
+  }
+
+  /**
+   * Cross-aggregate, chronologically ordered export of every transition ever
+   * recorded, for regulatory export (#130).
+   */
+  async exportAuditLog({ since, until, limit } = {}) {
+    if (this.degraded || !this.pool) return super.exportAuditLog({ since, until, limit });
+    try {
+      await this.ready;
+      const { rows } = await this.pool.query(
+        `SELECT idempotency_key, seq, event_type, event_version, payload, recorded_at
+         FROM settlement_events
+         WHERE ($1::timestamptz IS NULL OR recorded_at >= $1)
+           AND ($2::timestamptz IS NULL OR recorded_at <= $2)
+         ORDER BY recorded_at ASC, id ASC
+         LIMIT $3`,
+        [since ?? null, until ?? null, limit ?? 10_000],
+      );
+      return rows.map(mapEventRow);
+    } catch (err) {
+      this._degrade(`exportAuditLog failed: ${err.message}`);
+      return super.exportAuditLog({ since, until, limit });
+    }
+  }
+
+  /**
+   * Replays one aggregate's event log through the canonical fold and
+   * overwrites its projection row with the result. The hot write path
+   * (save/updateState) never calls this — it exists to repair or verify a
+   * read model from the source of truth.
+   */
+  async rebuildProjection(idempotencyKey) {
+    if (this.degraded || !this.pool) return super.rebuildProjection(idempotencyKey);
+    try {
+      await this.ready;
+      const events = await this.getEventLog(idempotencyKey);
+      const projection = projectSettlement(events);
+      if (!projection) return null;
+      const { rows } = await this.pool.query(
+        `INSERT INTO settlement_projections (${PROJECTION_COLUMNS})
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)
+         ON CONFLICT (idempotency_key) DO UPDATE SET
+           network = EXCLUDED.network, scheme = EXCLUDED.scheme, payer = EXCLUDED.payer,
+           pay_to = EXCLUDED.pay_to, asset = EXCLUDED.asset, amount = EXCLUDED.amount,
+           state = EXCLUDED.state, tx_hash = EXCLUDED.tx_hash, error_reason = EXCLUDED.error_reason,
+           error_message = EXCLUDED.error_message, response = EXCLUDED.response, key_id = EXCLUDED.key_id,
+           version = EXCLUDED.version, created_at = EXCLUDED.created_at, updated_at = EXCLUDED.updated_at
+         RETURNING ${PROJECTION_COLUMNS}`,
+        [
+          projection.idempotency_key,
+          projection.network,
+          projection.scheme,
+          projection.payer,
+          projection.pay_to,
+          projection.asset,
+          projection.amount,
+          projection.state,
+          projection.tx_hash,
+          projection.error_reason,
+          projection.error_message,
+          projection.response ? JSON.stringify(projection.response) : null,
+          projection.key_id,
+          events.length,
+          projection.created_at,
+          projection.updated_at,
+        ],
+      );
+      return mapProjectionRow(rows[0]);
+    } catch (err) {
+      this._degrade(`rebuildProjection failed: ${err.message}`);
+      return super.rebuildProjection(idempotencyKey);
     }
   }
 }

--- a/test/settlement-events.test.js
+++ b/test/settlement-events.test.js
@@ -1,0 +1,553 @@
+/**
+ * Event-sourced settlement state machine (#130).
+ *
+ * The settlement store no longer overwrites a row in place: every transition
+ * is an appended event, and the current state read back by `get`/`listUnknown`
+ * is a projection folded over that stream. These tests pin:
+ *   - the event log itself (types, ordering, that a retry appends rather than
+ *     mutates)
+ *   - that the projection matches what a fold over the raw events produces
+ *   - the audit-log export surface, both the store method and the HTTP route
+ *   - the Postgres-backed store issuing the same event-then-projection writes
+ *     against a fake pool that mirrors the real schema
+ */
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { Keypair } from '@stellar/stellar-sdk';
+import { MemorySettlementStore } from '../src/store/memory.js';
+import { PostgresSettlementStore } from '../src/store/postgres.js';
+import { projectSettlement } from '../src/eventstore/projection.js';
+import { createApp } from '../src/app.js';
+import { resolveConfig } from '../src/config.js';
+
+describe('Event-sourced settlement store (#130)', () => {
+  test('save() appends a SettlementInitiated event, not a row write', async () => {
+    const store = new MemorySettlementStore();
+    await store.save({
+      idempotency_key: 'k1',
+      network: 'stellar:testnet',
+      scheme: 'exact-stellar',
+      state: 'submitted',
+      tx_hash: 'hash1',
+    });
+
+    const log = await store.getEventLog('k1');
+    assert.equal(log.length, 1);
+    assert.equal(log[0].event_type, 'SettlementInitiated');
+    assert.equal(log[0].seq, 1);
+    assert.equal(log[0].payload.tx_hash, 'hash1');
+  });
+
+  test('updateState() appends a terminal event; the record is never mutated in place', async () => {
+    const store = new MemorySettlementStore();
+    await store.save({
+      idempotency_key: 'k1',
+      network: 'stellar:testnet',
+      scheme: 'exact-stellar',
+    });
+    await store.updateState('k1', 'settled', { tx_hash: 'hash1', response: { success: true } });
+
+    const log = await store.getEventLog('k1');
+    assert.equal(log.length, 2);
+    assert.equal(log[0].event_type, 'SettlementInitiated');
+    assert.equal(log[1].event_type, 'SettlementSettled');
+    assert.equal(log[1].seq, 2);
+
+    const rec = await store.get('k1');
+    assert.equal(rec.state, 'settled');
+    assert.equal(rec.tx_hash, 'hash1');
+  });
+
+  test('updateState() on a key with no prior event is a no-op, not a fabricated event', async () => {
+    const store = new MemorySettlementStore();
+    const result = await store.updateState('never-seen', 'settled', {});
+    assert.equal(result, null);
+    assert.deepEqual(await store.getEventLog('never-seen'), []);
+  });
+
+  test('a retryable-failure retry appends a new Initiated event instead of rewriting history', async () => {
+    const store = new MemorySettlementStore();
+    await store.save({
+      idempotency_key: 'k1',
+      network: 'stellar:testnet',
+      scheme: 'exact-stellar',
+      tx_hash: 'first-attempt-hash',
+    });
+    await store.updateState('k1', 'failed', {
+      error_reason: 'soroban_rpc_unreachable',
+      error_message: 'rpc down',
+    });
+
+    // App-level retry: same idempotency key, fresh attempt.
+    await store.save({
+      idempotency_key: 'k1',
+      network: 'stellar:testnet',
+      scheme: 'exact-stellar',
+    });
+
+    const log = await store.getEventLog('k1');
+    assert.equal(log.length, 3);
+    assert.deepEqual(
+      log.map(e => e.event_type),
+      ['SettlementInitiated', 'SettlementFailed', 'SettlementInitiated'],
+    );
+
+    const rec = await store.get('k1');
+    assert.equal(rec.state, 'submitted');
+    assert.equal(rec.tx_hash, null); // reset by the fresh Initiated, exactly as the old error/tx fields were
+    assert.equal(rec.error_reason, null);
+    // created_at is the *first* event's timestamp, not the retry's.
+    assert.equal(rec.created_at, log[0].recorded_at);
+  });
+
+  test('the projection returned by get() is exactly a fold over the raw event log', async () => {
+    const store = new MemorySettlementStore();
+    await store.save({
+      idempotency_key: 'k1',
+      network: 'stellar:testnet',
+      scheme: 'exact-stellar',
+      payer: 'GPAYER',
+      pay_to: 'GPAYTO',
+      asset: 'USDC',
+      amount: '1000000',
+    });
+    await store.updateState('k1', 'unknown', { error_reason: 'submitted_outcome_unknown' });
+    await store.updateState('k1', 'settled', { tx_hash: 'hash-final' });
+
+    const log = await store.getEventLog('k1');
+    const rebuilt = projectSettlement(log);
+    const read = await store.get('k1');
+    assert.deepEqual(rebuilt, read);
+    assert.equal(read.state, 'settled');
+    assert.equal(read.tx_hash, 'hash-final');
+  });
+
+  test('listUnknown() reflects the projection, not a stale write', async () => {
+    const store = new MemorySettlementStore();
+    await store.save({
+      idempotency_key: 'k1',
+      network: 'stellar:testnet',
+      scheme: 'exact-stellar',
+    });
+    await store.updateState('k1', 'unknown', { error_reason: 'submitted_outcome_unknown' });
+    assert.equal((await store.listUnknown()).length, 1);
+
+    await store.updateState('k1', 'settled', {});
+    assert.equal((await store.listUnknown()).length, 0);
+  });
+
+  test('exportAuditLog() returns every transition across every settlement, in order', async () => {
+    const store = new MemorySettlementStore();
+    await store.save({ idempotency_key: 'a', network: 'stellar:testnet', scheme: 'exact-stellar' });
+    await store.save({ idempotency_key: 'b', network: 'stellar:testnet', scheme: 'exact-stellar' });
+    await store.updateState('a', 'settled', {});
+    await store.updateState('b', 'failed', { error_reason: 'facilitator_error' });
+
+    const all = await store.exportAuditLog();
+    assert.equal(all.length, 4);
+    // Chronological, not grouped by key.
+    for (let i = 1; i < all.length; i++) {
+      assert.ok(all[i - 1].recorded_at <= all[i].recorded_at);
+    }
+    const limited = await store.exportAuditLog({ limit: 2 });
+    assert.equal(limited.length, 2);
+  });
+
+  test('rebuildProjection() reconstructs identical state from the event log alone', async () => {
+    const store = new MemorySettlementStore();
+    await store.save({
+      idempotency_key: 'k1',
+      network: 'stellar:testnet',
+      scheme: 'exact-stellar',
+    });
+    await store.updateState('k1', 'failed', { error_reason: 'rate_limited' });
+
+    const before = await store.get('k1');
+    const rebuilt = await store.rebuildProjection('k1');
+    assert.deepEqual(rebuilt, before);
+  });
+});
+
+describe('GET /settlements/:idempotencyKey/events (#130)', () => {
+  function buildApp(store) {
+    const dummySecret = Keypair.random().secret();
+    const config = resolveConfig({
+      FACILITATOR_SECRET: dummySecret,
+      FACILITATOR_API_KEYS: 'callerA:secretA,callerB:secretB',
+    });
+    return createApp(
+      config,
+      { getSupported: () => ({}) },
+      { checkSettle: async () => ({ allowed: true }) },
+      {},
+      null,
+      { settlementStore: store },
+    );
+  }
+
+  test('returns the full ordered event history for the owning caller', async () => {
+    const store = new MemorySettlementStore();
+    await store.save({
+      idempotency_key: 'settlement-A',
+      network: 'stellar:testnet',
+      scheme: 'exact-stellar',
+      key_id: 'callerA',
+    });
+    await store.updateState('settlement-A', 'settled', { tx_hash: 'hashA' });
+
+    const app = buildApp(store);
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/settlements/settlement-A/events',
+        headers: { authorization: 'Bearer secretA' },
+      });
+      assert.equal(res.statusCode, 200);
+      const body = JSON.parse(res.payload);
+      assert.equal(body.ok, true);
+      assert.equal(body.events.length, 2);
+      assert.deepEqual(
+        body.events.map(e => e.event_type),
+        ['SettlementInitiated', 'SettlementSettled'],
+      );
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('404s for a caller who does not own the settlement', async () => {
+    const store = new MemorySettlementStore();
+    await store.save({
+      idempotency_key: 'settlement-A',
+      network: 'stellar:testnet',
+      scheme: 'exact-stellar',
+      key_id: 'callerA',
+    });
+
+    const app = buildApp(store);
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/settlements/settlement-A/events',
+        headers: { authorization: 'Bearer secretB' },
+      });
+      assert.equal(res.statusCode, 404);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('404s for an unknown settlement', async () => {
+    const store = new MemorySettlementStore();
+    const app = buildApp(store);
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/settlements/does-not-exist/events',
+        headers: { authorization: 'Bearer secretA' },
+      });
+      assert.equal(res.statusCode, 404);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('PostgresSettlementStore event sourcing against a fake pool (#130)', () => {
+  test('save/updateState/get/listUnknown/getEventLog round-trip through events + projection', async () => {
+    const pool = fakePostgresPool();
+    const store = new PostgresSettlementStore('postgres://unused', { pool });
+
+    await store.save({
+      idempotency_key: 'pg-1',
+      network: 'stellar:testnet',
+      scheme: 'exact-stellar',
+      payer: 'GPAYER',
+      pay_to: 'GPAYTO',
+      asset: 'USDC',
+      amount: '1000000',
+      tx_hash: 'submit-hash',
+      key_id: 'callerA',
+    });
+
+    let rec = await store.get('pg-1');
+    assert.equal(rec.state, 'submitted');
+    assert.equal(rec.tx_hash, 'submit-hash');
+    assert.equal(rec.version, 1);
+
+    await store.updateState('pg-1', 'unknown', { error_reason: 'submitted_outcome_unknown' });
+    assert.equal((await store.listUnknown()).length, 1);
+
+    await store.updateState('pg-1', 'settled', { tx_hash: 'final-hash' });
+    rec = await store.get('pg-1');
+    assert.equal(rec.state, 'settled');
+    assert.equal(rec.tx_hash, 'final-hash');
+    assert.equal(rec.version, 3);
+    assert.equal((await store.listUnknown()).length, 0);
+
+    const log = await store.getEventLog('pg-1');
+    assert.deepEqual(
+      log.map(e => e.event_type),
+      ['SettlementInitiated', 'SettlementOutcomeUnknown', 'SettlementSettled'],
+    );
+    assert.deepEqual(
+      log.map(e => e.seq),
+      [1, 2, 3],
+    );
+  });
+
+  test('updateState() on an unknown key never appends an orphan event', async () => {
+    const pool = fakePostgresPool();
+    const store = new PostgresSettlementStore('postgres://unused', { pool });
+
+    const result = await store.updateState('never-seen', 'settled', {});
+    assert.equal(result, null);
+    assert.equal(pool.events.length, 0);
+  });
+
+  test('exportAuditLog() exposes the append-only log across aggregates', async () => {
+    const pool = fakePostgresPool();
+    const store = new PostgresSettlementStore('postgres://unused', { pool });
+
+    await store.save({ idempotency_key: 'a', network: 'stellar:testnet', scheme: 'exact-stellar' });
+    await store.save({ idempotency_key: 'b', network: 'stellar:testnet', scheme: 'exact-stellar' });
+    await store.updateState('a', 'settled', {});
+
+    const all = await store.exportAuditLog({});
+    assert.equal(all.length, 3);
+  });
+
+  test('rebuildProjection() replays the event log and reproduces the live projection', async () => {
+    const pool = fakePostgresPool();
+    const store = new PostgresSettlementStore('postgres://unused', { pool });
+
+    await store.save({
+      idempotency_key: 'pg-2',
+      network: 'stellar:testnet',
+      scheme: 'exact-stellar',
+    });
+    await store.updateState('pg-2', 'failed', {
+      error_reason: 'rate_limited',
+      error_message: 'slow down',
+    });
+
+    const live = await store.get('pg-2');
+
+    // Simulate read-model corruption/loss: the events table is untouched.
+    pool.projections.delete('pg-2');
+    assert.equal(await store.get('pg-2'), null);
+
+    const rebuilt = await store.rebuildProjection('pg-2');
+    assert.equal(rebuilt.state, live.state);
+    assert.equal(rebuilt.error_reason, live.error_reason);
+    assert.equal(rebuilt.error_message, live.error_message);
+
+    // The repaired read model serves get() again.
+    const readAfterRepair = await store.get('pg-2');
+    assert.equal(readAfterRepair.state, 'failed');
+  });
+
+  test('a retry after a retryable failure appends rather than overwrites, same as the memory store', async () => {
+    const pool = fakePostgresPool();
+    const store = new PostgresSettlementStore('postgres://unused', { pool });
+
+    await store.save({
+      idempotency_key: 'pg-3',
+      network: 'stellar:testnet',
+      scheme: 'exact-stellar',
+      tx_hash: 'h1',
+    });
+    await store.updateState('pg-3', 'failed', { error_reason: 'lock_timeout' });
+    await store.save({
+      idempotency_key: 'pg-3',
+      network: 'stellar:testnet',
+      scheme: 'exact-stellar',
+    });
+
+    const log = await store.getEventLog('pg-3');
+    assert.deepEqual(
+      log.map(e => e.event_type),
+      ['SettlementInitiated', 'SettlementFailed', 'SettlementInitiated'],
+    );
+    const rec = await store.get('pg-3');
+    assert.equal(rec.state, 'submitted');
+    assert.equal(rec.tx_hash, null);
+    assert.equal(rec.error_reason, null);
+  });
+});
+
+/**
+ * A minimal emulation of the pg Pool surface, implementing exactly the
+ * statements PostgresSettlementStore issues: an append to settlement_events
+ * paired with the projection write derived from it. This pins the SQL's
+ * semantics (atomic append + projection upsert, COALESCE-preserved fields on
+ * a partial update, seq/version derivation) without a live database.
+ */
+function fakePostgresPool() {
+  const events = [];
+  const projections = new Map();
+
+  function nextSeq(key) {
+    const seqs = events.filter(e => e.idempotency_key === key).map(e => e.seq);
+    return seqs.length ? Math.max(...seqs) + 1 : 1;
+  }
+
+  return {
+    events,
+    projections,
+    async query(sql, params = []) {
+      const norm = sql.replace(/\s+/g, ' ').trim();
+
+      if (norm.includes('CREATE TABLE IF NOT EXISTS settlement_events')) {
+        return { rows: [] };
+      }
+
+      if (norm.includes("'SettlementInitiated'")) {
+        const [key, payloadJson, network, scheme, payer, payTo, asset, amount, txHash, keyId] =
+          params;
+        const seq = nextSeq(key);
+        const recordedAt = new Date(Date.now() + events.length).toISOString();
+        events.push({
+          idempotency_key: key,
+          seq,
+          event_type: 'SettlementInitiated',
+          event_version: 1,
+          payload: JSON.parse(payloadJson),
+          recorded_at: recordedAt,
+        });
+        const existing = projections.get(key);
+        const row = {
+          idempotency_key: key,
+          network,
+          scheme,
+          payer,
+          pay_to: payTo,
+          asset,
+          amount,
+          state: 'submitted',
+          tx_hash: txHash,
+          error_reason: null,
+          error_message: null,
+          response: null,
+          key_id: keyId,
+          version: seq,
+          created_at: existing?.created_at ?? recordedAt,
+          updated_at: recordedAt,
+        };
+        projections.set(key, row);
+        return { rows: [{ ...row }] };
+      }
+
+      if (
+        norm.includes('WHERE settlement_projections.idempotency_key = ins_event.idempotency_key')
+      ) {
+        const [key, eventType, payloadJson, state, txHash, errorReason, errorMessage, response] =
+          params;
+        const existing = projections.get(key);
+        if (!existing) return { rows: [] };
+        const seq = nextSeq(key);
+        const recordedAt = new Date(Date.now() + events.length).toISOString();
+        events.push({
+          idempotency_key: key,
+          seq,
+          event_type: eventType,
+          event_version: 1,
+          payload: JSON.parse(payloadJson),
+          recorded_at: recordedAt,
+        });
+        const row = {
+          ...existing,
+          state,
+          tx_hash: txHash ?? existing.tx_hash,
+          error_reason: errorReason ?? existing.error_reason,
+          error_message: errorMessage ?? existing.error_message,
+          response: response ? JSON.parse(response) : existing.response,
+          version: seq,
+          updated_at: recordedAt,
+        };
+        projections.set(key, row);
+        return { rows: [{ ...row }] };
+      }
+
+      if (
+        norm.startsWith('SELECT') &&
+        norm.includes('FROM settlement_projections WHERE idempotency_key = $1')
+      ) {
+        const [key] = params;
+        const row = projections.get(key);
+        return { rows: row ? [{ ...row }] : [] };
+      }
+
+      if (norm.includes('FROM settlement_projections WHERE state = $1')) {
+        const [state] = params;
+        return {
+          rows: [...projections.values()].filter(r => r.state === state).map(r => ({ ...r })),
+        };
+      }
+
+      if (norm.includes('FROM settlement_events WHERE idempotency_key = $1 ORDER BY seq ASC')) {
+        const [key] = params;
+        return {
+          rows: events
+            .filter(e => e.idempotency_key === key)
+            .sort((a, b) => a.seq - b.seq)
+            .map(e => ({ ...e })),
+        };
+      }
+
+      if (norm.includes('($1::timestamptz IS NULL OR recorded_at >= $1)')) {
+        const [since, until, limit] = params;
+        let filtered = [...events].sort((a, b) => a.recorded_at.localeCompare(b.recorded_at));
+        if (since) filtered = filtered.filter(e => e.recorded_at >= since);
+        if (until) filtered = filtered.filter(e => e.recorded_at <= until);
+        return { rows: filtered.slice(0, limit ?? filtered.length).map(e => ({ ...e })) };
+      }
+
+      if (
+        norm.startsWith('INSERT INTO settlement_projections (') &&
+        norm.includes('VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)')
+      ) {
+        const [
+          key,
+          network,
+          scheme,
+          payer,
+          payTo,
+          asset,
+          amount,
+          state,
+          txHash,
+          errorReason,
+          errorMessage,
+          response,
+          keyId,
+          version,
+          createdAt,
+          updatedAt,
+        ] = params;
+        const row = {
+          idempotency_key: key,
+          network,
+          scheme,
+          payer,
+          pay_to: payTo,
+          asset,
+          amount,
+          state,
+          tx_hash: txHash,
+          error_reason: errorReason,
+          error_message: errorMessage,
+          response: response ? JSON.parse(response) : null,
+          key_id: keyId,
+          version,
+          created_at: createdAt,
+          updated_at: updatedAt,
+        };
+        projections.set(key, row);
+        return { rows: [{ ...row }] };
+      }
+
+      throw new Error(`fakePostgresPool: unrecognized statement: ${norm.slice(0, 120)}`);
+    },
+  };
+}

--- a/test/settlement-store.test.js
+++ b/test/settlement-store.test.js
@@ -187,9 +187,11 @@ describe('Durable Settlement Store & Idempotency Keys (#10)', () => {
       idempotency_key: 'unresolved-1',
       network: 'stellar:testnet',
       scheme: 'exact-stellar',
-      state: 'unknown',
-      tx_hash: 'tx_confirmed_123',
     });
+    // Realistic path to 'unknown': submitted, then the outcome couldn't be
+    // confirmed (see app.js's timeout-after-submission handling) — a
+    // settlement never starts life already 'unknown' (#130).
+    await store.updateState('unresolved-1', 'unknown', { tx_hash: 'tx_confirmed_123' });
 
     const mockRpc = async (_url, body) => {
       if (body.method === 'getTransaction' && body.params.hash === 'tx_confirmed_123') {


### PR DESCRIPTION
## Summary

Closes #130.

Settlement records were overwritten in place (`UPDATE ... SET state = $2, ...`), so the sequence of transitions that led to a final state — was it submitted once and timed out, or retried three times against a flapping RPC endpoint before the final rejection? — could never be reconstructed. This migrates the settlement state machine to append-only event sourcing:

- **Event schema** (`src/eventstore/events.js`): `SettlementInitiated`, `SettlementSettled`, `SettlementFailed`, `SettlementOutcomeUnknown`, each carrying an `event_version` so a future payload change doesn't invalidate history already on disk.
- **Projection engine** (`src/eventstore/projection.js`): one pure `projectSettlement(events)` fold is the single definition of "what does this settlement look like now" — used by both stores and by the repair path.
- **`MemorySettlementStore`** now keeps only the event log and projects on every read — there is no separate mutable record to drift from it.
- **`PostgresSettlementStore`** keeps a `settlement_projections` read model for fast indexed reads, written only inside the same statement that appends the event producing it (a CTE: insert the event, upsert the projection from it) — so an event can never exist without its projection or vice versa. `rebuildProjection()` replays a stream through the identical fold to repair or verify a read model from source of truth; it's off the hot write path.
- **Migration** `migrations/004_settlement_events.sql` adds `settlement_events` and `settlement_projections`, additive only — the existing `settlements` table from migration 003 is untouched.
- **New surface**: `getEventLog`/`exportAuditLog` on both stores, and `GET /settlements/:idempotencyKey/events` for exporting one settlement's full transition history over HTTP, scoped by caller `keyId` exactly like the existing state endpoint.
- **No breaking changes**: `get`/`save`/`updateState`/`listUnknown`/`deriveIdempotencyKey` keep their existing signatures and behaviour, so `src/app.js`'s `/settle` route required no changes.

Design write-up with the full rationale: `docs/EVENT-SOURCING.md`.

## Acceptance criteria (from #130)

- [x] Event schemas are strictly defined and versioned
- [x] State mutations only occur by appending events
- [x] Projections successfully build current state from event history
- [x] Full audit log of all transitions can be exported

## Test plan

- [x] `npm test` — 297/297 passing, including new `test/settlement-events.test.js` covering: event log ordering, retry-after-failure appending rather than mutating, projection-equals-fold-over-events, `listUnknown`/`exportAuditLog`, `rebuildProjection` reconstructing a deleted read-model row, the new HTTP route (owner/non-owner/unknown-key scoping), and a Postgres-backed run against a fake pool mirroring the real schema
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run licenses` — clean
- [x] Updated the one pre-existing test (`test/settlement-store.test.js`) that seeded a record directly into the `unknown` state via `save()` — no longer possible now that `save()` always means "an attempt was just initiated"; reseeded realistically via `save()` + `updateState()`