### PR TITLE
feat: add zero-downtime signer rotation

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -67,6 +67,8 @@ export function resolveConfig(env = process.env) {
       feeBumpSecret: testnetFeeBumpSecret,
       rpcUrl: env.STELLAR_RPC_URL,
       maxTransactionFeeStroops: Number(env.MAX_TX_FEE_STROOPS ?? 50_000),
+      keyManagerUrl: env.KEY_MANAGER_URL || null,
+      keyManagerPollIntervalMs: Number(env.KEY_MANAGER_POLL_INTERVAL_MS ?? 0),
     },
   };
 
@@ -144,6 +146,10 @@ export function resolveConfig(env = process.env) {
       feeBumpSecret: pubnetFeeBumpSecret,
       rpcUrl: env.STELLAR_RPC_URL_PUBNET,
       maxTransactionFeeStroops: Number(env.MAX_TX_FEE_STROOPS_PUBNET ?? 50_000),
+      keyManagerUrl: env.KEY_MANAGER_URL_PUBNET || null,
+      keyManagerPollIntervalMs: Number(
+        env.KEY_MANAGER_POLL_INTERVAL_MS_PUBNET ?? env.KEY_MANAGER_POLL_INTERVAL_MS ?? 0,
+      ),
     };
   }
 

--- a/src/facilitator.js
+++ b/src/facilitator.js
@@ -1,44 +1,38 @@
 /**
  * Wires @x402/stellar's ExactStellarScheme into an x402Facilitator.
- *
- * Deliberately thin. ExactStellarScheme already implements verify and settle —
- * including auth-entry structure and credential-type checks, expiration against
- * a max ledger, facilitator-safety (the facilitator must not be party to the
- * transfer), rejection of sub-invocations, payer-signature status, and
- * simulation-event validation that exactly one transfer event matches the
- * expected sender, recipient, amount and asset.
- *
- * None of that is reimplemented here. Reimplementing it is what the RFP tells
- * respondents not to do, and it is also the part most dangerous to get subtly
- * wrong.
+ * ExactStellarScheme owns protocol verification and settlement; this module only
+ * manages the signer generations supplied to it.
  */
 import { x402Facilitator } from '@x402/core/facilitator';
 import { ExactStellarScheme } from '@x402/stellar/exact/facilitator';
 import { createEd25519Signer } from '@x402/stellar';
 import { TESTNET, PUBNET } from './config.js';
 import { signerMetrics } from './metrics.js';
+import { KeyManager } from './key-manager.js';
 
