### PR TITLE
feat: implement HPA custom metrics exporter for active verifications (#118)

### DIFF
--- a/deploy/kubernetes/active-verifications-hpa.yaml
+++ b/deploy/kubernetes/active-verifications-hpa.yaml
@@ -1,0 +1,37 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: x402-facilitator
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: x402-facilitator
+  minReplicas: 2
+  maxReplicas: 20
+  metrics:
+    - type: External
+      external:
+        metric:
+          name: active_verifications
+        target:
+          type: AverageValue
+          averageValue: '5'
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 60
+        - type: Pods
+          value: 4
+          periodSeconds: 60
+      selectPolicy: Max
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 25
+          periodSeconds: 60
+      selectPolicy: Min

--- a/deploy/kubernetes/prometheus-adapter-values.yaml
+++ b/deploy/kubernetes/prometheus-adapter-values.yaml
@@ -1,0 +1,20 @@
+# Values for prometheus-community/prometheus-adapter.
+# Install with:
+# helm upgrade --install prometheus-adapter prometheus-community/prometheus-adapter \
+#   --namespace monitoring --create-namespace \
+#   -f deploy/kubernetes/prometheus-adapter-values.yaml
+
+prometheus:
+  url: http://prometheus-operated.monitoring.svc
+  port: 9090
+
+rules:
+  default: false
+  external:
+    - seriesQuery: 'active_verifications'
+      resources:
+        namespaced: false
+      name:
+        matches: '^active_verifications$'
+        as: 'active_verifications'
+      metricsQuery: 'sum(active_verifications)'

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -134,6 +134,8 @@ A resource server debugging a failed payment hands us a single `X-Request-Id` ra
 
 Prometheus text format, unauthenticated. By default it is served on `PORT`; set `METRICS_PORT` to bind it to a separate listener (typically an internal interface) so it is not on the public surface. Series:
 
+`active_verifications` is a process-wide gauge of calls currently waiting on the upstream Stellar verification operation. It is the custom metric used by the Kubernetes HPA. Apply `deploy/kubernetes/active-verifications-hpa.yaml` and install Prometheus Adapter with `deploy/kubernetes/prometheus-adapter-values.yaml` to expose it through the Kubernetes custom metrics API.
+
 | Metric | Type | Labels | What it tells you | Alert |
 |---|---|---|---|---|
 | `x402_requests_total` | counter | `route`, `network`, `outcome`, `reason` | every request, by result | page if `outcome="error"` rate spikes (a dependency or code bug); investigate `reason` labels |
@@ -142,6 +144,7 @@ Prometheus text format, unauthenticated. By default it is served on `PORT`; set 
 | `x402_settlement_fee_stroops` | histogram | `network` | **actual fee paid** — the number that shows whether `MAX_TX_FEE_STROOPS` is sane | alert if p95 fee approaches `MAX_TX_FEE_STROOPS` (fee ceiling about to throttle settlements) |
 | `x402_rpc_retries_total` | counter | `code` | Soroban RPC connection-level retries | alert if rate > 0 for a host over several minutes (RPC degradation / IPv6 dead-ends) |
 | `x402_signer_inflight` | gauge | `network`, `signer` | in-flight settlements per signer — **the sequence-contention signal (#9)** | alert if it sits at ≥ 1 persistently or climbs (signer pool needed before bursty traffic) |
+| `active_verifications` | gauge | none | process-wide number of verification calls waiting on Stellar Horizon | HPA target is 5 average active verifications per pod |
 
 Operational endpoints (`/metrics`, `/healthz`, `/health/ready`) are logged but excluded from `x402_requests_total` so the payment counters stay semantically about payments.
 

--- a/src/app.js
+++ b/src/app.js
@@ -769,10 +769,16 @@ export async function createApp(
           }, timeoutMs);
         });
 
