### PR TITLE
implemented

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,113 @@ jobs:
       # Search evaluation gate
       - run: npm run eval
 
+  # Coverage is intentionally off the critical path (continue-on-error) while
+  # we establish the baseline. Do not add a threshold until we know the real
+  # numbers — a number picked blind either does nothing or blocks everything.
+  # Node's built-in --experimental-test-coverage needs no new dependency.
+  # The lcov reporter writes coverage.lcov; the inline Node script turns it
+  # into a per-directory Markdown table posted to the job summary.
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          # Pin to 22: --experimental-test-coverage and the lcov reporter are
+          # stable enough there. The test matrix already checks Node 20.
+          node-version: '22'
+          cache: npm
+      - run: npm ci
+      - name: Run tests with coverage
+        # Two reporters in parallel: spec to stdout for readable logs, lcov to
+        # file for the summary script. Node >= 22 supports multiple
+        # --test-reporter / --test-reporter-destination pairs.
+        run: |
+          node --test \
+            --experimental-test-coverage \
+            --test-reporter=spec \
+            --test-reporter-destination=stdout \
+            --test-reporter=lcov \
+            --test-reporter-destination=coverage.lcov
+      - name: Build per-directory summary
+        # Pure Node — no lcov binary, no extra packages. Parses the lcov.info
+        # format (DA: line,hit records) and groups results into four buckets
+        # that reflect the four distinct maturity levels called out in the
+        # issue: src/ (top-level files), src/catalog/, src/mcp/, src/sdk/.
+        # An "other src/" row catches any future subdirectories automatically.
+        run: |
+          node - <<'NODE_SCRIPT'
+          import { readFileSync } from 'fs';
+          import { appendFileSync } from 'fs';
+
+          const raw = readFileSync('coverage.lcov', 'utf8');
+
+          // lcov format: SF:<path> … DA:<line>,<hit> … end_of_record
+          const buckets = {
+            'src/catalog/': { found: 0, hit: 0 },
+            'src/mcp/':     { found: 0, hit: 0 },
+            'src/sdk/':     { found: 0, hit: 0 },
+            'src/ (top-level)': { found: 0, hit: 0 },
+            'other':        { found: 0, hit: 0 },
+          };
+
+          function bucketFor(sf) {
+            if (sf.includes('src/catalog/')) return 'src/catalog/';
+            if (sf.includes('src/mcp/'))     return 'src/mcp/';
+            if (sf.includes('src/sdk/'))     return 'src/sdk/';
+            // top-level src/ files: path contains /src/ but no deeper subdir
+            if (/\/src\/[^/]+$/.test(sf))    return 'src/ (top-level)';
+            return 'other';
+          }
+
+          let currentBucket = null;
+          for (const line of raw.split('\n')) {
+            if (line.startsWith('SF:')) {
+              currentBucket = bucketFor(line.slice(3));
+            } else if (line.startsWith('DA:') && currentBucket) {
+              const [, hitStr] = line.slice(3).split(',');
+              buckets[currentBucket].found += 1;
+              if (parseInt(hitStr, 10) > 0) buckets[currentBucket].hit += 1;
+            }
+          }
+
+          const pct = (b) =>
+            b.found === 0 ? 'N/A' : ((b.hit / b.found) * 100).toFixed(1) + '%';
+
+          const total = Object.values(buckets).reduce(
+            (acc, b) => ({ found: acc.found + b.found, hit: acc.hit + b.hit }),
+            { found: 0, hit: 0 }
+          );
+
+          const rows = Object.entries(buckets)
+            .filter(([, b]) => b.found > 0)
+            .map(([name, b]) => `| \`${name}\` | ${b.hit} | ${b.found} | ${pct(b)} |`);
+
+          const md = [
+            '## Coverage by directory',
+            '',
+            '| Directory | Lines hit | Lines found | Coverage |',
+            '|-----------|----------:|------------:|----------|',
+            ...rows,
+            `| **total** | **${total.hit}** | **${total.found}** | **${pct(total)}** |`,
+            '',
+            '_Baseline — no threshold is enforced yet. File follow-ups against specific gaps._',
+          ].join('\n');
+
+          appendFileSync(process.env.GITHUB_STEP_SUMMARY, md + '\n');
+          console.log(md);
+          NODE_SCRIPT
+      - name: Upload lcov artifact
+        # Keeps the raw lcov for tools like codecov or local genhtml runs if
+        # someone later wants to drill into line-level gaps.
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: coverage.lcov
+          retention-days: 14
+
   # Issue #190: this job used to start each example with `&`, sleep, and kill
   # %1 — so a broken example still produced a green check. Now each example is
   # installed (a genuine dependency check) and then exercised by


### PR DESCRIPTION
## What changed

<!-- One or two sentences. What does this do that the tree did not do before? -->

## Why

<!-- The problem, not the patch. If it fixes an issue, link it: Closes #N -->

## How it was verified

<!-- Commands run and their result. "npm test passes" is fine; "should work" is not. -->

- [ ] `npm test`
- [ ] `npx eslint .`
- [ ] `npx prettier --check .`

## Wire format

Closes #148
Closes #150
Closes #172 
Closes #174

Does this change anything a client can observe — a route, a status code, a
field name, a reason code, or the shape of a response?

- [ ] No
- [ ] Yes, and it is described below

<!--
Conformance here is judged at the wire level: reviewers point stock SDK code at
the service rather than read a claim. A field renamed by accident is a
conformance failure that passes every local test, so it needs saying out loud.
-->

## Anything a reviewer should push back on

<!-- Shortcuts taken, assumptions made, things you were unsure about. -->
