### PR TITLE
fix: emit RateLimit-* headers from post-record state

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -593,6 +593,16 @@ export async function createApp(
   }
 
   /**
+   * Prefer the limiter state returned by a record call (which reflects the
+   * current request already being counted) for the RateLimit-* headers, falling
+   * back to the pre-record check if a limiter library does not return state.
+   */
+  function applyRateLimitHead(reply, recorded, check) {
+    if (recorded && Number.isFinite(recorded.remaining)) return handleRateLimit(reply, recorded);
+    return handleRateLimit(reply, check);
+  }
+
+  /**
    * Both /verify and /settle take {paymentPayload, paymentRequirements}.
    * Returning a non-null reason on a malformed body matters as much as on a
    * failed verification — a null reason anywhere is an acceptance failure.
@@ -757,8 +767,8 @@ export async function createApp(
         req.span.scheme = body.paymentRequirements.scheme;
       }
       try {
-        await rateLimiter.recordVerify(req);
-        handleRateLimit(reply, check);
+        const recorded = await rateLimiter.recordVerify(req);
+        applyRateLimitHead(reply, recorded, check);
         const timeoutMs = config.requestTimeoutMs ?? 30_000;
         let timeoutTimer;
         const timeoutPromise = new Promise((_, reject) => {
@@ -966,7 +976,7 @@ export async function createApp(
               : 0;
             // The metrics/audit record the fee actually paid by this settlement.
             const actualFee = result.success ? result.transactionFeeStroops || 0 : 0;
-            await rateLimiter.recordSettle(req, sponsoredFee);
+            const recorded = await rateLimiter.recordSettle(req, sponsoredFee);
             if (req.span) {
               req.span.settleOutcome = result.success ? 'settled' : 'failed';
               req.span.outcome = result.success ? 'ok' : 'rejected';
@@ -976,7 +986,7 @@ export async function createApp(
               req.span.txHash = result.transaction || null;
               req.span.feeStroops = actualFee;
             }
-            handleRateLimit(reply, check);
+            applyRateLimitHead(reply, recorded, check);
             if (result.success) {
               // Settlement notification (#123): the event is written to the
               // outbox in the SAME database transaction as the 'settled' state

--- a/src/rate-limit.js
+++ b/src/rate-limit.js
@@ -135,9 +135,36 @@ export class RateLimiter {
     return res;
   }
 
+  /**
+   * Given a post-increment bucket, derive the remaining allowance after the
+   * current request was counted. Counts are asserted finite: a lost/failed
+   * record (the transport degrades open on store failure) is treated as one
+   * consumed so the advertised remaining is never above the true headroom.
+   */
+  _postRecordRemaining(limit, bucket) {
+    const count = Number.isFinite(bucket?.count) ? bucket.count : 1;
+    return Math.max(0, limit - count);
+  }
+
+  /**
+   * Records this verify and returns the limiter state AFTER the request was
+   * counted, so the transport can advertise a remaining value that reflects
+   * what the caller truly has left (issue #141): `recordVerify` post-dates the
+   * `checkVerify` whose `remaining` is only a projection until this runs.
+   *
+   * @returns {{allowed: true, limit: number, remaining: number, resetAt: number}}
+   */
   async recordVerify(req) {
     const ownerId = req.keyId || req.ip;
-    await this._increment(ownerId, 'verify', 60, 1);
+    const limits = this._getKeyConfig(req.keyId);
+    const bucket = await this._increment(ownerId, 'verify', 60, 1);
+    const limit = limits.verifyRpm;
+    return {
+      allowed: true,
+      limit,
+      remaining: this._postRecordRemaining(limit, bucket),
+      resetAt: bucket?.resetAt,
+    };
   }
 
   async checkSettle(req, network = null) {
@@ -171,14 +198,40 @@ export class RateLimiter {
     );
   }
 
