### PR TITLE
fix: unify discovery validation policy

### DIFF
--- a/src/catalog/validation.js
+++ b/src/catalog/validation.js
@@ -10,9 +10,7 @@ import {
 /**
  * Distinguishes a hostile routeTemplate (path traversal, protocol smuggling,
  * unparseable percent-encoding) from one that is merely low-quality, such as
- * the wildcard ("*") pattern upstream's own SDK registers by default. Both
- * fail isValidRouteTemplate() identically, but only the former is a security
- * boundary worth discarding the whole resource over — see #65.
+ * the wildcard ("*") pattern upstream's own SDK registers by default.
  */
 function isHostileRouteTemplate(value) {
   if (typeof value !== 'string' || value.length === 0) return false;
@@ -25,25 +23,51 @@ function isHostileRouteTemplate(value) {
   return decoded.includes('..') || decoded.includes('://');
 }
 
-export function validateForCatalog(paymentPayload, paymentRequirements) {
-  const result = {
+function createResult() {
+  return {
     hardDrop: false,
     reason: null,
     softDrops: [],
+    advisories: [],
     resource: null,
   };
+}
 
-  // We rely on upstream extraction for base structure, then enforce our policy
+function addAdvisories(result, declaration) {
+  if (!declaration.routeTemplate) {
+    result.advisories.push('routeTemplate is required');
+  }
+
+  const matches =
+    typeof declaration.routeTemplate === 'string'
+      ? declaration.routeTemplate.match(/\{([^}]+)\}/g)
+      : null;
+  if (matches) {
+    for (const match of matches) {
+      const parameter = match.slice(1, -1);
+      if (!declaration.parameters?.[parameter]) {
+        result.advisories.push(`Missing description for parameter: ${parameter}`);
+      }
+    }
+  }
+
+  if (!declaration.pricing || typeof declaration.pricing !== 'object') {
+    result.advisories.push('pricing object is required');
+  } else {
+    if (!declaration.pricing.amount) result.advisories.push('pricing.amount is required');
+    if (!declaration.pricing.asset) result.advisories.push('pricing.asset is required');
+  }
+}
+
+function validatePolicy(paymentPayload, paymentRequirements, result) {
   const extracted = extractDiscoveryInfo(paymentPayload, paymentRequirements, false);
-
   if (!extracted) {
     result.hardDrop = true;
     result.reason = 'missing_or_invalid_discovery_extension';
     return result;
   }
 
-  // 1. extension validation (validate schema of bazaar.info)
-  const rawBazaar = paymentPayload.extensions && paymentPayload.extensions['bazaar'];
+  const rawBazaar = paymentPayload.extensions?.bazaar;
   if (rawBazaar) {
     const schemaResult = validateDiscoveryExtension(rawBazaar);
     if (!schemaResult.valid) {
@@ -53,21 +77,6 @@ export function validateForCatalog(paymentPayload, paymentRequirements) {
     }
   }
 
-  // 2. routeTemplate validation
-  //
-  // Path traversal and protocol smuggling stay a hard drop — that is a real
-  // security boundary (SSRF / traversal), not a quality issue. But a wildcard
-  // ("*") route is low-quality discovery metadata, not a malformed or hostile
-  // one: upstream's own SDK registers it by default and warns that it
-  // degrades to auto-generated parameter names (var1, var2, ...) rather than
-  // refusing to emit it. Hard-dropping the whole resource over that punishes
-  // a seller for the stock SDK's defaults, so this is a soft drop instead —
-  // the resource still lands, without the routeTemplate (extractDiscoveryInfo
-  // above already leaves it undefined and falls back to the payment's own
-  // resource URL), and the quality issue is surfaced via
-  // softDrops/EXTENSION-RESPONSES so the seller can improve it. See #23 for
-  // the soft-drop policy this stays consistent with, and #65 for the
-  // decision.
   const rawTemplate = rawBazaar?.routeTemplate;
   if (rawTemplate !== undefined && !isValidRouteTemplate(rawTemplate)) {
     if (isHostileRouteTemplate(rawTemplate)) {
@@ -78,7 +87,6 @@ export function validateForCatalog(paymentPayload, paymentRequirements) {
     result.softDrops.push('routeTemplate');
   }
 
-  // 3. serviceName validation
   const rawServiceName = paymentPayload.resource?.serviceName;
   if (rawServiceName !== undefined) {
     if (!isValidServiceName(rawServiceName)) {
@@ -89,7 +97,6 @@ export function validateForCatalog(paymentPayload, paymentRequirements) {
     }
   }
 
-  // 4. iconUrl validation
   const rawIconUrl = paymentPayload.resource?.iconUrl;
   if (rawIconUrl !== undefined) {
     if (!isValidIconUrl(rawIconUrl)) {
@@ -100,35 +107,29 @@ export function validateForCatalog(paymentPayload, paymentRequirements) {
     }
   }
 
-  // 5. description validation and truncation
-  const rawDesc = paymentPayload.resource?.description;
-  if (typeof rawDesc === 'string') {
-    let safeDesc = rawDesc.replace(/<[^>]*>?/gm, '').trim();
-    if (safeDesc.length > 200) {
-      safeDesc = safeDesc.substring(0, 200);
+  const rawDescription = paymentPayload.resource?.description;
+  if (typeof rawDescription === 'string') {
+    let description = rawDescription.replace(/<[^>]*>?/gm, '').trim();
+    if (description.length > 200) {
+      description = description.substring(0, 200);
       result.softDrops.push('description_truncated');
     }
-    extracted.description = safeDesc;
+    extracted.description = description;
   }
 
-  // 6. tags validation
   const rawTags = paymentPayload.resource?.tags;
   if (Array.isArray(rawTags)) {
-    const cleanTags = sanitizeTags(rawTags);
-    if (
-      cleanTags.length !== rawTags.length ||
-      JSON.stringify(cleanTags) !== JSON.stringify(rawTags)
-    ) {
+    const tags = sanitizeTags(rawTags);
+    if (tags.length !== rawTags.length || JSON.stringify(tags) !== JSON.stringify(rawTags)) {
       result.softDrops.push('tags_filtered');
     }
-    extracted.tags = cleanTags;
+    extracted.tags = tags;
   }
 
-  // Create final record shape expected by MemoryCatalogStore
-  const record = {
+  result.resource = {
     type: extracted.toolName ? 'mcp' : 'http',
     url: extracted.resourceUrl,
-    toolName: extracted.toolName, // undefined for http
+    toolName: extracted.toolName,
     serviceName: extracted.serviceName,
     description: extracted.description,
     tags: extracted.tags,
@@ -138,7 +139,71 @@ export function validateForCatalog(paymentPayload, paymentRequirements) {
     extensions: extracted.extensions,
     payTo: paymentRequirements.payTo,
   };
-
-  result.resource = record;
   return result;
+}
+
+/**
+ * Runs the authoritative catalog policy. Payment-shaped values are validated
+ * directly; SDK declarations are adapted into the same Bazaar extension shape.
+ * Seller-only guidance is returned as advisories and never changes admission.
+ */
+export function validateDiscoveryPolicy(input, paymentRequirements = {}) {
+  const result = createResult();
+  if (!input || typeof input !== 'object') {
+    result.hardDrop = true;
+    result.reason = 'invalid_declaration';
+    return result;
+  }
+
+  if (input.paymentPayload && input.paymentRequirements) {
+    return validatePolicy(input.paymentPayload, input.paymentRequirements, result);
+  }
+
+  addAdvisories(result, input);
+  const declaration = {
+    x402Version: 2,
+    resource: {
+      url: input.url || input.resourceUrl || 'https://discovery.invalid',
+      serviceName: input.serviceName,
+      description: input.description,
+      iconUrl: input.iconUrl,
+      tags: input.tags,
+    },
+    extensions: {
+      bazaar: {
+        info: input.info || {
+          input: { type: input.type || 'http', method: input.method || 'GET' },
+        },
+        schema: input.schema || {
+          type: 'object',
+          properties: {
+            input: {
+              type: 'object',
+              properties: {
+                type: { type: 'string' },
+                method: { type: 'string' },
+              },
+              required: ['type', 'method'],
+            },
+          },
+          required: ['input'],
+        },
+        routeTemplate: input.routeTemplate,
+      },
+    },
+  };
+
+  const policy = validatePolicy(
+    declaration,
+    {
+      network: input.network || paymentRequirements.network || 'stellar:testnet',
+      payTo: input.payTo || paymentRequirements.payTo || '',
+    },
+    result,
+  );
+  return policy;
+}
+
+export function validateForCatalog(paymentPayload, paymentRequirements) {
+  return validateDiscoveryPolicy({ paymentPayload, paymentRequirements });
 }

--- a/src/sdk/cli.js
+++ b/src/sdk/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import fs from 'fs';
-import { validateDiscoveryDeclaration } from './validation.js';
+import { validateDiscoveryPolicy } from './validation.js';
 
 const file = process.argv[2];
 if (!file) {
@@ -10,11 +10,19 @@ if (!file) {
 
 try {
   const data = JSON.parse(fs.readFileSync(file, 'utf8'));
-  const errors = validateDiscoveryDeclaration(data);
-  if (errors.length > 0) {
+  const result = validateDiscoveryPolicy(data);
+
+  if (result.hardDrop) {
     console.error('Validation failed:');
-    errors.forEach(err => console.error(' - ' + err));
+    console.error(` - ${result.reason}`);
     process.exit(1);
+  }
+
+  for (const field of result.softDrops) {
+    console.warn(`Warning: ${field} will be dropped or sanitized by the catalog.`);
+  }
+  for (const advisory of result.advisories) {
+    console.warn(`Advisory: ${advisory}`);
   }
   console.log('Validation passed.');
 } catch (err) {

--- a/src/sdk/validation.js
+++ b/src/sdk/validation.js
@@ -1,29 +1,8 @@
+import { validateDiscoveryPolicy } from '../catalog/validation.js';
+
 export function validateDiscoveryDeclaration(decl) {
-  const errors = [];
-  if (!decl || typeof decl !== 'object') {
-    return ['Declaration must be an object'];
-  }
-  if (!decl.routeTemplate) errors.push('routeTemplate is required');
-
-  // Check for parameter descriptions if parameters exist in template
-  if (decl.routeTemplate) {
-    const matches = decl.routeTemplate.match(/\{([^}]+)\}/g);
-    if (matches) {
-      const params = matches.map(m => m.slice(1, -1));
-      params.forEach(p => {
-        if (!decl.parameters || !decl.parameters[p]) {
-          errors.push(`Missing description for parameter: ${p}`);
-        }
-      });
-    }
-  }
-
-  if (!decl.pricing || typeof decl.pricing !== 'object') {
-    errors.push('pricing object is required');
-  } else {
-    if (!decl.pricing.amount) errors.push('pricing.amount is required');
-    if (!decl.pricing.asset) errors.push('pricing.asset is required');
-  }
-
-  return errors;
+  const result = validateDiscoveryPolicy(decl);
+  return result.hardDrop ? [result.reason, ...result.softDrops] : result.advisories;
 }
+
+export { validateDiscoveryPolicy };

--- a/test/catalog.policy.test.js
+++ b/test/catalog.policy.test.js
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { validateDiscoveryPolicy, validateForCatalog } from '../src/catalog/validation.js';
+
+const requirement = { network: 'stellar:testnet', payTo: 'G123' };
+
+function paymentFor(routeTemplate) {
+  return {
+    paymentPayload: {
+      x402Version: 2,
+      resource: { url: 'https://example.test/api/resource' },
+      extensions: {
+        bazaar: {
+          info: { input: { type: 'http', method: 'GET' } },
+          schema: {
+            type: 'object',
+            properties: {
+              input: {
+                type: 'object',
+                properties: {
+                  type: { type: 'string' },
+                  method: { type: 'string' },
+                },
+                required: ['type', 'method'],
+              },
+            },
+            required: ['input'],
+          },
+          routeTemplate,
+        },
+      },
+    },
+    paymentRequirements: requirement,
+  };
+}
+
+test('shared discovery policy keeps CLI and catalog admission aligned', () => {
+  const fixtures = [
+    { name: 'valid', declaration: { routeTemplate: '/api/resource' }, route: '/api/resource' },
+    { name: 'soft drop', declaration: { routeTemplate: '*' }, route: '*' },
+    {
+      name: 'hard drop',
+      declaration: { routeTemplate: '/api/%2e%2e/private' },
+      route: '/api/%2e%2e/private',
+    },
+  ];
+
+  for (const fixture of fixtures) {
+    const seller = validateDiscoveryPolicy(fixture.declaration, requirement);
+    const catalog = validateForCatalog(...Object.values(paymentFor(fixture.route)));
+
+    assert.equal(catalog.hardDrop, seller.hardDrop, fixture.name);
+    if (fixture.name === 'hard drop') {
+      assert.equal(seller.reason, 'invalid_routeTemplate');
+      assert.equal(catalog.reason, 'invalid_routeTemplate');
+    }
+    if (fixture.name === 'soft drop') {
+      assert.ok(seller.softDrops.includes('routeTemplate'));
+      assert.ok(catalog.softDrops.includes('routeTemplate'));
+    }
+  }
+});

--- a/test/sdk.test.js
+++ b/test/sdk.test.js
@@ -22,13 +22,13 @@ function testValidation() {
   };
   assert.strictEqual(validateDiscoveryDeclaration(valid).length, 0);
 
-  const invalid = {
+  const incomplete = {
     routeTemplate: '/api/data/{id}',
     pricing: { amount: '1', asset: 'USDC' },
   };
-  const errors = validateDiscoveryDeclaration(invalid);
-  assert.strictEqual(errors.length, 1);
-  assert.ok(errors[0].includes('Missing description for parameter: id'));
+  const advisories = validateDiscoveryDeclaration(incomplete);
+  assert.strictEqual(advisories.length, 1);
+  assert.ok(advisories[0].includes('Missing description for parameter: id'));
   console.log('✅ testValidation passed');
 }
 


### PR DESCRIPTION
Closes #167

## Summary
- Centralize catalog admission policy so seller validation and server cataloging use the same hard-drop and soft-drop rules.
- Keep parameter and pricing checks as seller-facing advisories instead of validity failures.
- Report catalog soft drops as warnings and add shared fixtures covering valid, soft-drop, and hard-drop outcomes.

## Scope
Does not fix upstream `isValidRouteTemplate` defects (#150), bind resources to claimed URLs (#151), change POST error shapes (#142), or touch MCP/key-rotation work.

## Testing
- `node --test test/sdk.test.js test/catalog.validation.test.js test/catalog.policy.test.js test/server.catalog.test.js` — passed (12 tests).
- CLI hard-drop fixture — passed with non-zero exit and `invalid_routeTemplate`.
- CLI wildcard fixture — passed with warning and zero exit.
- `npm run lint` — blocked by pre-existing syntax errors in `src/app.js` and `src/server.js`.
- `npm run format:check` — changed files pass; full repository blocked by the same pre-existing `src/server.js` syntax error and existing warnings.
- `npm test` — timed out before completion.
- `npm audit --audit-level=high` — passed.
- `node scripts/check-licenses.mjs --list` — passed.
- `npm run check:migration` — passed with six existing non-blocking warnings.
- `npm run eval` — passed.

## Files changed
- `src/catalog/validation.js` — shared authoritative policy and declaration adapter.
- `src/sdk/validation.js` — delegates SDK validation to the shared policy.
- `src/sdk/cli.js` — distinguishes failures, warnings, and advisories.
- `test/sdk.test.js` — updates seller guidance expectations.
- `test/catalog.policy.test.js` — shared fixture agreement coverage.