### PR TITLE
feat: durable Postgres catalog store so listings survive restart (#139)

### DIFF
--- a/migrations/006_catalog_resources.js
+++ b/migrations/006_catalog_resources.js
@@ -1,0 +1,35 @@
+/**
+ * 006: Durable catalog — catalog_resources table (#139).
+ *
+ * Backing store for the catalog. `key` mirrors the in-memory identity
+ * (url::toolName for mcp, url:: for http) so a restart can rebuild the exact
+ * same entries. The provenance and lifetime columns mirror the in-memory
+ * entry (#140): `provisional` is true only for verify-but-unpaid listings and
+ * `expires_at` carries their window, so an operator can audit which listings
+ * came from a /verify versus a settled payment, and the store's boot
+ * hydration reproduces the same public/private view.
+ *
+ * `embedding` holds the semantic-search vector when one exists, written back
+ * by the store as soon as the background embed completes, so /discovery/search
+ * is warm immediately after a restart (no wholesale re-embedding).
+ */
+
+export const up = pgm => {
+  pgm.createTable('catalog_resources', {
+    key: { type: 'TEXT', primaryKey: true },
+    resource: { type: 'JSONB', notNull: true },
+    source: { type: 'TEXT', notNull: true, default: 'manual' },
+    provisional: { type: 'BOOLEAN', notNull: true, default: false },
+    expires_at: { type: 'BIGINT' },
+    first_seen_at: { type: 'TIMESTAMPTZ', notNull: true },
+    last_seen_at: { type: 'TIMESTAMPTZ', notNull: true },
+    embedding: { type: 'JSONB' },
+  });
+
+  pgm.createIndex('catalog_resources', 'source');
+  pgm.createIndex('catalog_resources', 'provisional');
+};
+
+export const down = pgm => {
+  pgm.dropTable('catalog_resources');
+};

--- a/src/catalog/memory.js
+++ b/src/catalog/memory.js
@@ -138,25 +138,38 @@ export class MemoryCatalogStore {
     }
 
     // Re-embed asynchronously without blocking the upsert (or the payment path)
-    if (this.embeddingClient.url) {
-      const p = Promise.resolve().then(async () => {
-        try {
-          const text = this.embeddingClient.composeDocument(entry);
-          const vector = await this.embeddingClient.embed(text);
-          if (vector) {
-            entry.embedding = vector;
-          }
-        } catch (err) {
-          console.warn(`[Catalog] Failed to re-embed ${key}: ${err.message}`);
-        } finally {
-          this._pendingEmbeddings.delete(p);
-        }
-      });
-      this._pendingEmbeddings.add(p);
-    }
+    this._scheduleEmbed(entry);
 
     return entry;
   }
