### PR TITLE
fix: expose MCP server entrypoint

### DIFF
--- a/src/mcp/index.js
+++ b/src/mcp/index.js
@@ -1,0 +1,1 @@
+export { McpServer } from './server.js';

--- a/test/mcp-index.test.js
+++ b/test/mcp-index.test.js
@@ -1,0 +1,8 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { McpServer } from '../src/mcp/index.js';
+import { McpServer as ServerImplementation } from '../src/mcp/server.js';
+
+test('MCP index exports the server implementation', () => {
+  assert.strictEqual(McpServer, ServerImplementation);
+});


### PR DESCRIPTION
Closes #171

## Summary
- Expose the existing MCP server implementation from the previously empty module entrypoint.
- Add a focused regression test that verifies the public export resolves to the server implementation.

## Scope
Does not alter the MCP CLI, protocol behavior, payment flow, dependencies, or unrelated modules.

## Testing
- `node --test test/mcp-index.test.js test/mcp.test.js` — passed.
- `npm run lint` — blocked by pre-existing syntax errors in `src/app.js` and `src/server.js`.
- `npm run format:check` — blocked by the same pre-existing `src/server.js` syntax error and existing formatting warnings.
- `npm test` — timed out before completion.
- `npm audit --audit-level=high` — passed.
- `node scripts/check-licenses.mjs --list` — passed.
- `npm run check:migration` — passed with six existing non-blocking warnings.
- `npm run eval` — passed.

## Files changed
- `src/mcp/index.js` — exports `McpServer` from the existing implementation.
- `test/mcp-index.test.js` — regression coverage for the entrypoint export.