### PR TITLE
fix: catalog verify-only listings provisionally and promote on settle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -213,6 +213,10 @@ PORT=3402
 # ENABLE_RERANKING=false
 # EMBEDDINGS_TIMEOUT_MS=3000
 # CATALOG_MAX_RESOURCES_PER_PAYTO=50
+# CATALOG_VERIFY_TTL_MS=86400000
+#   How long a verify-only (provisional) catalog listing lives before being
+#   hidden and pruned if no settlement promotes it (#140). A verify moves no
+#   money, so a listing it creates must not live forever. Default: 24h.
 
 # The current geographic region or datacenter name (e.g. 'us-east-1').
 # Used for routing read queries to the nearest replica in CQRS setups.

--- a/src/app.js
+++ b/src/app.js
@@ -412,8 +412,13 @@ export async function createApp(
    * Cataloging must never delay or fail a payment: the expensive work is
    * enqueued and the payment response returns immediately. A cataloging failure
    * is logged, never surfaced as a payment failure.
+   *
+   * The `source` records how the resource entered the catalog (#140): a verify
+   * ("verify") proves nothing was paid, so the store catalogs it as provisional
+   * and expiring; a real settlement ("settle") promotes it to permanent public
+   * state. A hand-entered resource is "manual".
    */
-  async function processCataloging(req, body, reply, source = 'payment') {
+  async function processCataloging(req, body, reply, source = 'verify') {
     try {
       const validation = validateForCatalog(body.paymentPayload, body.paymentRequirements);
       const outcome = {};
@@ -785,7 +790,9 @@ export async function createApp(
           network: body.paymentRequirements.network,
         });
         if (result.isValid) {
-          await processCataloging(req, body, reply, 'payment');
+          // A verify moves no money, so the listing it creates is provisional
+          // and expires unless a settlement promotes it (#140).
+          await processCataloging(req, body, reply, 'verify');
         }
         return reply.send(result);
       } catch (err) {
@@ -1003,7 +1010,7 @@ export async function createApp(
                 event,
               );
 
-              await processCataloging(req, body, reply, 'payment');
+              await processCataloging(req, body, reply, 'settle');
 
               if (
                 !enqueued.atomicallyEnqueued &&

--- a/src/catalog/memory.js
+++ b/src/catalog/memory.js
@@ -44,6 +44,7 @@ export class MemoryCatalogStore {
     this.payToCounts = new Map();
     this.maxResourcesPerPayTo =
       config.maxResourcesPerPayTo ?? config.catalogMaxResourcesPerPayTo ?? 50;
+    this.verifyTtlMs = config.catalogVerifyTtlMs ?? 24 * 60 * 60 * 1000;
     this.embeddingClient = new EmbeddingClient(config.embeddingsUrl, {
       timeoutMs: config.embeddingsTimeoutMs,
     });
@@ -55,6 +56,22 @@ export class MemoryCatalogStore {
 
   _key(resource) {
     return resource.type === 'mcp' ? `${resource.url}::${resource.toolName}` : `${resource.url}::`;
+  }
+
+  /**
+   * A verify-only listing (`source: 'verify'`) is provisional: it is visible for
+   * discoverability but lacks the proof of a real payment, so once its window
+   * elapses it must stop being public. Settled and manual listings are never
+   * provisional (#140).
+   */
+  _isExpired(entry) {
+    if (!entry?.provisional) return false;
+    if (entry.expires_at == null) return true;
+    return Date.now() >= new Date(entry.expires_at).getTime();
+  }
+
+  _isPublic(entry) {
+    return !this._isExpired(entry);
   }
 
   _incrementPayToCount(payTo) {
@@ -93,10 +110,24 @@ export class MemoryCatalogStore {
       );
     }
 
+    // Provenance and lifetime (#140). A verify proves nothing was paid, so a
+    // listing it creates is provisional and expires unless a settlement
+    // promotes it. A listing created by a settle (or by hand) is permanent
+    // public state. A settle/manual write always promotes — even one landing
+    // on an old provisional entry — and never demotes an already-settled one.
+    const existingSettled = existing != null && existing.source !== 'verify';
+    const provisional = source === 'verify' && !existingSettled;
+    const expiresAt = provisional ? now.getTime() + this.verifyTtlMs : null;
+    // Provenance records how a listing entered the catalog: a verify touching
+    // an already-settled listing must not mask its permanent origin.
+    const recordedSource = existingSettled ? existing.source : source;
+
     const entry = {
       ...existing,
       ...resource,
-      source,
+      source: recordedSource,
+      provisional,
+      expires_at: expiresAt,
       last_seen_at: now,
       first_seen_at: existing ? existing.first_seen_at : now,
     };
@@ -139,11 +170,12 @@ export class MemoryCatalogStore {
 
   async getResource(url, toolName = null) {
     const key = toolName ? `${url}::${toolName}` : `${url}::`;
-    return this.resources.get(key) || null;
+    const entry = this.resources.get(key) || null;
+    return entry && this._isPublic(entry) ? entry : null;
   }
 
   async listResources(params = {}) {
-    let items = Array.from(this.resources.values());
+    let items = Array.from(this.resources.values()).filter(item => this._isPublic(item));
 
     if (params.type) items = items.filter(r => r.type === params.type);
     if (params.payTo) items = items.filter(r => r.payTo === params.payTo);
@@ -177,8 +209,25 @@ export class MemoryCatalogStore {
     };
   }
 
+  /**
+   * Physically removes expired provisional (verify-only) listings so they do
+   * not accumulate forever (#140). Called lazily by a background sweep rather
+   * than on the payment hot path. Returns the number of entries pruned.
+   */
+  async pruneExpired() {
+    let pruned = 0;
+    for (const [key, entry] of this.resources) {
+      if (this._isExpired(entry)) {
+        this.resources.delete(key);
+        this._decrementPayToCount(entry.payTo);
+        pruned += 1;
+      }
+    }
+    return pruned;
+  }
+
   async search(params) {
-    let items = Array.from(this.resources.values());
+    let items = Array.from(this.resources.values()).filter(item => this._isPublic(item));
 
     if (params.type) items = items.filter(r => r.type === params.type);
     if (params.payTo) items = items.filter(r => r.payTo === params.payTo);

--- a/src/config.js
+++ b/src/config.js
@@ -382,6 +382,12 @@ export function resolveConfig(env = process.env) {
     embeddingsUrl: env.EMBEDDINGS_URL || null,
     embeddingsTimeoutMs: Number(env.EMBEDDINGS_TIMEOUT_MS ?? 3000),
     catalogMaxResourcesPerPayTo: Number(env.CATALOG_MAX_RESOURCES_PER_PAYTO ?? 50),
+    /**
+     * How long a verify-only (provisional) catalog listing lives before it is
+     * hidden and pruned if no settlement promotes it (#140). A verify moves no
+     * money, so a listing it creates must not live forever.
+     */
+    catalogVerifyTtlMs: Number(env.CATALOG_VERIFY_TTL_MS ?? 24 * 60 * 60 * 1000),
     enableReranking: env.ENABLE_RERANKING === 'true',
     shutdownGraceMs: Number(env.SHUTDOWN_GRACE_MS ?? 15_000),
     requestTimeoutMs: Number(env.REQUEST_TIMEOUT_MS ?? 30_000),

--- a/src/server.js
+++ b/src/server.js
@@ -120,11 +120,14 @@ const catalog = new MemoryCatalogStore(config);
 // (verify-only) listings so they do not accumulate forever (#140).
 const catalogPruneTimer =
   config.catalogVerifyTtlMs > 0
-    ? globalThis.setInterval(() => {
-        catalog
-          .pruneExpired()
-          .catch(err => console.warn(`[Catalog] prune sweep failed: ${err.message}`));
-      }, Math.min(config.catalogVerifyTtlMs, 60_000))
+    ? globalThis.setInterval(
+        () => {
+          catalog
+            .pruneExpired()
+            .catch(err => console.warn(`[Catalog] prune sweep failed: ${err.message}`));
+        },
+        Math.min(config.catalogVerifyTtlMs, 60_000),
+      )
     : null;
 const idempotency = buildIdempotencyStore(config, { pool: vaultDatabase?.pool });
 

--- a/src/server.js
+++ b/src/server.js
@@ -116,6 +116,16 @@ if (config.rateLimitStore === 'crdt' && config.databaseUrl) {
   rateLimiter = new RateLimiter(config.rateLimits, rateLimitStore);
 }
 const catalog = new MemoryCatalogStore(config);
+// Off the hot path: a periodic sweep physically removes expired provisional
+// (verify-only) listings so they do not accumulate forever (#140).
+const catalogPruneTimer =
+  config.catalogVerifyTtlMs > 0
+    ? globalThis.setInterval(() => {
+        catalog
+          .pruneExpired()
+          .catch(err => console.warn(`[Catalog] prune sweep failed: ${err.message}`));
+      }, Math.min(config.catalogVerifyTtlMs, 60_000))
+    : null;
 const idempotency = buildIdempotencyStore(config, { pool: vaultDatabase?.pool });
 
 // Cross-process serialization for state transitions (#116). Absent config
@@ -287,6 +297,8 @@ async function shutdown(signal) {
       await crdtStore?.close().catch(() => {});
 
       failoverHealth?.stop();
+
+      if (catalogPruneTimer) globalThis.clearInterval(catalogPruneTimer);
 
       await rateLimiter?.close?.().catch(() => {});
       horizon.restore();

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -18,6 +18,7 @@ import {
   stubCatalog,
   VALID_BODY,
 } from './helpers/app.js';
+import { MemoryCatalogStore } from '../src/catalog/memory.js';
 
 describe('GET /healthz', () => {
   let app;
@@ -586,6 +587,144 @@ describe('automatic cataloging', () => {
       await app.post('/verify', VALID_BODY);
       await settle();
       assert.deepEqual(catalog.stored, []);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('catalog provenance and provisional lifecycle (issue #140)', () => {
+  // A body that actually produces a catalog entry: VALID_BODY has no discovery
+  // extension, so validateForCatalog hard-drops it. This one does.
+  const CATALOGABLE_BODY = {
+    paymentPayload: {
+      x402Version: 2,
+      scheme: 'exact',
+      network: 'stellar:testnet',
+      resource: { url: 'http://api.ex/140', serviceName: 'provenance-demo', description: 'demo' },
+      extensions: {
+        bazaar: {
+          info: { input: { type: 'http', method: 'GET' }, scheme: 'exact' },
+          schema: { type: 'object' },
+          routeTemplate: '/140',
+        },
+      },
+    },
+    paymentRequirements: {
+      scheme: 'exact',
+      network: 'stellar:testnet',
+      asset: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
+      maxAmountRequired: '1000',
+      payTo: 'GCALKSGAZRJLSUEJT3M5W6LN4R7XQOLIRCOS6ZA6EDZVTZDBIIPPFKJ6',
+    },
+  };
+
+  test('a verify without settle catalogues a provisional, expiring listing', async () => {
+    const catalog = new MemoryCatalogStore({ catalogVerifyTtlMs: 600_000 });
+    const app = await serve({
+      catalog,
+      facilitator: stubFacilitator({
+        verify: async () => ({ isValid: true }),
+      }),
+    });
+    try {
+      const res = await app.post('/verify', CATALOGABLE_BODY);
+      assert.equal(res.status, 200);
+      await new Promise(r => setTimeout(r, 50));
+
+      const discovery = await app.get('/discovery/resources');
+      const body = await discovery.json();
+      assert.equal(body.items.length, 1);
+      const entry = body.items[0];
+      assert.equal(entry.source, 'verify');
+      assert.equal(entry.provisional, true);
+      assert.ok(entry.expires_at, 'provisional listing must carry an expiry');
+
+      const stored = await catalog.getResource(entry.url);
+      assert.equal(stored.source, 'verify');
+      assert.equal(stored.provisional, true);
+      assert.ok(stored.expires_at > Date.now());
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('a settle promotes a provisional listing to permanent public state', async () => {
+    const catalog = new MemoryCatalogStore({ catalogVerifyTtlMs: 600_000 });
+    const app = await serve({
+      catalog,
+      facilitator: stubFacilitator({
+        verify: async () => ({ isValid: true }),
+        settle: async () => ({ success: true, transaction: 'tx', network: 'stellar:testnet' }),
+      }),
+    });
+    try {
+      const headers = { authorization: 'Bearer secret' };
+      // First a verify-only pass leaves a provisional listing.
+      await app.post('/verify', CATALOGABLE_BODY, headers);
+      await new Promise(r => setTimeout(r, 50));
+      const before = (await (await app.get('/discovery/resources')).json()).items[0];
+      assert.equal(before.source, 'verify');
+
+      // Then an actual settlement promotes it.
+      await app.post('/settle', CATALOGABLE_BODY, headers);
+      await new Promise(r => setTimeout(r, 50));
+      const after = (await (await app.get('/discovery/resources')).json()).items[0];
+      assert.equal(after.source, 'settle');
+      assert.equal(after.provisional, false);
+      assert.equal(after.expires_at, null);
+
+      const stored = await catalog.getResource(after.url);
+      assert.equal(stored.source, 'settle');
+      assert.equal(stored.provisional, false);
+      assert.equal(stored.expires_at, null);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('a settle on its own catalogues a permanent listing', async () => {
+    const catalog = new MemoryCatalogStore({ catalogVerifyTtlMs: 600_000 });
+    const app = await serve({
+      catalog,
+      facilitator: stubFacilitator({
+        settle: async () => ({ success: true, transaction: 'tx', network: 'stellar:testnet' }),
+      }),
+    });
+    try {
+      await app.post('/settle', CATALOGABLE_BODY, { authorization: 'Bearer secret' });
+      await new Promise(r => setTimeout(r, 50));
+      const entry = (await (await app.get('/discovery/resources')).json()).items[0];
+      assert.equal(entry.source, 'settle');
+      assert.equal(entry.provisional, false);
+      assert.equal(entry.expires_at, null);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('an unsettled verify-only listing disappears from discovery once it expires', async () => {
+    // Short TTL so the test does not wait out a real window.
+    const catalog = new MemoryCatalogStore({ catalogVerifyTtlMs: 150 });
+    const app = await serve({
+      catalog,
+      facilitator: stubFacilitator({
+        verify: async () => ({ isValid: true }),
+      }),
+    });
+    try {
+      const headers = { authorization: 'Bearer secret' };
+      await app.post('/verify', CATALOGABLE_BODY, headers);
+      // Give the enqueued (off-hot-path) catalog write time to land while the
+      // 150ms window still puts the listing in the public view.
+      await new Promise(r => setTimeout(r, 60));
+      assert.equal((await (await app.get('/discovery/resources')).json()).items.length, 1);
+
+      await new Promise(r => setTimeout(r, 180));
+      assert.equal((await (await app.get('/discovery/resources')).json()).items.length, 0);
+
+      const pruned = await catalog.pruneExpired();
+      assert.equal(pruned, 1);
     } finally {
       await app.close();
     }

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -593,6 +593,82 @@ describe('automatic cataloging', () => {
   });
 });
 
+describe('RateLimit-Remaining reflects the post-count state (issue #141)', () => {
+  test('/verify decrements to zero and refuses exactly the request after the budget runs out', async () => {
+    const { RateLimiter } = await import('../src/rate-limit.js');
+    const rateLimiter = new RateLimiter({
+      global: { verifyRpm: 3, settleRpm: 100, settleRph: 100, settleRpd: 100, feeSpd: 1000000 },
+      keys: {},
+    });
+    const app = await serve({
+      config: testConfig({ apiKeys: ['custom_key:secret'] }),
+      rateLimiter,
+      facilitator: stubFacilitator(),
+    });
+    try {
+      const headers = { authorization: 'Bearer secret' };
+      const remaining = [];
+      for (let i = 0; i < 4; i += 1) {
+        const res = await app.post('/verify', VALID_BODY, headers);
+        remaining.push({
+          status: res.status,
+          remaining: Number(res.headers.get('ratelimit-remaining')),
+        });
+      }
+      // 3 allowances: the current request is counted before headers are emitted,
+      // so remaining drops 2 -> 1 -> 0, then the fourth is refused as a 429.
+      assert.deepEqual(remaining, [
+        { status: 200, remaining: 2 },
+        { status: 200, remaining: 1 },
+        { status: 200, remaining: 0 },
+        { status: 429, remaining: 0 },
+      ]);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('/settle decrements to zero and refuses exactly the request after the budget runs out', async () => {
+    const { RateLimiter } = await import('../src/rate-limit.js');
+    const rateLimiter = new RateLimiter({
+      global: { verifyRpm: 100, settleRpm: 3, settleRph: 100, settleRpd: 100, feeSpd: 1000000 },
+      keys: {},
+    });
+    const app = await serve({
+      config: testConfig({ apiKeys: ['custom_key:secret'] }),
+      rateLimiter,
+      facilitator: stubFacilitator({
+        settle: async () => ({ success: true, transaction: 'tx', network: 'stellar:testnet' }),
+      }),
+    });
+    try {
+      const headers = { authorization: 'Bearer secret' };
+      const remaining = [];
+      for (let i = 0; i < 4; i += 1) {
+        // Distinct bodies so each call is a genuine settlement, not an
+        // idempotent replay (a replay would not consume budget).
+        const body = {
+          ...VALID_BODY,
+          paymentPayload: { ...VALID_BODY.paymentPayload, payload: { tx: `tx-${i}` } },
+        };
+        const res = await app.post('/settle', body, headers);
+        remaining.push({
+          status: res.status,
+          remaining: Number(res.headers.get('ratelimit-remaining')),
+        });
+      }
+      assert.deepEqual(remaining, [
+        { status: 200, remaining: 2 },
+        { status: 200, remaining: 1 },
+        { status: 200, remaining: 0 },
+        { status: 429, remaining: 0 },
+      ]);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
 describe('catalog provenance and provisional lifecycle (issue #140)', () => {
   // A body that actually produces a catalog entry: VALID_BODY has no discovery
   // extension, so validateForCatalog hard-drops it. This one does.
@@ -678,36 +754,6 @@ describe('catalog provenance and provisional lifecycle (issue #140)', () => {
       assert.equal(stored.source, 'settle');
       assert.equal(stored.provisional, false);
       assert.equal(stored.expires_at, null);
-describe('RateLimit-Remaining reflects the post-count state (issue #141)', () => {
-  test('/verify decrements to zero and refuses exactly the request after the budget runs out', async () => {
-    const { RateLimiter } = await import('../src/rate-limit.js');
-    const rateLimiter = new RateLimiter({
-      global: { verifyRpm: 3, settleRpm: 100, settleRph: 100, settleRpd: 100, feeSpd: 1000000 },
-      keys: {},
-    });
-    const app = await serve({
-      config: testConfig({ apiKeys: ['custom_key:secret'] }),
-      rateLimiter,
-      facilitator: stubFacilitator(),
-    });
-    try {
-      const headers = { authorization: 'Bearer secret' };
-      const remaining = [];
-      for (let i = 0; i < 4; i += 1) {
-        const res = await app.post('/verify', VALID_BODY, headers);
-        remaining.push({
-          status: res.status,
-          remaining: Number(res.headers.get('ratelimit-remaining')),
-        });
-      }
-      // 3 allowances: the current request is counted before headers are emitted,
-      // so remaining drops 2 -> 1 -> 0, then the fourth is refused as a 429.
-      assert.deepEqual(remaining, [
-        { status: 200, remaining: 2 },
-        { status: 200, remaining: 1 },
-        { status: 200, remaining: 0 },
-        { status: 429, remaining: 0 },
-      ]);
     } finally {
       await app.close();
     }
@@ -740,17 +786,6 @@ describe('RateLimit-Remaining reflects the post-count state (issue #141)', () =>
       catalog,
       facilitator: stubFacilitator({
         verify: async () => ({ isValid: true }),
-  test('/settle decrements to zero and refuses exactly the request after the budget runs out', async () => {
-    const { RateLimiter } = await import('../src/rate-limit.js');
-    const rateLimiter = new RateLimiter({
-      global: { verifyRpm: 100, settleRpm: 3, settleRph: 100, settleRpd: 100, feeSpd: 1000000 },
-      keys: {},
-    });
-    const app = await serve({
-      config: testConfig({ apiKeys: ['custom_key:secret'] }),
-      rateLimiter,
-      facilitator: stubFacilitator({
-        settle: async () => ({ success: true, transaction: 'tx', network: 'stellar:testnet' }),
       }),
     });
     try {
@@ -766,26 +801,6 @@ describe('RateLimit-Remaining reflects the post-count state (issue #141)', () =>
 
       const pruned = await catalog.pruneExpired();
       assert.equal(pruned, 1);
-      const remaining = [];
-      for (let i = 0; i < 4; i += 1) {
-        // Distinct bodies so each call is a genuine settlement, not an
-        // idempotent replay (a replay would not consume budget).
-        const body = {
-          ...VALID_BODY,
-          paymentPayload: { ...VALID_BODY.paymentPayload, payload: { tx: `tx-${i}` } },
-        };
-        const res = await app.post('/settle', body, headers);
-        remaining.push({
-          status: res.status,
-          remaining: Number(res.headers.get('ratelimit-remaining')),
-        });
-      }
-      assert.deepEqual(remaining, [
-        { status: 200, remaining: 2 },
-        { status: 200, remaining: 1 },
-        { status: 200, remaining: 0 },
-        { status: 429, remaining: 0 },
-      ]);
     } finally {
       await app.close();
     }

--- a/test/catalog.auto.test.js
+++ b/test/catalog.auto.test.js
@@ -1,4 +1,4 @@
-import test from 'node:test';
+import test, { describe } from 'node:test';
 import assert from 'node:assert/strict';
 import { MemoryCatalogStore, MAX_RESOURCES_PER_PAYTO_CODE } from '../src/catalog/memory.js';
 
@@ -33,5 +33,61 @@ test('Auto Cataloging Store Limits', async t => {
     assert.ok(warning.includes('changed payTo from G123 to G456'));
 
     console.warn = originalWarn;
+  });
+});
+
+describe('Catalog provenance and provisional lifecycle (#140)', () => {
+  test('a verify-source upsert is provisional and expiring; a settle promotes it', async () => {
+    const store = new MemoryCatalogStore({ catalogVerifyTtlMs: 60_000 });
+
+    await store.upsertResource({ url: 'http://p.ex/1', payTo: 'G1' }, 'verify');
+    let entry = await store.getResource('http://p.ex/1');
+    assert.equal(entry.source, 'verify');
+    assert.equal(entry.provisional, true);
+    assert.ok(entry.expires_at != null);
+    // Still discoverable before expiry.
+    assert.equal((await store.listResources({})).total, 1);
+
+    await store.upsertResource({ url: 'http://p.ex/1', payTo: 'G1' }, 'settle');
+    entry = await store.getResource('http://p.ex/1');
+    assert.equal(entry.source, 'settle');
+    assert.equal(entry.provisional, false);
+    assert.equal(entry.expires_at, null);
+  });
+
+  test('a settle landing on an old provisional entry promotes it and clears expiry', async () => {
+    const store = new MemoryCatalogStore({ catalogVerifyTtlMs: -1 });
+    await store.upsertResource({ url: 'http://p.ex/2', payTo: 'G1' }, 'verify');
+    await store.upsertResource({ url: 'http://p.ex/2', payTo: 'G1' }, 'settle');
+    const entry = await store.getResource('http://p.ex/2');
+    assert.equal(entry.source, 'settle');
+    assert.equal(entry.provisional, false);
+    assert.equal(entry.expires_at, null);
+  });
+
+  test('a verify never demotes an already-settled listing', async () => {
+    const store = new MemoryCatalogStore({ catalogVerifyTtlMs: 1_000_000 });
+    await store.upsertResource({ url: 'http://p.ex/3', payTo: 'G1' }, 'settle');
+    await store.upsertResource({ url: 'http://p.ex/3', payTo: 'G1' }, 'verify');
+    const entry = await store.getResource('http://p.ex/3');
+    assert.equal(entry.source, 'settle');
+    assert.equal(entry.provisional, false);
+    assert.equal(entry.expires_at, null);
+  });
+
+  test('expired provisional listings are hidden from discovery and pruned', async () => {
+    const store = new MemoryCatalogStore({ catalogVerifyTtlMs: 5 });
+
+    await store.upsertResource({ url: 'http://p.ex/4', payTo: 'G1' }, 'verify');
+    await store.upsertResource({ url: 'http://p.ex/4', payTo: 'G1' }, 'settle');
+    await store.upsertResource({ url: 'http://e.ex/4', payTo: 'G2' }, 'verify');
+    assert.equal((await store.listResources({})).total, 2);
+
+    await new Promise(r => setTimeout(r, 20));
+    // The expired verify-only entry is hidden; the settled one stays public.
+    assert.equal((await store.listResources({})).total, 1);
+    const pruned = await store.pruneExpired();
+    assert.equal(pruned, 1);
+    assert.equal((await store.listResources({})).total, 1);
   });
 });


### PR DESCRIPTION
## Summary

A `/verify` moves no money, so a resource it catalogs must not become a **permanent, free public listing** that survives forever. This PR records the provenance of every catalog entry and gives verify-only entries a lifetime.

### Policy decided (issue #140 asks to confirm intent)

Verify-only listings are **not** permanent public state. `/verify` is a check, not a payment — cataloging on it is kept (for the discoverability benefit) but as a **provisional, expiring** entry. A genuine `/settle` **promotes** it to permanent public state. If no settlement ever lands, the entry expires and is pruned. Cataloging remains off the payment hot path, exactly as before.

### What changed

- **Sources distinguished**: `/verify` catalogs with `source: 'verify'`; `/settle` with `source: 'settle'` (previously both passed `'payment'`). Hand-entered resources keep `'manual'`. The `catalog_write` audit and the discovery payloads now carry this provenance.
- **Provisional + expiry (`MemoryCatalogStore`)**: a `verify` upsert creates a provisional entry with `expires_at = now + catalogVerifyTtlMs` (default 24h, new `CATALOG_VERIFY_TTL_MS` env). A `settle` upsert promotes: clears `provisional`/`expires_at`, and never demotes an already-settled listing when a later verify touches it.
- **Expiry enforcement**: expired provisional entries are lazily filtered out of `listResources`, `search`, and `getResource`, and physically removed by a background `pruneExpired()` sweep in `server.js` (off the hot path, `globalThis.setInterval`).
- **Config**: `catalogVerifyTtlMs` added to resolved config + documented in `.env.example` (the env-doc check enforces it).

### Tests

8 new tests (both store-level and over the HTTP surface), covering:
- verify-without-settle → provisional, expiring listing present in discovery
- settle → promotes to permanent (`provisional: false`, no expiry)
- settle on its own → permanent from the start
- a verify never demotes an already-settled listing
- expired verify-only listing disappears from discovery and is pruned

### Checks

- `npm run lint`: clean
- `npm test`: **499 passing** (491 baseline + 8 new), 0 failures
- `npm run e2e`: boots cleanly; gated in this environment on live testnet credentials + a running facilitator (payment wire path is unchanged by this PR, and the HTTP-surface behavior is covered by the new integration tests)

Closes #140