+
+  /**
+   * Re-embeds a resource in the background when an embedding provider is wired
+   * up, never blocking the upsert or the payment path. `_afterEmbedding` is a
+   * hook that durable stores override to persist the freshly-computed vector
+   * (#139) — the base implementation stores nothing.
+   */
+  _scheduleEmbed(entry) {
+    if (!this.embeddingClient.url) return;
+    const p = Promise.resolve().then(async () => {
+      try {
+        const text = this.embeddingClient.composeDocument(entry);
+        const vector = await this.embeddingClient.embed(text);
+        if (vector) {
+          entry.embedding = vector;
+          await this._afterEmbedding(entry);
+        }
+      } catch (err) {
+        console.warn(`[Catalog] Failed to re-embed ${this._key(entry)}: ${err.message}`);
+      } finally {
+        this._pendingEmbeddings.delete(p);
+      }
+    });
+    this._pendingEmbeddings.add(p);
+  }
+
+  /** Hook for durable stores to persist a freshly-computed embedding vector. */
+  async _afterEmbedding() {}
 
   /**
    * Await all in-flight background embedding requests.

--- a/src/catalog/postgres.js
+++ b/src/catalog/postgres.js
@@ -1,0 +1,242 @@
+/**
+ * Postgres-backed catalog store (#139).
+ *
+ * Postgres is chosen because it is already a hard dependency of the service
+ * (DATABASE_URL) and already backs the settlement, idempotency and outbox
+ * stores — adding a second datastore for the catalog would be a new
+ * operational burden for no benefit.
+ *
+ * The durable store extends MemoryCatalogStore and treats Postgres as the
+ * source of truth and the in-memory maps as a boot-time hydrated cache:
+ *   - writes persist the row AND the memory copy (reads/search must never
+ *     wait on the database);
+ *   - at boot all rows are hydrated into memory, so /discovery reads behave
+ *     identically to the memory store with zero Postgres involvement;
+ *   - embedding vectors are stored alongside the row and written back as soon
+ *     as the background embed completes (write-behind), so semantic search is
+ *     warm immediately after a restart instead of re-embedding everything.
+ *
+ * Outage behaviour is degradation-with-warning, never failure: any Postgres
+ * error flips the store to process-local memory and payment/catalog writes
+ * proceed exactly as before. The payment path is never blocked by the catalog
+ * (cataloging runs off the hot path in app.js), so an outage cannot fail or
+ * delay a settlement.
+ */
+import { MemoryCatalogStore } from './memory.js';
+
+/** The entry fields persisted as columns; the rest is the resource link. */
+function resourceLink(entry) {
+  const {
+    source: _source,
+    provisional: _provisional,
+    expires_at: _expiresAt,
+    last_seen_at: _lastSeenAt,
+    first_seen_at: _firstSeenAt,
+    embedding: _embedding,
+    ...resource
+  } = entry;
+  return resource;
+}
+
+/** Rebuilds one persisted row into the in-memory entry shape. */
+function hydrateRow(r) {
+  const resource = typeof r.resource === 'string' ? JSON.parse(r.resource) : r.resource;
+  const entry = {
+    ...resource,
+    source: r.source,
+    provisional: r.provisional,
+    // int8 columns come back from node-postgres as strings.
+    expires_at: r.expires_at == null ? null : Number(r.expires_at),
+    first_seen_at: new Date(r.first_seen_at),
+    last_seen_at: new Date(r.last_seen_at),
+  };
+  if (r.embedding) {
+    entry.embedding = typeof r.embedding === 'string' ? JSON.parse(r.embedding) : r.embedding;
+  }
+  return entry;
+}
+
+export class PostgresCatalogStore extends MemoryCatalogStore {
+  /**
+   * @param {object} config - resolved config (embeddingsUrl, catalogVerifyTtlMs,
+   *   databaseUrl, …) — the same shape MemoryCatalogStore takes
+   * @param {object} [options]
+   * @param {object} [options.pool] - injected pg Pool (tests, or the shared
+   *   Vault-managed pool #127); absent builds one from config.databaseUrl
+   * @param {Function} [options.warn] - warning sink
+   */
+  constructor(config = {}, { pool, warn = msg => console.warn(msg) } = {}) {
+    super(config);
+    this.warn = warn;
+    this.pool = pool ?? null;
+    this.degraded = false;
+    // Resolves once schema + hydration have been attempted. Never rejects: a
+    // failure degrades the store instead of blocking the payment path.
+    this.ready = null;
+    if (this.pool) {
+      this.ready = this._init();
+    } else if (config.databaseUrl) {
+      this.ready = import('pg')
+        .then(({ default: pg }) => {
+          this.pool = new pg.Pool({ connectionString: config.databaseUrl, max: 5 });
+          this.pool.on('error', err => this._degrade(`Postgres error: ${err.message}`));
+          return this._init();
+        })
+        .catch(err => this._degrade(`pg unavailable (${err.message}); using in-memory catalog`));
+    }
+  }
+
+  _degrade(message) {
+    if (!this.degraded) {
+      this.degraded = true;
+      this.warn(`[CatalogStore] ${message} — catalog is now process-local memory only`);
+    }
+  }
+
+  async _ensureSchema() {
+    if (!this.pool || this.degraded) return;
+    try {
+      await this.pool.query(`
+        CREATE TABLE IF NOT EXISTS catalog_resources (
+            key TEXT PRIMARY KEY,
+            resource JSONB NOT NULL,
+            source TEXT NOT NULL,
+            provisional BOOLEAN NOT NULL DEFAULT false,
+            expires_at BIGINT,
+            first_seen_at TIMESTAMPTZ NOT NULL,
+            last_seen_at TIMESTAMPTZ NOT NULL,
+            embedding JSONB
+        );
+        CREATE INDEX IF NOT EXISTS idx_catalog_resources_source ON catalog_resources(source);
+        CREATE INDEX IF NOT EXISTS idx_catalog_resources_provisional ON catalog_resources(provisional);
+      `);
+    } catch (err) {
+      this._degrade(`failed to create schema: ${err.message}`);
+    }
+  }
+
+  async _hydrate() {
+    if (!this.pool || this.degraded) return;
+    const { rows } = await this.pool.query(
+      `SELECT key, resource, source, provisional, expires_at, first_seen_at, last_seen_at, embedding
+       FROM catalog_resources`,
+    );
+    for (const row of rows) {
+      const entry = hydrateRow(row);
+      this.resources.set(row.key, entry);
+      this._incrementPayToCount(entry.payTo);
+      // Rows written before embeddings existed (or an older model) are
+      // re-embedded through the exact same background path new upserts use.
+      if (!entry.embedding) {
+        this._scheduleEmbed(entry);
+      }
+    }
+  }
+
+  async _init() {
+    await this._ensureSchema();
+    if (this.degraded) return;
+    try {
+      await this._hydrate();
+    } catch (err) {
+      this._degrade(`hydration failed: ${err.message}`);
+    }
+  }
+
+  /** Upserts the durable row for an entry. Safe to call more than once: the
+   *  key is stable and first_seen_at is preserved on conflict. */
+  async _persistResource(entry) {
+    await this.pool.query(
+      `INSERT INTO catalog_resources
+         (key, resource, source, provisional, expires_at, first_seen_at, last_seen_at, embedding)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       ON CONFLICT (key) DO UPDATE SET
+         resource = EXCLUDED.resource,
+         source = EXCLUDED.source,
+         provisional = EXCLUDED.provisional,
+         expires_at = EXCLUDED.expires_at,
+         first_seen_at = catalog_resources.first_seen_at,
+         last_seen_at = EXCLUDED.last_seen_at,
+         embedding = EXCLUDED.embedding`,
+      [
+        this._key(entry),
+        JSON.stringify(resourceLink(entry)),
+        entry.source ?? 'manual',
+        Boolean(entry.provisional),
+        entry.expires_at ?? null,
+        entry.first_seen_at,
+        entry.last_seen_at,
+        entry.embedding ? JSON.stringify(entry.embedding) : null,
+      ],
+    );
+  }
+
+  /**
+   * Persist a freshly-computed embedding vector as soon as it lands, so a
+   * restart is warm for semantic search. Loss of a vector write must not fail
+   * the embed that produced it — degrade instead.
+   */
+  async _afterEmbedding(entry) {
+    if (this.degraded || !this.pool) return;
+    try {
+      await this.ready;
+      await this._persistResource(entry);
+    } catch (err) {
+      this._degrade(`vector persist failed: ${err.message}`);
+    }
+  }
+
+  async upsertResource(resource, source = 'manual') {
+    // Memory first: domain rejections (the flooding guard #186) propagate
+    // identically to the in-memory implementation, and the entry is visible to
+    // reads/search instantly without waiting on the database.
+    const entry = await super.upsertResource(resource, source);
+    if (this.degraded || !this.pool) return entry;
+    try {
+      await this.ready;
+      await this._persistResource(entry);
+    } catch (err) {
+      this._degrade(`upsertResource persist failed: ${err.message}`);
+    }
+    return entry;
+  }
+
+  async pruneExpired() {
+    const expiredKeys = [];
+    for (const [key, entry] of this.resources) {
+      if (this._isExpired(entry)) expiredKeys.push(key);
+    }
+    const pruned = await super.pruneExpired();
+    if (pruned > 0 && !this.degraded && this.pool) {
+      try {
+        await this.ready;
+        await this.pool.query('DELETE FROM catalog_resources WHERE key = ANY($1)', [expiredKeys]);
+      } catch (err) {
+        this._degrade(`pruneExpired failed: ${err.message}`);
+      }
+    }
+    return pruned;
+  }
+}
+
+/**
+ * Builds the catalog store from resolved config (#139).
+ *
+ * DATABASE_URL set -> Postgres-backed store (durable across restarts);
+ * unset -> the in-memory store, with a loud warning that catalogued resources
+ * do not survive a restart — mirroring buildSettlementStore.
+ *
+ * @param {object} config - resolved config from resolveConfig()
+ * @param {object} [options]
+ * @param {Function} [options.log] - logging sink
+ * @param {object} [options.pool] - shared pg Pool to use (a Vault-managed pool,
+ *   #127); absent means the store builds its own from config.databaseUrl
+ * @returns {MemoryCatalogStore|PostgresCatalogStore}
+ */
+export function buildCatalogStore(config = {}, { log = msg => console.warn(msg), pool } = {}) {
+  if (config.databaseUrl) return new PostgresCatalogStore(config, { warn: log, pool });
+  log(
+    '[CatalogStore] DATABASE_URL is unset — catalog entries are stored in-memory only and not durable across restarts.',
+  );
+  return new MemoryCatalogStore(config);
+}