-        const verifyPromise = facilitator.verify(body.paymentPayload, body.paymentRequirements);
-        const result = await Promise.race([verifyPromise, timeoutPromise]).finally(() => {
-          clearTimeout(timeoutTimer);
-        });
+        metrics.incActiveVerifications();
+        let result;
+        try {
+          const verifyPromise = facilitator.verify(body.paymentPayload, body.paymentRequirements);
+          result = await Promise.race([verifyPromise, timeoutPromise]).finally(() => {
+            clearTimeout(timeoutTimer);
+          });
+        } finally {
+          metrics.decActiveVerifications();
+        }
 
         if (req.span) {
           req.span.outcome = result.isValid ? 'ok' : 'rejected';

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -14,6 +14,7 @@
  *   x402_settlement_fee_stroops histogram{network}
  *   x402_rpc_retries_total{code}
  *   x402_signer_inflight{network,signer}
+ *   active_verifications
  */
 
 const DURATION_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10];
@@ -125,6 +126,18 @@ class Gauge {
     this.series.set(key, { labels: { ...labels }, value });
   }
 
+  inc(labels = {}, value = 1) {
+    const key = labelKey(labels);
+    const current = this.series.get(key)?.value ?? 0;
+    this.set(labels, current + value);
+  }
+
+  dec(labels = {}, value = 1) {
+    const key = labelKey(labels);
+    const current = this.series.get(key)?.value ?? 0;
+    this.set(labels, Math.max(0, current - value));
+  }
+
   render() {
     let out = `# HELP ${this.name} ${this.help}\n# TYPE ${this.name} gauge\n`;
     for (const { labels, value } of this.series.values()) {
@@ -173,6 +186,12 @@ export function createMetrics() {
     'In-flight settlements per signer — the sequence-contention signal (#9).',
     ['network', 'signer'],
   );
+  const activeVerifications = new Gauge(
+    'active_verifications',
+    'Current number of in-flight verification operations.',
+    [],
+  );
+  activeVerifications.set({}, 0);
 
   return {
     incRequests: labels => requests.inc(labels),
@@ -183,9 +202,11 @@ export function createMetrics() {
     incRpcRetry: ({ code }) => rpcRetries.inc({ code: code ?? 'unknown' }),
     setSignerInflight: ({ network, signer, value }) =>
       signerInflight.set({ network, signer }, value),
+    incActiveVerifications: () => activeVerifications.inc(),
+    decActiveVerifications: () => activeVerifications.dec(),
 
     render: () =>
-      [requests, duration, settlements, fee, rpcRetries, signerInflight]
+      [requests, duration, settlements, fee, rpcRetries, signerInflight, activeVerifications]
         .map(m => m.render())
         .join(''),
   };

--- a/test/observability.test.js
+++ b/test/observability.test.js
@@ -145,6 +145,8 @@ test('GET /metrics serves valid Prometheus text with the required series', async
     );
     const text = await res.text();
 
+    assert.match(text, /active_verifications 0/);
+
     for (const name of [
       'x402_requests_total',
       'x402_request_duration_seconds',
@@ -152,9 +154,46 @@ test('GET /metrics serves valid Prometheus text with the required series', async
       'x402_settlement_fee_stroops',
       'x402_rpc_retries_total',
       'x402_signer_inflight',
+      'active_verifications',
     ]) {
       assert.ok(text.includes(`# TYPE ${name} `), `missing series ${name}`);
     }
+  } finally {
+    await app.close();
+  }
+});
+
+test('active_verifications tracks an upstream verify while it is in flight', async () => {
+  let releaseVerify;
+  let verifyStarted;
+  const verifyStartedPromise = new Promise(resolve => {
+    verifyStarted = resolve;
+  });
+  const verifyBlocked = new Promise(resolve => {
+    releaseVerify = resolve;
+  });
+  const metrics = createMetrics();
+  const app = await serve({
+    facilitator: stubFacilitator({
+      verify: async () => {
+        verifyStarted();
+        await verifyBlocked;
+        return { isValid: true };
+      },
+    }),
+    extras: {
+      logger: createRequestLog({ sink: () => {} }),
+      metrics,
+      serveMetrics: true,
+    },
+  });
+  try {
+    const request = app.post('/verify', VALID_BODY);
+    await verifyStartedPromise;
+    assert.match(metrics.render(), /active_verifications 1/);
+    releaseVerify();
+    assert.equal((await request).status, 200);
+    assert.match(metrics.render(), /active_verifications 0/);
   } finally {
     await app.close();
   }


### PR DESCRIPTION
## Summary

This PR implements the custom metrics pipeline needed to feed Kubernetes HPA based on active pending verify operations. Scaling the facilitator purely on CPU/memory is inadequate because the primary bottleneck is concurrent open connections to Stellar Horizon nodes.

**Closes #118**

---

## What Changed

### 1. Prometheus Metrics Instrumentation (`src/metrics.js`)

- Added `active_verifications` gauge to the hand-rolled Prometheus metrics registry (no external dependency)
- Exposes `incActiveVerifications()` and `decActiveVerifications()` methods
- Gauge tracks in-flight verification calls in real-time

### 2. Verify Handler Instrumentation (`src/app.js`)

- `incActiveVerifications()` called when `/verify` request starts processing
- `decActiveVerifications()` called in a `finally` block to ensure proper decrement even on timeout/error

### 3. Kubernetes HPA Manifest (`deploy/kubernetes/active-verifications-hpa.yaml`)

- Targets **5 average active verifications per pod**
- **Min replicas:** 2 | **Max replicas:** 20
- **Scale-up:** Aggressive — 100% or 4 pods per 60s (whichever is larger)
- **Scale-down:** Conservative — 25% per 60s with 300s stabilization window to prevent flapping

### 4. Prometheus Adapter Configuration (`deploy/kubernetes/prometheus-adapter-values.yaml`)

- Maps the `active_verifications` metric to the Kubernetes custom metrics API
- Series query: `active_verifications`
- Aggregation: `sum(active_verifications)` across all pods

### 5. Documentation (`docs/OPERATIONS.md`)

- Added `active_verifications` to the metrics table
- Added HPA deployment instructions referencing the new manifests
- Explains the metric's role as the custom metric for Kubernetes HPA

### 6. Tests (`test/observability.test.js`)

- **New test:** Verifies `active_verifications` tracks an upstream verify operation while it is in flight
  - Blocks the verify call mid-flight, asserts gauge = 1
  - Releases the call, asserts gauge returns to 0
- All 6 observability tests pass ✅

---

## How It Works

```
Request → /verify → incActiveVerifications() → facilitator.verify() → decActiveVerifications()
                                                                          ↑ finally block
```

Prometheus scrapes `GET /metrics` → Prometheus Adapter reads `active_verifications` → Kubernetes custom metrics API → HPA adjusts replica count.

---

## Deployment Steps

1. Apply the Prometheus Adapter:
   ```bash
   helm upgrade --install prometheus-adapter prometheus-community/prometheus-adapter \
     --namespace monitoring --create-namespace \
     -f deploy/kubernetes/prometheus-adapter-values.yaml
   ```

2. Apply the HPA:
   ```bash
   kubectl apply -f deploy/kubernetes/active-verifications-hpa.yaml
   ```

3. Verify:
   ```bash
   kubectl get hpa x402-facilitator
   kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1 | jq .
   ```

---

## Acceptance Criteria

| Criteria | Status |
|---|---|
| Prometheus metrics endpoint (`/metrics`) is exposed | ✅ |
| `active_verifications` gauge correctly tracks in-flight requests | ✅ |
| Kubernetes HPA configured to scale based on the metric | ✅ |
| Load tests showing autoscaling prevents latency degradation | ⚠️ Operational validation in deployed environment |

---

## Files Changed

- `src/metrics.js` — added `active_verifications` gauge
- `src/app.js` — instrumented `/verify` handler
- `test/observability.test.js` — added gauge lifecycle test
- `docs/OPERATIONS.md` — documented metric and HPA setup
- `deploy/kubernetes/active-verifications-hpa.yaml` — **new** HPA manifest
- `deploy/kubernetes/prometheus-adapter-values.yaml` — **new** adapter config