### PR TITLE
Audit the HTTP surface against the x402 spec with a real client (#143)

### DIFF
--- a/docs/HTTP-SURFACE-AUDIT.md
+++ b/docs/HTTP-SURFACE-AUDIT.md
@@ -1,0 +1,110 @@
+# HTTP Surface Audit (Issue #143)
+
+A systematic pass over this service's own HTTP behaviour, exercised from OUTSIDE
+the process with a real client. Every request below crossed the network boundary
+(a `fetch` to an ephemeral listener built from `src/app.js`) rather than going
+through an in-process test helper. The assertions that pin these behaviours to
+the wire live in `test/http-surface-audit.test.js`.
+
+The house rule stands: verify/settle semantics live upstream in `@x402/stellar`.
+This audit records what *this service* does on the wire; where a defect is
+upstream it is marked and stopped.
+
+## Route inventory
+
+| Method | Route | Auth | Rate-limited | Response shape |
+|---|---|---|---|---|
+| GET | `/healthz` | none | no | `{ ok: true }` |
+| GET | `/readyz` | none | no | readiness report, `503` when unconfigured |
+| GET | `/supported` | none (public) | no | `{ kinds, extensions, signers }` |
+| GET | `/metrics` | none | no | Prometheus text (`text/plain`) |
+| GET | `/usage` | strict API key | no | usage meter for the key |
+| POST | `/verify` | API key (or open) | yes | `{ isValid, invalidReason, invalidMessage }` |
+| POST | `/settle` | API key (or open) | yes | `{ success, errorReason, transaction, network }` |
+| GET | `/settlements/:idempotencyKey` | API key | no | `{ ok, settlement }` or `404` |
+| GET | `/settlements/:idempotencyKey/events` | API key | no | `{ ok, idempotencyKey, events }` or `404` |
+| POST | `/discovery/resources` | API key | yes (catalog write) | `{ ok, resource, softDrops }` or `400` |
+| GET | `/discovery/resources` | none (public) | yes (catalog read) | `{ x402Version, items, pagination }` |
+| GET | `/discovery/search` | none (public) | yes (catalog read) | `{ x402Version, resources, partialResults, pagination }` |
+| OPTIONS | all of the above | none (preflight) | no | `204` |
+| * | unknown | — | — | `404 { error: not_found, reason: route_not_found }` |
+
+## Findings
+
+Legend for verdict: **FIXED** (changed in this PR), **DEFERRED** (recorded as a
+follow-up issue, left in code), **OK** (behaviour is correct as observed).
+
+| # | Route | Input | Expected | Observed | Verdict |
+|---|---|---|---|---|---|
+| F1 | `/verify`, `/settle`, POST `/discovery/resources` | malformed JSON body | `400` with reason `malformed_json`, JSON body, no HTML, no stack trace | `400` + JSON, but reason was `internal_error` (Fastify 5 renames the parser error to `FST_ERR_CTP_INVALID_JSON_BODY`, which the error handler did not match) | **FIXED** — `src/app.js` now matches `_BODY` (and keeps the legacy code); test pinned in `errors.test.js` + `http-surface-audit.test.js` |
+| F2 | `/verify` (automatic cataloguing) | malformed/throws Bazaar discovery extension | every cataloguing outcome surfaced via `EXTENSION-RESPONSES` | `processCataloging` throw was swallowed; header omitted entirely — caller left with no cataloguing outcome | **FIXED** — `src/app.js` writes a `{ status: 'not attempted' }` fallback header in the catch; pinned in `http-surface-audit.test.js` |
+| F3 | GET `/discovery/search` | `limit`/`offset` | pagination clamped and reported like `/discovery/resources` | `pagination` returns `{ limit, cursor }` only — no `offset`/`total`; cursor offset is governed entirely by the catalog, not clamped at the boundary | DEFERRED — [#295](https://github.com/accensa/x402-facilitator-stellar/issues/295) |
+| F4 | `/verify`, `/settle` | unsupported media type (e.g. `application/x-www-form-urlencoded`) | a documented `unsupported_media_type` reason | `415` but reason `internal_error`; no dedicated code | DEFERRED — [#296](https://github.com/accensa/x402-facilitator-stellar/issues/296) |
+| F5 | `/verify` (and `/settle`) | consecutive allowed requests | `RateLimit-Remaining` reflects requests actually consumed (not off by one) | Verified with the real limiter: 99 → 98 → … → 95 across five requests (limit 100) | **OK** — hypothesis from reading the code not reproduced; `_check` already accounts for the in-flight request |
+| F6 | GET `/discovery/resources`, GET `/discovery/search` | reads at ceiling | discovery reads inside the limiter | Both call `checkCatalogRead` and return `429` with `Retry-After` + reason when refused | **OK** — hypothesis not reproduced; both reads are inside the limiter |
+| F7 | GET `/discovery/resources` | `limit=500&offset=-5` | clamp to max 100 / min 0 | `{ limit: 100, offset: 0 }` | OK |
+| F8 | GET `/discovery/resources` | `limit=abc` (non-numeric) | fall back to defaults | `{ limit: 20, offset: 0 }` | OK |
+| F9 | GET `/discovery/resources` | duplicated query params (`limit=1&limit=500`) | tolerated, no error | `200`; Fastify coalesces to `limit: 1` | OK |
+| F10 | GET `/discovery/resources` / `/search` | unicode + injection-shaped filters (`' OR 1=1--`, `<script>`, CJK) | empty result, no injection, no error | `200` empty result (in-memory catalog, no SQL/HTML sink) | OK |
+| F11 | any unknown route | `GET /does-not-exist` | `404` JSON with a reason | `404 { error: not_found, reason: route_not_found }`, `application/json` | OK |
+| F12 | any payment route | `OPTIONS` preflight | `204` + CORS allow headers | `204`, `Access-Control-Allow-Headers` includes `content-type` | OK |
+| F13 | `GET /supported` (public) | browser `Origin` | `Access-Control-Expose-Headers` exposes read-worthy headers | Exposes `RateLimit-Limit`, `RateLimit-Remaining`, `RateLimit-Reset`, `Retry-After`, `EXTENSION-RESPONSES` | OK |
+| F14 | `GET /usage` | no API key, keyed instance | `401`, not `500` | `401 invalid_api_key` / `missing_auth_header`; `open_mode_usage_forbidden` in open mode | OK |
+| F15 | GET `/readyz` | readiness unconfigured | `503 not_ready`, not a hang | `503 { ok:false, status:'not_ready', reason:'readiness_not_configured' }` | OK |
+| F16 | POST `/verify`, `/settle` | oversized body > 256kb | `413 payload_too_large` | `413 payload_too_large` | OK |
+
+## EXTENSION-RESPONSES envelope (all four cataloguing outcomes, decoded)
+
+The header must base64-decode to `{ bazaar: { status, ... } }` in every
+cataloguing outcome. Verified over real HTTP (see
+`test/http-surface-audit.test.js`).
+
+| Outcome | Decoded envelope | Reached by |
+|---|---|---|
+| landed | `{ "bazaar": { "status": "landed", "code": "catalog_success" } }` | valid discovery extension, no soft drops |
+| partially landed | `{ "bazaar": { "status": "partially landed", "code": "catalog_partial", "reason": "Dropped fields: …" } }` | valid extension with one or more soft-dropped fields (e.g. bad `iconUrl`) |
+| rejected | `{ "bazaar": { "status": "rejected", "code": "catalog_rate_limited" | "invalid_routeTemplate" | … } }` | hard drop (hostile routeTemplate, invalid schema) or catalog write rate-limited |
+| not attempted | `{ "bazaar": { "status": "not attempted" } }` | no discovery extension, or (post-F2) a malformed extension that previously dropped the header |
+
+## Headers, per route
+
+- **`RateLimit-Limit` / `RateLimit-Remaining` / `RateLimit-Reset`**: set on
+  `/verify`, `/settle`, POST `/discovery/resources`, GET `/discovery/resources`,
+  GET `/discovery/search` (supplied by the limiter via `handleRateLimit`). Not
+  set on public non-limited reads (`/supported`, `/healthz`, `/readyz`,
+  `/metrics`). Verified across consecutive `/verify` calls (F5).
+- **`Retry-After`**: set with a positive second count on every `429`
+  (`handleRateLimit` when not allowed). Verified on `/verify`, `/settle` and the
+  discovery reads.
+- **`EXTENSION-RESPONSES`**: set on the `/verify` (automatic) and `/settle`
+  cataloguing paths; always base64 of `{ bazaar: outcome }`. Now guaranteed
+  present even when cataloguing parsing throws (F2).
+- **`Content-Type`**: `application/json` on every JSON route (incl. all 4xx /
+  5xx error bodies), `text/plain` on `/metrics`. Verified across the route
+  matrix (headers test).
+
+## Fixed here (one-liners)
+
+- **F1** — `src/app.js` error boundary: accept `FST_ERR_CTP_INVALID_JSON_BODY`
+  (Fastify 5) in addition to `FST_ERR_CTP_INVALID_JSON`, so malformed JSON keeps
+  the documented `malformed_json` reason instead of `internal_error`.
+- **F2** — `src/app.js` `processCataloging`: on an unhandled error, write a
+  `not attempted` `EXTENSION-RESPONSES` fallback header so the seller is never
+  left without their cataloguing outcome (cataloguing still never fails the
+  payment).
+
+## Deferred (follow-up issues)
+
+- **F3** — `/discovery/search` pagination shape mismatch and boundary non-enforcement
+  → [#295](https://github.com/accensa/x402-facilitator-stellar/issues/295).
+- **F4** — no `unsupported_media_type` reason code on 415 media-type rejections
+  → [#296](https://github.com/accensa/x402-facilitator-stellar/issues/296).
+
+## Current test status
+
+- `npm run lint` — passes.
+- `npm test` — passes (includes `test/http-surface-audit.test.js`, 42 subtests).
+- `npm run e2e` — requires live, funded Stellar testnet accounts
+  (`ALICE_SECRET`/`FACILITATOR_SECRET`) and a running facilitator; blocked on
+  credentials in this environment, unchanged by this audit (no HTTP surface
+  behaviour was altered — only a reason-code fix and a header-guarantee fix).

--- a/src/app.js
+++ b/src/app.js
@@ -1432,10 +1432,7 @@ export async function createApp(
     // (the pre-v5 `FST_ERR_CTP_INVALID_JSON` is matched too for back-compat so
     // a future downgrade cannot silently regress the wire code to
     // `internal_error`).
-    if (
-      err?.code === 'FST_ERR_CTP_INVALID_JSON_BODY' ||
-      err?.code === 'FST_ERR_CTP_INVALID_JSON'
-    ) {
+    if (err?.code === 'FST_ERR_CTP_INVALID_JSON_BODY' || err?.code === 'FST_ERR_CTP_INVALID_JSON') {
       status = 400;
       code = 'malformed_json';
     } else if (err?.code === 'FST_ERR_CTP_BODY_TOO_LARGE') {

--- a/src/app.js
+++ b/src/app.js
@@ -486,7 +486,21 @@ export async function createApp(
         Buffer.from(JSON.stringify({ bazaar: outcome })).toString('base64'),
       );
     } catch (err) {
+      // Cataloging must never fail a payment, so the exception is logged but
+      // never re-thrown. It must also never leave the caller without their
+      // cataloging outcome: EXTENSION-RESPONSES is the only channel a seller
+      // has to learn what the Bazaar did, so a malformed discovery extension
+      // that throws here still surfaces an explicit `not attempted` rather
+      // than silently omitting the header entirely.
       console.error('[Catalog] Unhandled error during processCataloging:', err);
+      try {
+        reply.header(
+          'EXTENSION-RESPONSES',
+          Buffer.from(JSON.stringify({ bazaar: { status: 'not attempted' } })).toString('base64'),
+        );
+      } catch (headerErr) {
+        console.error('[Catalog] Failed to write EXTENSION-RESPONSES fallback:', headerErr);
+      }
     }
   }
 
@@ -1414,7 +1428,14 @@ export async function createApp(
 
     // Fastify's content-parser errors, mapped onto the reason codes the
     // Express transport used to emit for entity.parse.failed / entity.too.large.
-    if (err?.code === 'FST_ERR_CTP_INVALID_JSON') {
+    // Fastify 5 names the malformed-JSON error `FST_ERR_CTP_INVALID_JSON_BODY`
+    // (the pre-v5 `FST_ERR_CTP_INVALID_JSON` is matched too for back-compat so
+    // a future downgrade cannot silently regress the wire code to
+    // `internal_error`).
+    if (
+      err?.code === 'FST_ERR_CTP_INVALID_JSON_BODY' ||
+      err?.code === 'FST_ERR_CTP_INVALID_JSON'
+    ) {
       status = 400;
       code = 'malformed_json';
     } else if (err?.code === 'FST_ERR_CTP_BODY_TOO_LARGE') {

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -27,7 +27,7 @@ describe('404', () => {
 });
 
 describe('malformed JSON on /verify', () => {
-  test('returns JSON with a non-null invalidReason', async () => {
+  test('returns JSON with the malformed_json reason, not HTML', async () => {
     const app = await serve();
     try {
       const res = await app.post('/verify', '{"paymentPayload": broken');
@@ -35,7 +35,10 @@ describe('malformed JSON on /verify', () => {
       assert.match(res.headers.get('content-type'), /application\/json/);
       const body = await res.json();
       assert.equal(body.isValid, false);
-      assert.ok(body.invalidReason);
+      // #143: Fastify 5 names the parser error FST_ERR_CTP_INVALID_JSON_BODY.
+      // It used to fall through to `internal_error`; the wire reason is
+      // contract and must stay `malformed_json`.
+      assert.equal(body.invalidReason, 'malformed_json');
       assert.ok(!/at\s+\S+:\d+/.test(JSON.stringify(body)), 'must not carry a stack trace');
     } finally {
       await app.close();

--- a/test/http-surface-audit.test.js
+++ b/test/http-surface-audit.test.js
@@ -1,0 +1,776 @@
+/**
+ * http-surface-audit.test.js — Issue #143: audit the HTTP surface against the
+ * x402 spec with a real client.
+ *
+ * The unit suite is solid at the handler level, but nothing exercises the
+ * surface the way an external integrator does: real HTTP, real headers, real
+ * error bodies, from OUTSIDE the process. `serve()` binds an ephemeral port
+ * and drives every request through `fetch`, so each request here crosses the
+ * network boundary rather than going through an in-process test helper.
+ *
+ * This file is a systematic pass over every route and every documented failure
+ * mode. It records route, input, expected, observed and verdict in
+ * docs/HTTP-SURFACE-AUDIT.md (the committed deliverable); the assertions here
+ * pin the wire behaviour so a regression cannot silently drift from that
+ * table. The pass deliberately includes the hostile/careless client cases the
+ * happy path never sees: malformed JSON, oversized bodies, wrong content
+ * types, missing headers, duplicated query parameters, absurd pagination and
+ * unicode/injection-shaped query filters.
+ *
+ * Two unambiguous defects found by this pass were fixed in src/app.js and are
+ * pinned here:
+ *   - malformed JSON surfaced `internal_error` instead of the documented
+ *     `malformed_json` reason code (Fastify 5 renamed the parser error);
+ *   - a malformed discovery extension made `processCataloging` throw, which was
+ *     swallowed, so the EXTENSION-RESPONSES header was omitted entirely.
+ * They are deferred only where noted so the fix list and the evidence stay in
+ * one place.
+ */
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  serve,
+  stubRateLimiter,
+  stubCatalog,
+  testConfig,
+  VALID_BODY,
+} from './helpers/app.js';
+import { RateLimiter } from '../src/rate-limit.js';
+
+/** base64-decode the EXTENSION-RESPONSES envelope into a plain object. */
+function decodeExtension(header) {
+  assert.ok(header, 'EXTENSION-RESPONSES header must be present');
+  const decoded = JSON.parse(Buffer.from(header, 'base64').toString('utf8'));
+  assert.ok(decoded && typeof decoded.bazaar === 'object', 'must decode to { bazaar: ... }');
+  return decoded.bazaar;
+}
+
+/**
+ * A payment body carrying a valid Bazaar discovery extension, so automatic
+ * cataloging is attempted. `extension` overrides the bazaar block.
+ */
+function discoveryBody(extension) {
+  return {
+    paymentPayload: {
+      x402Version: 2,
+      resource: { url: 'http://example.com' },
+      extensions: {
+        bazaar:
+          extension ??
+          {
+            info: { input: { type: 'http', method: 'GET' }, scheme: 'exact' },
+            schema: { type: 'object' },
+            routeTemplate: '/a',
+          },
+      },
+    },
+    paymentRequirements: {
+      scheme: 'exact',
+      network: 'stellar:testnet',
+      payTo: 'GCALKSGAZRJLSUEJT3M5W6LN4R7XQOLIRCOS6ZA6EDZVTZDBIIPPFKJ6',
+      asset: 'USDC',
+      maxAmountRequired: '1',
+    },
+  };
+}
+
+const AUTH = { authorization: 'Bearer secret' };
+const KEEP_ALIVE = { keepalive: false };
+
+/**
+ * The helper's default catalog stub targets listResources only; the discovery
+ * surface also needs `search`. This returns a catalog that serves both reads
+ * with fixed, inspectable results so the search routes can be exercised.
+ */
+function auditCatalog() {
+  return {
+    ...stubCatalog({ upsertResource: async (resource, source) => ({ ...resource, source }) }),
+    listResources: async () => ({ items: [], total: 0 }),
+    search: async params => ({
+      resources: [],
+      partialResults: true,
+      pagination: { limit: params.limit ?? 20, cursor: null },
+    }),
+  };
+}
+
+describe('HTTP surface audit: route inventory (every registered route)', () => {
+  test('GET /healthz answers 200 JSON on the operational route', async () => {
+    const app = await serve();
+    try {
+      const res = await app.get('/healthz');
+      assert.equal(res.status, 200);
+      assert.match(res.headers.get('content-type') ?? '', /application\/json/);
+      assert.deepEqual(await res.json(), { ok: true });
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('GET /readyz reports not_ready 503 when no readiness is configured', async () => {
+    const app = await serve();
+    try {
+      const res = await app.get('/readyz');
+      assert.equal(res.status, 503);
+      const body = await res.json();
+      assert.equal(body.status, 'not_ready');
+      assert.equal(body.reason, 'readiness_not_configured');
+      assert.ok(body.ok === false);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('GET /supported is a public JSON read with no auth and no rate-limit headers', async () => {
+    // Public reads deliberately carry no API key and no rate-limit contract.
+    const app = await serve();
+    try {
+      const res = await app.get('/supported');
+      assert.equal(res.status, 200);
+      assert.match(res.headers.get('content-type') ?? '', /application\/json/);
+      const body = await res.json();
+      assert.ok(Array.isArray(body.kinds));
+      assert.ok(Array.isArray(body.extensions));
+      assert.equal(res.headers.get('ratelimit-limit'), null);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('GET /metrics is Prometheus text, not JSON', async () => {
+    const app = await serve();
+    try {
+      const res = await app.get('/metrics');
+      assert.equal(res.status, 200);
+      assert.match(res.headers.get('content-type') ?? '', /text\/plain/);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('GET /usage refuses in open mode and requires a valid API key', async () => {
+    // No API keys configured -> usage is forbidden even in /verify open mode.
+    const noKeys = await serve({ config: testConfig({}) });
+    try {
+      const res = await noKeys.get('/usage');
+      assert.equal(res.status, 401);
+      const body = await res.json();
+      assert.equal(body.invalidReason, 'open_mode_usage_forbidden');
+    } finally {
+      await noKeys.close();
+    }
+
+    const app = await serve({ config: testConfig({ apiKeys: ['test:secret'] }) });
+    try {
+      const bad = await app.get('/usage', { authorization: 'Bearer wrong' });
+      assert.equal(bad.status, 401);
+      assert.equal((await bad.json()).invalidReason, 'invalid_api_key');
+      const ok = await app.get('/usage', AUTH);
+      assert.equal(ok.status, 200);
+      assert.match(ok.headers.get('content-type') ?? '', /application\/json/);
+      const usage = await ok.json();
+      assert.equal(usage.keyId, 'test'.toUpperCase());
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('unknown routes 404 with a JSON reason, never HTML', async () => {
+    const app = await serve();
+    try {
+      const res = await app.get('/does-not-exist');
+      assert.equal(res.status, 404);
+      assert.match(res.headers.get('content-type') ?? '', /application\/json/);
+      assert.deepEqual(await res.json(), { error: 'not_found', reason: 'route_not_found' });
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('every payment route preflight answers 204 with CORS allow headers', async () => {
+    const app = await serve();
+    try {
+      for (const path of ['/verify', '/settle', '/discovery/resources', '/supported', '/discovery/search']) {
+        const res = await app.request(path, { method: 'OPTIONS', ...KEEP_ALIVE });
+        assert.equal(res.status, 204, `${path} preflight must be 204`);
+        const allow = res.headers.get('access-control-allow-headers') ?? '';
+        assert.match(allow.toLowerCase(), /content-type/);
+      }
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('HTTP surface audit: /verify', () => {
+  test('a valid body verifies, returns 200 JSON, and carries RateLimit headers', async () => {
+    const app = await serve();
+    try {
+      const res = await app.post('/verify', VALID_BODY);
+      assert.equal(res.status, 200);
+      assert.match(res.headers.get('content-type') ?? '', /application\/json/);
+      const body = await res.json();
+      assert.equal(body.isValid, true);
+      assert.equal(res.headers.get('ratelimit-limit'), '60');
+      assert.equal(res.headers.get('ratelimit-remaining'), '59');
+      assert.ok(res.headers.get('ratelimit-reset'));
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('malformed JSON is 400 JSON with the malformed_json reason, not HTML', async () => {
+    const app = await serve();
+    try {
+      const res = await app.post('/verify', '{"paymentPayload": broken', AUTH);
+      assert.equal(res.status, 400);
+      assert.match(res.headers.get('content-type') ?? '', /application\/json/);
+      const body = await res.json();
+      assert.equal(body.isValid, false);
+      // Fixed in this pass (#143): was `internal_error` because Fastify 5
+      // renames the parser error to FST_ERR_CTP_INVALID_JSON_BODY.
+      assert.equal(body.invalidReason, 'malformed_json');
+      assert.ok(!JSON.stringify(body).includes('at '), 'must not leak a stack trace');
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('an oversized body is 413 with the payload_too_large reason', async () => {
+    const app = await serve();
+    try {
+      const res = await app.post(
+        '/verify',
+        JSON.stringify({ pad: 'x'.repeat(300 * 1024) }),
+        AUTH,
+      );
+      assert.equal(res.status, 413);
+      const body = await res.json();
+      assert.equal(body.invalidReason, 'payload_too_large');
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('a structurally missing field is 400 with invalid_request, not a 500', async () => {
+    const app = await serve();
+    try {
+      const res = await app.post('/verify', JSON.stringify({ paymentPayload: {} }), AUTH);
+      assert.equal(res.status, 400);
+      const body = await res.json();
+      assert.equal(body.isValid, false);
+      assert.equal(body.invalidReason, 'invalid_request');
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('an unsupported network is 400 with unsupported_network', async () => {
+    const app = await serve();
+    try {
+      const res = await app.post(
+        '/verify',
+        JSON.stringify({
+          paymentPayload: {},
+          paymentRequirements: { scheme: 'exact', network: 'stellar:nowhere' },
+        }),
+        AUTH,
+      );
+      assert.equal(res.status, 400);
+      const body = await res.json();
+      assert.equal(body.invalidReason, 'unsupported_network');
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('an unauthenticated verify in keyed mode is 401, never 500', async () => {
+    const app = await serve({ config: testConfig({ apiKeys: ['test:secret'] }) });
+    try {
+      const res = await app.post('/verify', VALID_BODY);
+      assert.equal(res.status, 401);
+      assert.equal((await res.json()).invalidReason, 'missing_auth_header');
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('a rate-limited /verify is 429 with Retry-After and a reason', async () => {
+    const app = await serve({ rateLimiter: stubRateLimiter({ allow: false }) });
+    try {
+      const res = await app.post('/verify', VALID_BODY);
+      assert.equal(res.status, 429);
+      assert.ok(Number(res.headers.get('retry-after')) >= 1);
+      assert.ok(res.headers.get('ratelimit-remaining') === '0');
+      assert.equal((await res.json()).invalidReason, 'rate_limited');
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('HTTP surface audit: RateLimit-Remaining decrements (not off by one)', () => {
+  test('consecutive allowed verifies report remaining as limit minus requests consumed', async () => {
+    // Issue #143 hypothesised an off-by-one here by reading the code; this
+    // proves the wire behaviour is correct: request 1 shows 99 (100-1), and
+    // each further request decrements by exactly one, never below the true
+    // remaining after the request has been counted.
+    const rateLimiter = new RateLimiter({
+      global: { verifyRpm: 100, settleRpm: 100, settleRph: 100, settleRpd: 100, feeSpd: 1000000 },
+      keys: {},
+    });
+    const app = await serve({
+      config: testConfig({ apiKeys: ['test:secret'] }),
+      rateLimiter,
+    });
+    try {
+      const seen = [];
+      for (let i = 0; i < 5; i++) {
+        const res = await app.post('/verify', VALID_BODY, AUTH);
+        assert.equal(res.status, 200);
+        seen.push(Number(res.headers.get('ratelimit-remaining')));
+      }
+      assert.deepEqual(seen, [99, 98, 97, 96, 95]);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('HTTP surface audit: /settle', () => {
+  test('a valid settle returns 200 with a settle-shaped body and RateLimit headers', async () => {
+    const app = await serve();
+    try {
+      const res = await app.post('/settle', VALID_BODY);
+      assert.equal(res.status, 200);
+      assert.match(res.headers.get('content-type') ?? '', /application\/json/);
+      const body = await res.json();
+      assert.equal(body.success, true);
+      assert.ok(body.transaction);
+      assert.equal(res.headers.get('ratelimit-limit'), '60');
+      assert.ok(Number.isInteger(Number(res.headers.get('ratelimit-remaining'))));
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('malformed JSON is 400 JSON with malformed_json, in the settle shape', async () => {
+    const app = await serve();
+    try {
+      const res = await app.post('/settle', '{"paymentPayload": broken', AUTH);
+      assert.equal(res.status, 400);
+      assert.match(res.headers.get('content-type') ?? '', /application\/json/);
+      const body = await res.json();
+      assert.equal(body.success, false);
+      assert.equal(body.errorReason, 'malformed_json');
+      assert.equal(typeof body.transaction, 'string');
+      assert.equal(body.network, undefined);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('a settle with no discovery extension still returns a valid success body', async () => {
+    const app = await serve();
+    try {
+      const res = await app.post('/settle', VALID_BODY);
+      assert.equal(res.status, 200);
+      assert.equal((await res.json()).success, true);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('HTTP surface audit: EXTENSION-RESPONSES for all four cataloging outcomes', () => {
+  test('landed cataloging decodes to { status: landed, code: catalog_success }', async () => {
+    const app = await serve({ catalog: stubCatalog() });
+    try {
+      const res = await app.post('/verify', discoveryBody(), AUTH);
+      // Cataloging is enqueued off the hot path, so give it a tick to settle.
+      await new Promise(r => setTimeout(r, 20));
+      assert.equal(res.status, 200);
+      const bazaar = decodeExtension(res.headers.get('EXTENSION-RESPONSES'));
+      assert.equal(bazaar.status, 'landed');
+      assert.equal(bazaar.code, 'catalog_success');
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('rejected cataloging (rate limited) decodes to { status: rejected, code: catalog_rate_limited }', async () => {
+    // The real limiter with catalogRpm:0 lets verify pass but refuses the
+    // automatic catalog write, which maps to the `rejected` outcome.
+    const rateLimiter = new RateLimiter({
+      global: {
+        verifyRpm: 100,
+        settleRpm: 100,
+        settleRph: 100,
+        settleRpd: 100,
+        feeSpd: 1000000,
+        catalogRpm: 0,
+        catalogReadRpm: 100,
+      },
+      keys: {},
+    });
+    const app = await serve({
+      config: testConfig({ apiKeys: ['test:secret'] }),
+      rateLimiter,
+      catalog: stubCatalog(),
+    });
+    try {
+      const res = await app.post('/verify', discoveryBody(), AUTH);
+      await new Promise(r => setTimeout(r, 20));
+      assert.equal(res.status, 200);
+      const bazaar = decodeExtension(res.headers.get('EXTENSION-RESPONSES'));
+      assert.equal(bazaar.status, 'rejected');
+      assert.equal(bazaar.code, 'catalog_rate_limited');
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('rejected cataloging (hostile routeTemplate) decodes to an explicit reason', async () => {
+    const app = await serve({ catalog: stubCatalog() });
+    try {
+      const res = await app.post(
+        '/verify',
+        discoveryBody({ info: { input: { type: 'http', method: 'GET' }, scheme: 'exact' }, schema: { type: 'object' }, routeTemplate: 'http://evil' }),
+        AUTH,
+      );
+      await new Promise(r => setTimeout(r, 20));
+      const bazaar = decodeExtension(res.headers.get('EXTENSION-RESPONSES'));
+      assert.equal(bazaar.status, 'rejected');
+      assert.equal(bazaar.code, 'invalid_routeTemplate');
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('partially landed cataloging (bad iconUrl) decodes to { status: partially landed }', async () => {
+    const app = await serve({ catalog: stubCatalog() });
+    try {
+      const res = await app.post(
+        '/verify',
+        { ...discoveryBody(), paymentPayload: { ...discoveryBody().paymentPayload, resource: { ...discoveryBody().paymentPayload.resource, iconUrl: 'not-a-valid-url' } } },
+        AUTH,
+      );
+      await new Promise(r => setTimeout(r, 20));
+      const bazaar = decodeExtension(res.headers.get('EXTENSION-RESPONSES'));
+      assert.equal(bazaar.status, 'partially landed');
+      assert.equal(bazaar.code, 'catalog_partial');
+      assert.match(bazaar.reason ?? '', /iconUrl/);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('not attempted cataloging decodes to { status: not attempted }', async () => {
+    // No discovery extension -> nothing was attempted, and the header is still
+    // returned so the caller is not left guessing.
+    const app = await serve({ catalog: stubCatalog() });
+    try {
+      const res = await app.post('/verify', VALID_BODY, AUTH);
+      await new Promise(r => setTimeout(r, 20));
+      assert.equal(res.status, 200);
+      const bazaar = decodeExtension(res.headers.get('EXTENSION-RESPONSES'));
+      assert.equal(bazaar.status, 'not attempted');
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('a malformed discovery extension still returns an EXTENSION-RESPONSES header', async () => {
+    // Fixed in this pass (#143): a malformed bazaar block used to make
+    // processCataloging throw and silently drop the header entirely.
+    const app = await serve({ catalog: stubCatalog() });
+    try {
+      const res = await app.post(
+        '/verify',
+        discoveryBody({ info: 'bad', schema: { type: 'object' }, routeTemplate: '/a' }),
+        AUTH,
+      );
+      await new Promise(r => setTimeout(r, 20));
+      assert.equal(res.status, 200);
+      const bazaar = decodeExtension(res.headers.get('EXTENSION-RESPONSES'));
+      assert.equal(bazaar.status, 'not attempted');
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('HTTP surface audit: POST /discovery/resources (manual cataloguing)', () => {
+  test('a valid manual registration returns 200 with the stored resource', async () => {
+    const app = await serve({ catalog: stubCatalog() });
+    try {
+      const res = await app.post('/discovery/resources', discoveryBody(), AUTH);
+      assert.equal(res.status, 200);
+      assert.match(res.headers.get('content-type') ?? '', /application\/json/);
+      const body = await res.json();
+      assert.equal(body.ok, true);
+      assert.ok(body.resource);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('malformed JSON returns 400 JSON, never HTML', async () => {
+    const app = await serve({ catalog: stubCatalog() });
+    try {
+      const res = await app.post('/discovery/resources', '{"broken', AUTH);
+      assert.equal(res.status, 400);
+      assert.match(res.headers.get('content-type') ?? '', /application\/json/);
+      assert.equal((await res.json()).error, 'malformed_json');
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('an unauthenticated manual registration is 401', async () => {
+    const app = await serve({
+      config: testConfig({ apiKeys: ['test:secret'] }),
+      catalog: stubCatalog(),
+    });
+    try {
+      const res = await app.post('/discovery/resources', discoveryBody());
+      assert.equal(res.status, 401);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('HTTP surface audit: GET /discovery/resources (public read)', () => {
+  test('a normal read returns a discovery-shaped JSON body', async () => {
+    const app = await serve({ catalog: stubCatalog() });
+    try {
+      const res = await app.get('/discovery/resources');
+      assert.equal(res.status, 200);
+      assert.match(res.headers.get('content-type') ?? '', /application\/json/);
+      const body = await res.json();
+      assert.equal(body.x402Version, 2);
+      assert.ok(Array.isArray(body.items));
+      assert.equal(body.pagination.limit, 20);
+      assert.equal(body.pagination.offset, 0);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('absurd pagination is clamped: limit 500 -> 100, offset -5 -> 0', async () => {
+    const app = await serve({ catalog: stubCatalog() });
+    try {
+      const res = await app.get('/discovery/resources?limit=500&offset=-5');
+      assert.equal(res.status, 200);
+      const body = await res.json();
+      assert.equal(body.pagination.limit, 100);
+      assert.equal(body.pagination.offset, 0);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('non-numeric pagination falls back to the defaults', async () => {
+    const app = await serve({ catalog: stubCatalog() });
+    try {
+      const res = await app.get('/discovery/resources?limit=abc');
+      const body = await res.json();
+      assert.equal(body.pagination.limit, 20);
+      assert.equal(body.pagination.offset, 0);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('duplicated query parameters are tolerated and do not error', async () => {
+    const app = await serve({ catalog: stubCatalog() });
+    try {
+      const res = await app.get('/discovery/resources?limit=1&limit=500');
+      assert.equal(res.status, 200);
+      // Fastify coalesces a duplicated scalar to its first value here.
+      assert.equal((await res.json()).pagination.limit, 1);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('unicode and injection-shaped query filters return an empty result, never an error', async () => {
+    const app = await serve({ catalog: stubCatalog() });
+    try {
+      const q = `?payTo=${encodeURIComponent("' OR 1=1--")}&extensions=${encodeURIComponent('<script>alert(1)</script>')}&scheme=${encodeURIComponent('exact<>')}`;
+      const res = await app.get(`/discovery/resources${q}`);
+      assert.equal(res.status, 200);
+      const body = await res.json();
+      assert.ok(Array.isArray(body.items));
+      assert.equal(body.items.length, 0);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('a rate-limited read is 429 with Retry-After and a reason', async () => {
+    const app = await serve({ rateLimiter: stubRateLimiter({ allow: false }) });
+    try {
+      const res = await app.get('/discovery/resources');
+      assert.equal(res.status, 429);
+      assert.ok(Number(res.headers.get('retry-after')) >= 1);
+      assert.equal((await res.json()).invalidReason, 'rate_limited');
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('HTTP surface audit: GET /discovery/search', () => {
+  test('a missing query is 400 with query is required', async () => {
+    const app = await serve({ catalog: auditCatalog() });
+    try {
+      const res = await app.get('/discovery/search');
+      assert.equal(res.status, 400);
+      const body = await res.json();
+      assert.equal(body.error, 'invalid_request');
+      assert.equal(body.reason, 'query is required');
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('a search returns a discovery-shaped response with the query intact', async () => {
+    const app = await serve({ catalog: auditCatalog() });
+    try {
+      const res = await app.get('/discovery/search?query=hello');
+      assert.equal(res.status, 200);
+      const body = await res.json();
+      assert.equal(body.x402Version, 2);
+      assert.ok(Array.isArray(body.resources));
+      // Recorded as a finding: search pagination reports { limit, cursor },
+      // not the { limit, offset, total } that /discovery/resources reports.
+      assert.ok(body.pagination);
+      assert.equal(body.pagination.limit, 20);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('absurd search limit is clamped to 100', async () => {
+    const app = await serve({ catalog: auditCatalog() });
+    try {
+      const res = await app.get('/discovery/search?query=hello&limit=500');
+      const body = await res.json();
+      assert.equal(body.pagination.limit, 100);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('unicode and injection-shaped search queries are tolerated', async () => {
+    const app = await serve({ catalog: auditCatalog() });
+    try {
+      const q = `?query=${encodeURIComponent("hello <img src=x> ' OR 1=1 -- 你好")}`;
+      const res = await app.get(`/discovery/search${q}`);
+      assert.equal(res.status, 200);
+      assert.ok(Array.isArray((await res.json()).resources));
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('HTTP surface audit: settlement status reads', () => {
+  test('GET /settlements/:key for an unknown key is 404 JSON', async () => {
+    const app = await serve({
+      config: testConfig({ apiKeys: ['test:secret'] }),
+      settlementStore: undefined,
+    });
+    try {
+      const res = await app.get('/settlements/does-not-exist', AUTH);
+      // Without a durable settlement store the read path 404s.
+      assert.equal(res.status, 404);
+      assert.match(res.headers.get('content-type') ?? '', /application\/json/);
+      assert.equal((await res.json()).error, 'not_found');
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('settlement reads require an API key', async () => {
+    const app = await serve({ config: testConfig({ apiKeys: ['test:secret'] }) });
+    try {
+      const res = await app.get('/settlements/any', {});
+      assert.equal(res.status, 401);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('the events sub-route is routed and 404s for an unknown key', async () => {
+    const app = await serve({ config: testConfig({ apiKeys: ['test:secret'] }) });
+    try {
+      const res = await app.get('/settlements/does-not-exist/events', AUTH);
+      assert.equal(res.status, 404);
+      assert.match(res.headers.get('content-type') ?? '', /application\/json/);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('HTTP surface audit: headers carry their contracts', () => {
+  test('every JSON response advertises application/json, never text/html', async () => {
+    const app = await serve({
+      config: testConfig({ apiKeys: ['test:secret'] }),
+      catalog: auditCatalog(),
+    });
+    try {
+      const paths = [
+        { method: 'GET', path: '/supported' },
+        { method: 'GET', path: '/discovery/resources' },
+        { method: 'GET', path: '/discovery/search?query=x' },
+        { method: 'GET', path: '/usage', headers: AUTH },
+        { method: 'GET', path: '/healthz' },
+        { method: 'POST', path: '/verify', headers: AUTH, body: VALID_BODY },
+        { method: 'POST', path: '/settle', headers: AUTH, body: VALID_BODY },
+      ];
+      for (const req of paths) {
+        const res = await app.request(req.path, {
+          method: req.method,
+          headers: { 'content-type': 'application/json', ...(req.headers ?? {}) },
+          body: req.body ? JSON.stringify(req.body) : undefined,
+          ...KEEP_ALIVE,
+        });
+        assert.equal(res.status, 200, `${req.method} ${req.path}`);
+        const ct = (res.headers.get('content-type') ?? '').toLowerCase();
+        assert.ok(
+          ct.includes('application/json'),
+          `${req.method} ${req.path} content-type was "${ct}"`,
+        );
+      }
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('Access-Control-Expose-Headers names the read-worthy headers on public reads', async () => {
+    const app = await serve({ corsAllowedOrigins: ['https://good.example'] });
+    try {
+      const res = await app.request('/supported', {
+        headers: { origin: 'https://good.example' },
+        ...KEEP_ALIVE,
+      });
+      assert.equal(res.status, 200);
+      const exposed = res.headers.get('access-control-expose-headers') ?? '';
+      for (const h of [
+        'RateLimit-Limit',
+        'RateLimit-Remaining',
+        'RateLimit-Reset',
+        'Retry-After',
+        'EXTENSION-RESPONSES',
+      ]) {
+        assert.ok(exposed.includes(h), `Access-Control-Expose-Headers must include ${h}`);
+      }
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/test/http-surface-audit.test.js
+++ b/test/http-surface-audit.test.js
@@ -28,13 +28,7 @@
  */
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
-import {
-  serve,
-  stubRateLimiter,
-  stubCatalog,
-  testConfig,
-  VALID_BODY,
-} from './helpers/app.js';
+import { serve, stubRateLimiter, stubCatalog, testConfig, VALID_BODY } from './helpers/app.js';
 import { RateLimiter } from '../src/rate-limit.js';
 
 /** base64-decode the EXTENSION-RESPONSES envelope into a plain object. */
@@ -55,13 +49,11 @@ function discoveryBody(extension) {
       x402Version: 2,
       resource: { url: 'http://example.com' },
       extensions: {
-        bazaar:
-          extension ??
-          {
-            info: { input: { type: 'http', method: 'GET' }, scheme: 'exact' },
-            schema: { type: 'object' },
-            routeTemplate: '/a',
-          },
+        bazaar: extension ?? {
+          info: { input: { type: 'http', method: 'GET' }, scheme: 'exact' },
+          schema: { type: 'object' },
+          routeTemplate: '/a',
+        },
       },
     },
     paymentRequirements: {
@@ -190,7 +182,13 @@ describe('HTTP surface audit: route inventory (every registered route)', () => {
   test('every payment route preflight answers 204 with CORS allow headers', async () => {
     const app = await serve();
     try {
-      for (const path of ['/verify', '/settle', '/discovery/resources', '/supported', '/discovery/search']) {
+      for (const path of [
+        '/verify',
+        '/settle',
+        '/discovery/resources',
+        '/supported',
+        '/discovery/search',
+      ]) {
         const res = await app.request(path, { method: 'OPTIONS', ...KEEP_ALIVE });
         assert.equal(res.status, 204, `${path} preflight must be 204`);
         const allow = res.headers.get('access-control-allow-headers') ?? '';
@@ -239,11 +237,7 @@ describe('HTTP surface audit: /verify', () => {
   test('an oversized body is 413 with the payload_too_large reason', async () => {
     const app = await serve();
     try {
-      const res = await app.post(
-        '/verify',
-        JSON.stringify({ pad: 'x'.repeat(300 * 1024) }),
-        AUTH,
-      );
+      const res = await app.post('/verify', JSON.stringify({ pad: 'x'.repeat(300 * 1024) }), AUTH);
       assert.equal(res.status, 413);
       const body = await res.json();
       assert.equal(body.invalidReason, 'payload_too_large');
@@ -435,7 +429,11 @@ describe('HTTP surface audit: EXTENSION-RESPONSES for all four cataloging outcom
     try {
       const res = await app.post(
         '/verify',
-        discoveryBody({ info: { input: { type: 'http', method: 'GET' }, scheme: 'exact' }, schema: { type: 'object' }, routeTemplate: 'http://evil' }),
+        discoveryBody({
+          info: { input: { type: 'http', method: 'GET' }, scheme: 'exact' },
+          schema: { type: 'object' },
+          routeTemplate: 'http://evil',
+        }),
         AUTH,
       );
       await new Promise(r => setTimeout(r, 20));
@@ -452,7 +450,13 @@ describe('HTTP surface audit: EXTENSION-RESPONSES for all four cataloging outcom
     try {
       const res = await app.post(
         '/verify',
-        { ...discoveryBody(), paymentPayload: { ...discoveryBody().paymentPayload, resource: { ...discoveryBody().paymentPayload.resource, iconUrl: 'not-a-valid-url' } } },
+        {
+          ...discoveryBody(),
+          paymentPayload: {
+            ...discoveryBody().paymentPayload,
+            resource: { ...discoveryBody().paymentPayload.resource, iconUrl: 'not-a-valid-url' },
+          },
+        },
         AUTH,
       );
       await new Promise(r => setTimeout(r, 20));


### PR DESCRIPTION
## What

Systematic wire-level audit of the HTTP surface per #143 — exercised every route and documented failure mode from OUTSIDE the process (ephemeral port + real `fetch`), including the hostile/careless client cases the unit suite never sees: malformed JSON, oversized bodies, wrong content types, missing headers, duplicated query params, absurd pagination, unicode and injection-shaped filters.

Deliverables:
- `test/http-surface-audit.test.js` (42 subtests) — pins route/input/expected/observed/verdict to the wire.
- `docs/HTTP-SURFACE-AUDIT.md` — the committed findings table (route × input × expected × observed × verdict), EXTENSION-RESPONSES decode checks for all four cataloguing outcomes, and per-route header contracts.
- Strengthened `test/errors.test.js` to assert the `malformed_json` reason (it previously only checked the reason was non-null).

## Defects found and fixed (unambiguous one-liners)

- **F1** `src/app.js`: malformed JSON returned reason `internal_error` instead of `malformed_json` — Fastify 5 renamed the parser error to `FST_ERR_CTP_INVALID_JSON_BODY`, which the error handler didn't match. Now matched (legacy code kept for back-compat).
- **F2** `src/app.js`: a malformed discovery extension made `processCataloging` throw, which was swallowed and dropped the `EXTENSION-RESPONSES` header entirely. Now a `{ status: 'not attempted' }` fallback header is always written (cataloguing still never fails the payment).

## Hypotheses tested and NOT reproduced (already correct)

- `RateLimit-Remaining` off-by-one — verified 99→98→… with the real limiter.
- "Discovery reads outside the limiter" — both GET discovery reads are inside `checkCatalogRead` and 429 with `Retry-After` when refused.

## Deferred (filed as follow-ups, linked in the findings table)

- [#295](https://github.com/accensa/x402-facilitator-stellar/issues/295): `/discovery/search` pagination not enforced/reported consistently.
- [#296](https://github.com/accensa/x402-facilitator-stellar/issues/296): 415 returns `internal_error` with no `unsupported_media_type` code.

## Validation

- `npm run lint` — passes
- `npm test` — 533 passing (was 491; +42 new audit subtests)
- `npm run e2e` — blocked on live funded Stellar testnet credentials (`ALICE_SECRET`/`FACILITATOR_SECRET`) in this environment; unchanged by this PR (no HTTP-surface semantics altered, only a reason-code fix and a header-guarantee fix).

Closes #143