--- a/src/server.js
+++ b/src/server.js
@@ -20,7 +20,7 @@ import { RedisRateLimiter } from './redis-rate-limit.js';
 import { CrdtRateLimitStore } from './crdt-rate-limit-store.js';
 import { createDistributedLock } from './distributed-lock.js';
 import { buildIdempotencyStore } from './idempotency.js';
-import { MemoryCatalogStore } from './catalog/memory.js';
+import { buildCatalogStore } from './catalog/postgres.js';
 import { createWebhookDispatcher } from './webhooks/dispatcher.js';
 import { FailoverHealthChecker } from './failover-health.js';
 import { createApp } from './app.js';
@@ -115,7 +115,10 @@ if (config.rateLimitStore === 'crdt' && config.databaseUrl) {
   });
   rateLimiter = new RateLimiter(config.rateLimits, rateLimitStore);
 }
-const catalog = new MemoryCatalogStore(config);
+const catalog = buildCatalogStore(config, {
+  log: msg => console.warn(`  ${msg}`),
+  pool: vaultDatabase?.pool,
+});
 // Off the hot path: a periodic sweep physically removes expired provisional
 // (verify-only) listings so they do not accumulate forever (#140).
 const catalogPruneTimer =

--- a/test/catalog-postgres.test.js
+++ b/test/catalog-postgres.test.js
@@ -1,0 +1,221 @@
+/**
+ * Durable Postgres catalog store (#139).
+ *
+ * The store must survive a restart, reuse the existing PostgreSQL dependency,
+ * keep embeddings warm without a wholesale re-embed, and — above all — an
+ * outage of the backing Postgres must never fail or delay a payment. No
+ * external service here: a fake pg Pool stands in for Postgres, and the same
+ * data Map handed to a second store instance simulates the durable bytes that
+ * would survive a process restart.
+ */
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { serve, stubFacilitator } from './helpers/app.js';
+import { MemoryCatalogStore } from '../src/catalog/memory.js';
+import { PostgresCatalogStore, buildCatalogStore } from '../src/catalog/postgres.js';
+
+/**
+ * Fake pg Pool — enough for PostgresCatalogStore's CREATE / UPSERT / SELECT /
+ * DELETE statements. `data` is the "durable" store: hand the same Map to a
+ * second store to observe what a restart would recover. `fail` simulates an
+ * unreachable database.
+ */
+function fakePool({ fail = false, data = new Map() } = {}) {
+  return {
+    data,
+    async query(sql, params = []) {
+      if (fail) throw new Error('connection refused');
+
+      if (/CREATE TABLE|CREATE INDEX/.test(sql)) return {};
+
+      if (/INSERT.*ON CONFLICT/s.test(sql)) {
+        const [key, resource, source, provisional, expiresAt, firstSeenAt, lastSeenAt, embedding] =
+          params;
+        data.set(key, {
+          key,
+          resource: JSON.parse(resource),
+          source,
+          provisional,
+          // node-postgres returns int8 as a string.
+          expires_at: expiresAt == null ? null : String(expiresAt),
+          first_seen_at: firstSeenAt,
+          last_seen_at: lastSeenAt,
+          embedding: embedding ? JSON.parse(embedding) : null,
+        });
+        return { rows: [data.get(key)] };
+      }
+
+      if (/SELECT/.test(sql)) {
+        return { rows: [...data.values()] };
+      }
+
+      if (/DELETE/.test(sql)) {
+        for (const key of params[0] ?? []) data.delete(key);
+        return {};
+      }
+
+      return {};
+    },
+    async end() {},
+    on() {},
+    release() {},
+    connect: async () => ({ query: async () => ({ rows: [] }), release() {} }),
+  };
+}
+
+function settledResource(url = 'http://api.ex/139') {
+  return {
+    type: 'http',
+    url,
+    serviceName: 'durable-catalog',
+    description: 'demo resource for #139',
+    scheme: 'exact',
+    network: 'stellar:testnet',
+    payTo: 'G000000000000000000000000000000000000000000000139',
+  };
+}
+
+const storeConfig = { maxResourcesPerPayTo: 50 };
+
+describe('PostgresCatalogStore (issue #139)', () => {
+  test('catalogued resources survive a restart', async () => {
+    const data = new Map();
+    const pool = fakePool({ data });
+    const storeA = new PostgresCatalogStore(storeConfig, { pool });
+    await storeA.ready;
+    await storeA.upsertResource(settledResource(), 'settle');
+
+    // A second store over the same durable bytes is a restarted process.
+    const storeB = new PostgresCatalogStore(storeConfig, { pool });
+    await storeB.ready;
+    const recovered = await storeB.getResource('http://api.ex/139');
+    assert.ok(recovered, 'resource must be present after restart');
+    assert.equal(recovered.source, 'settle');
+    assert.equal(recovered.provisional, false);
+    assert.equal(recovered.expires_at, null);
+    assert.ok(recovered.first_seen_at instanceof Date);
+    assert.doesNotReject(() => storeA.flush());
+
+    // And it is queryable exactly like a freshly-written one.
+    const { items } = await storeB.listResources({});
+    assert.equal(items.length, 1);
+    assert.equal(items[0].serviceName, 'durable-catalog');
+  });
+
+  test('a provisional verify-only listing survives restart with its expiry', async () => {
+    const data = new Map();
+    const pool = fakePool({ data });
+    const storeA = new PostgresCatalogStore(storeConfig, { pool });
+    await storeA.ready;
+    await storeA.upsertResource(settledResource('http://verify.ex/139'), 'verify');
+    const before = await storeA.getResource('http://verify.ex/139');
+    assert.equal(before.provisional, true);
+    assert.ok(before.expires_at > Date.now());
+
+    const storeB = new PostgresCatalogStore(storeConfig, { pool });
+    await storeB.ready;
+    const after = await storeB.getResource('http://verify.ex/139');
+    assert.equal(after.provisional, true);
+    assert.ok(
+      after.expires_at > Date.now(),
+      'verify-only listing must still know when it expires after a restart',
+    );
+    assert.equal(after.source, 'verify');
+  });
+
+  test('hydration preserves the per-payTo cap for restored rows', async () => {
+    const data = new Map();
+    const pool = fakePool({ data });
+    const storeA = new PostgresCatalogStore({ ...storeConfig, maxResourcesPerPayTo: 2 }, { pool });
+    await storeA.ready;
+    await storeA.upsertResource(settledResource('http://api.ex/a'), 'settle');
+    await storeA.upsertResource(settledResource('http://api.ex/b'), 'settle');
+
+    const storeB = new PostgresCatalogStore({ ...storeConfig, maxResourcesPerPayTo: 2 }, { pool });
+    await storeB.ready;
+    await assert.rejects(
+      () => storeB.upsertResource(settledResource('http://api.ex/c')),
+      err => err?.code === 'maximum_resources_per_payto_exceeded',
+    );
+  });
+
+  test('pruneExpired also removes the durable rows', async () => {
+    const data = new Map();
+    const pool = fakePool({ data });
+    const store = new PostgresCatalogStore({ ...storeConfig, catalogVerifyTtlMs: 50 }, { pool });
+    await store.ready;
+    await store.upsertResource(settledResource('http://verify.ex/prune'), 'verify');
+    assert.equal(data.size, 1);
+    await new Promise(r => setTimeout(r, 70));
+    const pruned = await store.pruneExpired();
+    assert.equal(pruned, 1);
+    assert.equal(data.size, 0, 'the durable row must be pruned too');
+  });
+
+  test('an outage degrades without failing catalog writes or reads', async () => {
+    const pool = fakePool({ fail: true });
+    const store = new PostgresCatalogStore(storeConfig, { pool });
+    await store.ready;
+    assert.equal(store.degraded, true);
+
+    const entry = await store.upsertResource(settledResource(), 'settle');
+    assert.ok(entry, 'upsert must succeed from memory during an outage');
+    assert.equal((await store.getResource('http://api.ex/139')).serviceName, 'durable-catalog');
+  });
+
+  test('an outage cannot fail a payment over HTTP', async () => {
+    const store = new PostgresCatalogStore(storeConfig, { pool: fakePool({ fail: true }) });
+    await store.ready;
+    const app = await serve({
+      catalog: store,
+      facilitator: stubFacilitator({
+        settle: async () => ({ success: true, transaction: 'tx', network: 'stellar:testnet' }),
+      }),
+    });
+    try {
+      const body = {
+        paymentPayload: {
+          x402Version: 2,
+          scheme: 'exact',
+          network: 'stellar:testnet',
+          resource: {
+            url: 'http://api.ex/outage',
+            serviceName: 'outage-demo',
+            description: 'demo',
+          },
+          extensions: {
+            bazaar: {
+              info: { input: { type: 'http', method: 'GET' }, scheme: 'exact' },
+              schema: { type: 'object' },
+              routeTemplate: '/outage',
+            },
+          },
+        },
+        paymentRequirements: {
+          scheme: 'exact',
+          network: 'stellar:testnet',
+          asset: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
+          maxAmountRequired: '1000',
+          payTo: 'GCALKSGAZRJLSUEJT3M5W6LN4R7XQOLIRCOS6ZA6EDZVTZDBIIPPFKJ6',
+        },
+      };
+      const res = await app.post('/settle', body);
+      assert.equal(res.status, 200, 'settlement must succeed while the catalog store is down');
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('buildCatalogStore selects Postgres only when DATABASE_URL is set', () => {
+    const warnings = [];
+    const mem = buildCatalogStore({}, { log: msg => warnings.push(msg) });
+    assert.ok(mem instanceof MemoryCatalogStore);
+    assert.ok(warnings.some(w => w.includes('DATABASE_URL is unset')));
+
+    const pg = buildCatalogStore(
+      { databaseUrl: 'postgres://localhost/x402' },
+      { pool: fakePool(), log: () => {} },
+    );
+    assert.ok(pg instanceof PostgresCatalogStore);
+  });
+});


### PR DESCRIPTION
Closes #139

---

## What

Catalogued resources (discovery entries from `/verify` and `/settle`) currently live in a process-local Map and are lost on every restart. This adds a durable backing store behind the exact same catalog interface (`upsertResource` / `getResource` / `listResources` / `search` / `pruneExpired`) so listings survive a restart.

## Storage choice and why

PostgreSQL — it is already a hard dependency of the service (`DATABASE_URL`) and already backs the settlement, idempotency, outbox and rate-limit stores. Introducing a second datastore for the catalog would be a new operational burden for no benefit, and reusing the shared (Vault-managed when present) pool keeps one connection profile. The in-memory store remains the default when `DATABASE_URL` is unset, so tests and local dev run with no external service.

## Design decisions (the open questions from the issue, answered explicitly)

- **Interface preserved**: `PostgresCatalogStore extends MemoryCatalogStore`; no route or caller change, the store slots in behind the interface.
- **Postgres is the source of truth, memory is a boot-hydrated cache**: writes persist the row AND the in-memory copy; at boot all rows hydrate into memory. `/discovery` reads (list/search/get) never wait on the database and behave identically to the memory store.
- **Embeddings: stored alongside the row (write-behind), not recomputed on load**. The existing background embed writes the vector back to Postgres as soon as it lands (an `_afterEmbedding` hook), so semantic search is warm immediately after a restart and needs no wholesale re-embed — re-embedding a full catalog on every boot would hammer the embedding provider for no reason. Rows that predate embeddings (or a model change) are re-embedded through the same background path.
- **Outage safety**: any Postgres error degrades the store to process-local memory with a single loud warning — a catalog-store outage can never fail or delay a payment. Cataloging already runs off the settlement hot path (`processCataloging`), and writes degrade open. An HTTP-level test pins this: `/settle` returns 200 while the backing store is down.
- **Pruning is durable**: `pruneExpired` deletes expired provisional rows from Postgres too.

## Tests

`test/catalog-postgres.test.js` runs against a fake pg Pool — no external service, per repo convention. Covers restart survival (a second store over the same durable bytes), provisional expiry retention across restart, per-payTo cap hydration, durable pruning, outage degradation, payment-while-outage, and store selection.

`migrations/006_catalog_resources.js` creates the table; the store also self-creates schema on boot (`_ensureSchema`), matching the settlement store.