+  /**
+   * Records this settlement and returns the limiter state AFTER the request was
+   * counted (issue #141): the tightest remaining allowance across the per-minute,
+   * per-hour and per-day buckets, advertised as RateLimit-* so it reflects what
+   * the caller truly has left rather than the pre-record projection.
+   *
+   * @returns {{allowed: true, limit: number, remaining: number, resetAt: number}}
+   */
   async recordSettle(req, feeCharged) {
     const ownerId = req.keyId || req.ip;
-    await this._increment(ownerId, 'settle', 60, 1);
-    await this._increment(ownerId, 'settle', 3600, 1);
-    await this._increment(ownerId, 'settle', 86400, 1);
+    const limits = this._getKeyConfig(req.keyId);
+    const b60 = await this._increment(ownerId, 'settle', 60, 1);
+    const b3600 = await this._increment(ownerId, 'settle', 3600, 1);
+    const b86400 = await this._increment(ownerId, 'settle', 86400, 1);
     if (feeCharged > 0) {
       await this._increment(ownerId, 'fee', 86400, feeCharged);
     }
+    const tightest = [
+      { limit: limits.settleRpm, remaining: this._postRecordRemaining(limits.settleRpm, b60) },
+      {
+        limit: limits.settleRph,
+        remaining: this._postRecordRemaining(limits.settleRph, b3600),
+      },
+      {
+        limit: limits.settleRpd,
+        remaining: this._postRecordRemaining(limits.settleRpd, b86400),
+      },
+    ].sort((a, b) => a.remaining - b.remaining)[0];
+    return {
+      allowed: true,
+      limit: tightest.limit,
+      remaining: tightest.remaining,
+      resetAt: b60?.resetAt,
+    };
   }
 
   /**

--- a/src/redis-rate-limit.js
+++ b/src/redis-rate-limit.js
@@ -117,7 +117,15 @@ export class RedisRateLimiter extends RateLimiter {
 
   async recordVerify(req) {
     const ownerId = req.keyId || req.ip;
-    await this._incrementAsync(ownerId, 'verify', 60, 1);
+    const limits = this._getKeyConfig(req.keyId);
+    const bucket = await this._incrementAsync(ownerId, 'verify', 60, 1);
+    const limit = limits.verifyRpm;
+    return {
+      allowed: true,
+      limit,
+      remaining: this._postRecordRemaining(limit, bucket),
+      resetAt: bucket?.resetAt,
+    };
   }
 
   async checkSettle(req, _network = null) {
@@ -142,10 +150,22 @@ export class RedisRateLimiter extends RateLimiter {
 
   async recordSettle(req, feeCharged) {
     const ownerId = req.keyId || req.ip;
-    await this._incrementAsync(ownerId, 'settle', 60, 1);
-    await this._incrementAsync(ownerId, 'settle', 3600, 1);
-    await this._incrementAsync(ownerId, 'settle', 86400, 1);
+    const limits = this._getKeyConfig(req.keyId);
+    const b60 = await this._incrementAsync(ownerId, 'settle', 60, 1);
+    const b3600 = await this._incrementAsync(ownerId, 'settle', 3600, 1);
+    const b86400 = await this._incrementAsync(ownerId, 'settle', 86400, 1);
     if (feeCharged) await this._incrementAsync(ownerId, 'fee', 86400, feeCharged);
+    const tightest = [
+      { limit: limits.settleRpm, remaining: this._postRecordRemaining(limits.settleRpm, b60) },
+      { limit: limits.settleRph, remaining: this._postRecordRemaining(limits.settleRph, b3600) },
+      { limit: limits.settleRpd, remaining: this._postRecordRemaining(limits.settleRpd, b86400) },
+    ].sort((a, b) => a.remaining - b.remaining)[0];
+    return {
+      allowed: true,
+      limit: tightest.limit,
+      remaining: tightest.remaining,
+      resetAt: b60?.resetAt,
+    };
   }
 
   checkCatalog(req) {

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -591,3 +591,79 @@ describe('automatic cataloging', () => {
     }
   });
 });
+
+describe('RateLimit-Remaining reflects the post-count state (issue #141)', () => {
+  test('/verify decrements to zero and refuses exactly the request after the budget runs out', async () => {
+    const { RateLimiter } = await import('../src/rate-limit.js');
+    const rateLimiter = new RateLimiter({
+      global: { verifyRpm: 3, settleRpm: 100, settleRph: 100, settleRpd: 100, feeSpd: 1000000 },
+      keys: {},
+    });
+    const app = await serve({
+      config: testConfig({ apiKeys: ['custom_key:secret'] }),
+      rateLimiter,
+      facilitator: stubFacilitator(),
+    });
+    try {
+      const headers = { authorization: 'Bearer secret' };
+      const remaining = [];
+      for (let i = 0; i < 4; i += 1) {
+        const res = await app.post('/verify', VALID_BODY, headers);
+        remaining.push({
+          status: res.status,
+          remaining: Number(res.headers.get('ratelimit-remaining')),
+        });
+      }
+      // 3 allowances: the current request is counted before headers are emitted,
+      // so remaining drops 2 -> 1 -> 0, then the fourth is refused as a 429.
+      assert.deepEqual(remaining, [
+        { status: 200, remaining: 2 },
+        { status: 200, remaining: 1 },
+        { status: 200, remaining: 0 },
+        { status: 429, remaining: 0 },
+      ]);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('/settle decrements to zero and refuses exactly the request after the budget runs out', async () => {
+    const { RateLimiter } = await import('../src/rate-limit.js');
+    const rateLimiter = new RateLimiter({
+      global: { verifyRpm: 100, settleRpm: 3, settleRph: 100, settleRpd: 100, feeSpd: 1000000 },
+      keys: {},
+    });
+    const app = await serve({
+      config: testConfig({ apiKeys: ['custom_key:secret'] }),
+      rateLimiter,
+      facilitator: stubFacilitator({
+        settle: async () => ({ success: true, transaction: 'tx', network: 'stellar:testnet' }),
+      }),
+    });
+    try {
+      const headers = { authorization: 'Bearer secret' };
+      const remaining = [];
+      for (let i = 0; i < 4; i += 1) {
+        // Distinct bodies so each call is a genuine settlement, not an
+        // idempotent replay (a replay would not consume budget).
+        const body = {
+          ...VALID_BODY,
+          paymentPayload: { ...VALID_BODY.paymentPayload, payload: { tx: `tx-${i}` } },
+        };
+        const res = await app.post('/settle', body, headers);
+        remaining.push({
+          status: res.status,
+          remaining: Number(res.headers.get('ratelimit-remaining')),
+        });
+      }
+      assert.deepEqual(remaining, [
+        { status: 200, remaining: 2 },
+        { status: 200, remaining: 1 },
+        { status: 200, remaining: 0 },
+        { status: 429, remaining: 0 },
+      ]);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/test/helpers/app.js
+++ b/test/helpers/app.js
@@ -69,10 +69,22 @@ export function stubRateLimiter({ allow = true, reason = 'verify_rpm_exceeded' }
     checkSettle: () => result(),
     checkCatalog: () => result(),
     checkCatalogRead: () => result(),
-    recordCatalog: req => recorded.push({ name: 'recordCatalog', keyId: req.keyId }),
-    recordCatalogRead: req => recorded.push({ name: 'recordCatalogRead', keyId: req.keyId }),
-    recordVerify: req => recorded.push({ name: 'recordVerify', keyId: req.keyId }),
-    recordSettle: (req, fee) => recorded.push({ name: 'recordSettle', keyId: req.keyId, fee }),
+    recordCatalog: req => {
+      recorded.push({ name: 'recordCatalog', keyId: req.keyId });
+      return result();
+    },
+    recordCatalogRead: req => {
+      recorded.push({ name: 'recordCatalogRead', keyId: req.keyId });
+      return result();
+    },
+    recordVerify: req => {
+      recorded.push({ name: 'recordVerify', keyId: req.keyId });
+      return result();
+    },
+    recordSettle: (req, fee) => {
+      recorded.push({ name: 'recordSettle', keyId: req.keyId, fee });
+      return result();
+    },
     getUsage: keyId => ({ keyId, verify: 1, settle: 2, feeStroops: 3000 }),
   };
 }


### PR DESCRIPTION
## Summary

The rate-limit transport now advertises `RateLimit-*` headers that reflect the limiter state **after** the current request is counted, on both `/verify` and `/settle`.

### Why

`/verify` and `/settle` shared the same pattern: they emitted headers from the **pre-record `check*`** result, whose `remaining` is only a projection of what the caller will have left. The actual headroom only became real once the request was recorded. This change makes the post-count guarantee explicit and removes the reliance on the projection staying in sync with what `record*` does.

### What changed

- `RateLimiter.recordVerify` / `recordSettle` (and the `RedisRateLimiter` overrides) now **return** the limiter state after recording: `{ allowed, limit, remaining, resetAt }`. For settle this is the tightest remaining allowance across the per-minute / per-hour / per-day buckets.
- `/verify` and `/settle` emit `RateLimit-Limit/-Remaining/-Reset` from that returned state at the recording-path sites. The 429 path is unchanged — a refusal still reports the **pre-record** check that rejected the request, and `Retry-After` works exactly as before.
- Idempotent-replay / early-return branches of `/settle` (which do **not** record a settlement) still emit from the pre-record check, which is correct since no budget is consumed on those paths.

### Tests

Two tests pin the invariant end-to-end with a real `RateLimiter`:
- `/verify` with a budget of 3: `RateLimit-Remaining` reads `2 → 1 → 0`, then the 4th request is refused with `429`.
- `/settle` with a budget of 3 (distinct settlement bodies so each call is a genuine spend): likewise `2 → 1 → 0`, then `429`.

Full suite: 493 tests passing, lint clean.

Closes #141