-/**
- * Builds the facilitator.
- *
- * One scheme instance per network rather than one shared across both: the
- * signer pool, fee-bump signer, RPC endpoint and fee ceiling are all
- * network-specific.
- *
- * @param {object} config - resolved config from resolveConfig()
- * @returns {{ facilitator: x402Facilitator, signers: Record<string, string[]>, feeBumpSigners: Record<string, string|null> }}
- */
+async function loadRemoteKeys(url) {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`key source returned HTTP ${response.status}`);
+  const body = await response.json();
+  return body.keys;
+}
+
 export function buildFacilitator(config) {
   const facilitator = new x402Facilitator();
   const signers = {};
   const feeBumpSigners = {};
+  const keyManagers = {};
+  const schemes = {};
 
   for (const network of config.networks) {
     const netConfig = config.perNetwork[network];
-
-    const secrets = netConfig.secrets ?? [netConfig.secret];
-    const poolSigners = secrets.map(secret => createEd25519Signer(secret, network));
-    signers[network] = poolSigners.map(s => s.address);
+    const keyManager = new KeyManager({
+      network,
+      secrets: netConfig.secrets ?? [netConfig.secret],
+      loadKeys: netConfig.keyManagerUrl ? () => loadRemoteKeys(netConfig.keyManagerUrl) : undefined,
+      pollIntervalMs: netConfig.keyManagerPollIntervalMs,
+    });
+    keyManagers[network] = keyManager;
 
     let feeBumpSigner = null;
     if (netConfig.feeBumpSecret) {
@@ -48,26 +42,43 @@ export function buildFacilitator(config) {
       feeBumpSigners[network] = null;
     }
 
-    let rrIndex = 0;
-    // Package default selection is round-robin; wrapped here to track metrics.
-    const selectSigner = signersList => {
-      const selected = signersList[rrIndex % signersList.length];
-      rrIndex = (rrIndex + 1) % signersList.length;
-      signerMetrics.recordSelection(network, selected.address);
-      return selected;
+    const createScheme = snapshot => {
+      let rrIndex = 0;
+      const signersForScheme = snapshot.entries.map(entry => entry.signer);
+      const selectSigner = addresses => {
+        const address = addresses[rrIndex % addresses.length];
+        rrIndex = (rrIndex + 1) % addresses.length;
+        signerMetrics.recordSelection(network, address);
+        return address;
+      };
+      const scheme = new ExactStellarScheme(signersForScheme, {
+        rpcConfig: netConfig.rpcUrl ? { url: netConfig.rpcUrl } : undefined,
+        maxTransactionFeeStroops: netConfig.maxTransactionFeeStroops,
+        feeBumpSigner,
+        selectSigner,
+      });
+      return { scheme };
     };
 
-    const scheme = new ExactStellarScheme(poolSigners, {
-      rpcConfig: netConfig.rpcUrl ? { url: netConfig.rpcUrl } : undefined,
-      maxTransactionFeeStroops: netConfig.maxTransactionFeeStroops,
-      feeBumpSigner,
-      selectSigner,
-    });
+    const initial = keyManager.snapshot();
+    schemes[network] = createScheme(initial);
+    signers[network] = [...keyManager.getCurrent().entries.values()].map(
+      entry => entry.signer.address,
+    );
 
-    facilitator.register(network, scheme);
+    keyManager.onRefresh = () => {
+      const next = createScheme(keyManager.snapshot());
+      schemes[network] = next;
+      signers[network] = [...keyManager.getCurrent().entries.values()].map(
+        entry => entry.signer.address,
+      );
+      facilitator.register(network, next.scheme);
+    };
+    keyManager.start();
+    facilitator.register(network, schemes[network].scheme);
   }
 
-  return { facilitator, signers, feeBumpSigners };
+  return { facilitator, signers, feeBumpSigners, keyManagers, schemes };
 }
 
 export { TESTNET, PUBNET };

--- a/src/key-manager.js
+++ b/src/key-manager.js
@@ -1,0 +1,140 @@
+import crypto from 'node:crypto';
+import { clearInterval, setInterval, setTimeout } from 'node:timers';
+import { createEd25519Signer } from '@x402/stellar';
+
+function keyId(secret) {
+  return crypto.createHash('sha256').update(secret).digest('hex').slice(0, 16);
+}
+
+function normaliseKeys(keys) {
+  if (!Array.isArray(keys) || keys.length === 0) {
+    throw new Error('Key source must return a non-empty keys array.');
+  }
+  const seen = new Set();
+  return keys.map(entry => {
+    const secret = typeof entry === 'string' ? entry : entry?.secret;
+    if (!secret || typeof secret !== 'string' || !secret.startsWith('S')) {
+      throw new Error('Key source returned an invalid Stellar secret key.');
+    }
+    const kid = typeof entry === 'string' ? keyId(secret) : entry.kid || keyId(secret);
+    if (seen.has(kid)) throw new Error(`Key source returned duplicate kid: ${kid}`);
+    seen.add(kid);
+    return { kid, secret };
+  });
+}
+
+export class KeyManager {
+  constructor({
+    network,
+    secrets,
+    loadKeys,
+    pollIntervalMs = 0,
+    createSigner = createEd25519Signer,
+  }) {
+    if (!network) throw new Error('KeyManager requires a network.');
+    this.network = network;
+    this.loadKeys = loadKeys;
+    this.createSigner = createSigner;
+    this.pollIntervalMs = pollIntervalMs;
+    this.generations = new Map();
+    this.currentGeneration = 0;
+    this.timer = null;
+    this.refreshPromise = null;
+    this.onRefresh = null;
+    this.retirementGraceMs = 60_000;
+    this._install(normaliseKeys(secrets));
+  }
+
+  _install(keys) {
+    const generation = ++this.currentGeneration;
+    const entries = new Map(
+      keys.map(({ kid, secret }) => [
+        kid,
+        { kid, secret, signer: this.createSigner(secret, this.network), leases: 0 },
+      ]),
+    );
+    this.generations.set(generation, { generation, entries, retiredAt: null });
+    for (const state of this.generations.values()) {
+      if (state.generation !== generation && !state.retiredAt) {
+        state.retiredAt = Date.now();
+        setTimeout(() => {
+          this._purgeRetired();
+        }, this.retirementGraceMs).unref?.();
+      }
+    }
+    this._purgeRetired();
+    return generation;
+  }
+
+  _purgeRetired() {
+    for (const [generation, state] of this.generations) {
+      if (
+        generation !== this.currentGeneration &&
+        state.retiredAt + this.retirementGraceMs <= Date.now() &&
+        [...state.entries.values()].every(entry => entry.leases === 0)
+      ) {
+        this.generations.delete(generation);
+      }
+    }
+  }
+
+  getCurrent() {
+    return this.generations.get(this.currentGeneration);
+  }
+
+  getActiveKeyIds() {
+    return [...this.getCurrent().entries.keys()];
+  }
+
+  snapshot() {
+    const state = this.getCurrent();
+    for (const entry of state.entries.values()) entry.leases += 1;
+    return {
+      generation: state.generation,
+      entries: [...state.entries.values()],
+      release: () => {
+        for (const entry of state.entries.values()) entry.leases = Math.max(0, entry.leases - 1);
+        this._purgeRetired();
+      },
+    };
+  }
+
+  async refresh() {
+    if (!this.loadKeys) return false;
+    if (this.refreshPromise) return this.refreshPromise;
+    this.refreshPromise = Promise.resolve()
+      .then(() => this.loadKeys())
+      .then(async keys => {
+        const next = normaliseKeys(keys);
+        const current = this.getCurrent();
+        if (
+          next.length === current.entries.size &&
+          next.every(({ kid }) => current.entries.has(kid))
+        ) {
+          return false;
+        }
+        this._install(next);
+        await this.onRefresh?.();
+        return true;
+      })
+      .finally(() => {
+        this.refreshPromise = null;
+      });
+    return this.refreshPromise;
+  }
+
+  start() {
+    if (!this.loadKeys || this.pollIntervalMs <= 0 || this.timer) return;
+    this.timer = setInterval(() => {
+      this.refresh().catch(err => console.warn(`[KeyManager] refresh failed: ${err.message}`));
+    }, this.pollIntervalMs);
+    this.timer.unref?.();
+  }
+
+  stop() {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+  }
+}
+
+export { keyId };

--- a/test/key-manager.test.js
+++ b/test/key-manager.test.js
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { KeyManager, keyId } from '../src/key-manager.js';
+
+const first = 'SAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const second = 'SBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+
+function signer(secret, network) {
+  return { address: `${network}:${secret[1]}` };
+}
+
+test('KeyManager derives stable key IDs and rotates without purging leased generations', async () => {
+  let keys = [first];
+  const manager = new KeyManager({
+    network: 'stellar:testnet',
+    secrets: keys,
+    loadKeys: async () => keys,
+    createSigner: signer,
+  });
+
+  const original = manager.snapshot();
+  assert.deepEqual(manager.getActiveKeyIds(), [keyId(first)]);
+
+  keys = [second];
+  assert.equal(await manager.refresh(), true);
+  assert.deepEqual(manager.getActiveKeyIds(), [keyId(second)]);
+  assert.equal(manager.generations.size, 2);
+
+  manager.retirementGraceMs = 0;
+  original.release();
+  assert.equal(manager.generations.size, 1);
+  assert.equal(await manager.refresh(), false);
+});
+
+test('KeyManager rejects invalid and duplicate keys', () => {
+  assert.throws(
+    () =>
+      new KeyManager({
+        network: 'stellar:testnet',
+        secrets: ['not-a-secret'],
+        createSigner: signer,
+      }),
+    /invalid Stellar secret key/,
+  );
+
+  assert.throws(
+    () =>
+      new KeyManager({
+        network: 'stellar:testnet',
+        secrets: [
+          { kid: 'same', secret: first },
+          { kid: 'same', secret: second },
+        ],
+        createSigner: signer,
+      }),
+    /duplicate kid/,
+  );
+});

--- a/test/key-rotation.test.js
+++ b/test/key-rotation.test.js
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Keypair } from '@stellar/stellar-sdk';
+import { resolveConfig } from '../src/config.js';
+import { buildFacilitator } from '../src/facilitator.js';
+
+const first = Keypair.random();
+const second = Keypair.random();
+
+test('buildFacilitator exposes independently rotatable key managers', async () => {
+  const config = resolveConfig({
+    FACILITATOR_SECRET: first.secret(),
+    KEY_MANAGER_POLL_INTERVAL_MS: '0',
+  });
+  const built = buildFacilitator(config);
+  const manager = built.keyManagers['stellar:testnet'];
+
+  assert.deepEqual(built.signers['stellar:testnet'], [first.publicKey()]);
+  assert.equal(manager.getActiveKeyIds().length, 1);
+
+  let refreshed = false;
+  manager.loadKeys = async () => [second.secret()];
+  manager.onRefresh = async () => {
+    refreshed = true;
+  };
+  assert.equal(await manager.refresh(), true);
+  assert.equal(refreshed, true);
+  assert.deepEqual(manager.getActiveKeyIds().length, 1);
+  assert.equal(
+    manager.getCurrent().entries.values().next().value.signer.address,
+    second.publicKey(),
+  );
+});


### PR DESCRIPTION
Closes #125

## Summary
- Add a provider-neutral `KeyManager` that derives stable key IDs, polls an injected/HTTP key source, and rejects invalid or duplicate keys.
- Rebuild Stellar scheme generations on rotation so new operations use the new signer set while existing scheme calls continue without a restart.
- Retain retired key generations during a grace period and expose per-network key managers for controlled operations and testing.

## Scope
Does not alter the x402 wire format or upstream verification/settlement logic; JWT `kid` tagging is not applicable because this service has no JWT layer. Vault/KMS-specific adapters and deployment credentials remain out of scope; the HTTP key source is an integration-neutral boundary.

## Testing
- `node --test test/key-manager.test.js test/key-rotation.test.js` — passed (3 tests).
- `npx eslint src/key-manager.js src/facilitator.js src/config.js test/key-manager.test.js test/key-rotation.test.js` — passed.
- `npx prettier --check src/key-manager.js src/facilitator.js src/config.js test/key-manager.test.js test/key-rotation.test.js` — passed.
- `npm run lint` — blocked by pre-existing syntax errors in `src/app.js` and `src/server.js`.
- `npm run format:check` — blocked by the pre-existing `src/server.js` syntax error and existing repository warnings.
- `npm test` — timed out before completion; existing multi-signer coverage is also blocked by the pre-existing `src/app.js` syntax error.
- `npm audit --audit-level=high` — passed.
- `node scripts/check-licenses.mjs --list` — passed.
- `npm run check:migration` — passed with six existing non-blocking warnings.
- `npm run eval` — passed.

## Files changed
- `src/key-manager.js` — hot-reloadable signer generations, key IDs, polling, and retirement.
- `src/facilitator.js` — integrates key-manager generations with Stellar schemes.
- `src/config.js` — adds optional key-source URL and polling settings.
- `test/key-manager.test.js` — manager rotation and validation coverage.
- `test/key-rotation.test.js` — facilitator integration coverage.