### PR TITLE
implemented

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,6 +114,10 @@ PORT=3402
 # KAFKA_CLIENT_ID=x402-facilitator-stellar
 # KAFKA_WEBHOOK_TOPIC=x402-webhook-delivery
 # KAFKA_WEBHOOK_GROUP_ID=x402-webhook-dispatchers
+# Broker-level DLQ topic: a message the consumer could not deliver (after
+# exhausting its own retries) is republished here in addition to the
+# Postgres dead_letters table. Unset means no broker-side DLQ topic.
+# KAFKA_WEBHOOK_DLQ_TOPIC=x402-webhook-delivery.dlq
 # Default webhook receiver; individual events may carry their own url.
 # WEBHOOK_URL=
 
@@ -124,6 +128,21 @@ PORT=3402
 # cannot lose the notification. Requires the 004_outbox_events migration.
 # How often the outbox worker polls for pending events (ms).
 # OUTBOX_POLL_INTERVAL_MS=5000
+
+# ── Dead-letter queue (#DLQ) ───────────────────────────────────────────────
+# With DATABASE_URL set, a message that exhausts its normal delivery retries
+# (outbox worker, Kafka consumer, or direct fire-and-forget) is recorded in
+# the dead_letters table (migration 007) instead of silently dropped. A
+# background worker retries it with its own, slower exponential backoff;
+# GET/POST/DELETE /admin/dlq* let an operator inspect, replay, or discard one.
+# How often the DLQ worker polls for due retries (ms).
+# DLQ_POLL_INTERVAL_MS=10000
+# DLQ retry attempts before a message goes `exhausted` (needs an operator).
+# DLQ_MAX_RETRY_ATTEMPTS=5
+# First backoff step for DLQ retries; doubles per attempt (ms).
+# DLQ_BASE_BACKOFF_MS=30000
+# pending+exhausted depth that trips the x402_dlq_depth alert; 0 disables it.
+# DLQ_ALERT_THRESHOLD=50
 
 # ── Horizon/RPC connection pooling and circuit breaker (#120) ─────────────
 # Max keep-alive sockets per origin.

--- a/migrations/007_dead_letters.js
+++ b/migrations/007_dead_letters.js
@@ -1,0 +1,55 @@
+/**
+ * 007: Dead-letter queue for poisoned webhook messages.
+ *
+ * A message lands here once its normal delivery path (the outbox worker, the
+ * Kafka consumer group, or the direct fire-and-forget path) has exhausted its
+ * own retry budget (see src/webhooks/dispatcher.js's `deliverWebhook` and
+ * src/outbox/worker.js). Before this table existed, that message was either
+ * silently dropped (direct/Kafka paths) or stuck as an unreachable `failed`
+ * row with no operator surface (outbox path).
+ *
+ * `next_retry_at` drives a second, independent backoff schedule (src/dlq/worker.js)
+ * separate from the original delivery backoff — a message here has already
+ * proven the receiver was down for the original budget, so retries here are
+ * slower and bounded by DLQ_MAX_RETRY_ATTEMPTS before landing in `exhausted`,
+ * where only an operator (via the replay/discard API) can move it.
+ */
+
+export const up = pgm => {
+  pgm.createTable('dead_letters', {
+    id: 'id',
+    // Correlates back to the originating outbox event_id or Kafka message key
+    // when one exists; a generated id for the direct-delivery path.
+    message_id: { type: 'TEXT', notNull: true },
+    // Which delivery path dead-lettered this message: 'outbox' | 'kafka-consumer' | 'direct'.
+    source: { type: 'TEXT', notNull: true },
+    type: { type: 'TEXT' },
+    payload: { type: 'JSONB', notNull: true },
+    error: { type: 'TEXT' },
+    // Delivery attempts made on the original path before it gave up.
+    delivery_attempts: { type: 'INT', notNull: true, default: 0 },
+    // Retries attempted from this table by the DLQ worker.
+    dlq_attempts: { type: 'INT', notNull: true, default: 0 },
+    status: {
+      type: 'TEXT',
+      notNull: true,
+      default: 'pending',
+      check: "status IN ('pending', 'exhausted', 'resolved', 'discarded')",
+    },
+    next_retry_at: { type: 'TIMESTAMPTZ', notNull: true, default: pgm.func('now()') },
+    claimed_at: { type: 'TIMESTAMPTZ' },
+    first_failed_at: { type: 'TIMESTAMPTZ', notNull: true, default: pgm.func('now()') },
+    last_failed_at: { type: 'TIMESTAMPTZ', notNull: true, default: pgm.func('now()') },
+    resolved_at: { type: 'TIMESTAMPTZ' },
+    created_at: { type: 'TIMESTAMPTZ', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'TIMESTAMPTZ', notNull: true, default: pgm.func('now()') },
+  });
+
+  // The DLQ worker's poll query filters on exactly this.
+  pgm.createIndex('dead_letters', ['status', 'next_retry_at']);
+  pgm.createIndex('dead_letters', 'message_id');
+};
+
+export const down = pgm => {
+  pgm.dropTable('dead_letters');
+};

--- a/src/app.js
+++ b/src/app.js
@@ -47,6 +47,7 @@ import { lockKeyFor } from './distributed-lock.js';
 import { requestState } from './request-state.js';
 import { signerMetrics } from './metrics.js';
 import { buildSettlementStore } from './store/index.js';
+import { registerDlqRoutes } from './dlq/routes.js';
 
 /** 256kb body cap, carried over unchanged from the Express transport. */
 const BODY_LIMIT_BYTES = 256 * 1024;
@@ -115,6 +116,9 @@ export async function createApp(
     webhooks = null,
     failoverHealth = null,
     settlementStore = extras.settlementStore ?? buildSettlementStore(config),
+    // DLQ operator API (#DLQ): { store: DeadLetterStore, publish, retryOptions }.
+    // Absent (no DATABASE_URL) means the routes are simply not registered.
+    dlq = null,
   } = extras;
 
   // Observability collaborators. Both are injectable so tests can capture the
@@ -390,7 +394,7 @@ export async function createApp(
     };
   }
 
-  function preflight(policy) {
+  function preflight(policy, methods) {
     return async (req, reply) => {
       cors(policy)(req, reply);
       // Answer the preflight even when the origin is not granted: the 204
@@ -398,7 +402,7 @@ export async function createApp(
       // which is the enforcement point, not the preflight status.
       reply.header(
         'Access-Control-Allow-Methods',
-        policy === 'public' ? 'GET, OPTIONS' : 'POST, OPTIONS',
+        methods ?? (policy === 'public' ? 'GET, OPTIONS' : 'POST, OPTIONS'),
       );
       reply.header('Access-Control-Allow-Headers', 'Authorization, Content-Type');
       reply.header('Access-Control-Max-Age', '600');
@@ -1393,6 +1397,22 @@ export async function createApp(
       return reply.code(500).send({ error: 'internal_error', reason: 'internal_error' });
     }
   });
+
+  /**
+   * DLQ operator API (view/replay/discard poisoned webhook messages).
+   * Registered only when a DeadLetterStore is available (DATABASE_URL set).
+   */
+  if (dlq) {
+    registerDlqRoutes(app, {
+      dlq: dlq.store,
+      publish: dlq.publish,
+      requireApiKeyStrict,
+      cors,
+      preflight,
+      audit,
+      retryOptions: dlq.retryOptions,
+    });
+  }
 
   /**
    * Preflight routes (#76).

--- a/src/config.js
+++ b/src/config.js
@@ -366,10 +366,25 @@ export function resolveConfig(env = process.env) {
       clientId: env.KAFKA_CLIENT_ID ?? 'x402-facilitator-stellar',
       topic: env.KAFKA_WEBHOOK_TOPIC ?? 'x402-webhook-delivery',
       groupId: env.KAFKA_WEBHOOK_GROUP_ID ?? 'x402-webhook-dispatchers',
+      /** Broker-level DLQ topic (#DLQ). Unset means no broker-side DLQ topic. */
+      dlqTopic: env.KAFKA_WEBHOOK_DLQ_TOPIC || null,
     },
 
     /** Default webhook receiver (#117); events may carry their own url. */
     webhookUrl: env.WEBHOOK_URL || null,
+
+    /**
+     * Dead-letter queue (#DLQ). Only relevant when DATABASE_URL is set (the
+     * dead_letters table lives in Postgres, migration 007) — without it,
+     * exhausted messages are still logged and dropped, the pre-DLQ behaviour.
+     */
+    dlq: {
+      pollIntervalMs: Number(env.DLQ_POLL_INTERVAL_MS ?? 10_000),
+      maxRetryAttempts: Number(env.DLQ_MAX_RETRY_ATTEMPTS ?? 5),
+      baseBackoffMs: Number(env.DLQ_BASE_BACKOFF_MS ?? 30_000),
+      /** pending+exhausted depth that trips the alert; 0 disables the check. */
+      alertThreshold: Number(env.DLQ_ALERT_THRESHOLD ?? 50),
+    },
 
     /**
      * Caller authentication. Unset means open, which is correct for a free

--- a/src/dlq/routes.js
+++ b/src/dlq/routes.js
@@ -65,7 +65,8 @@ export function registerDlqRoutes(
         return reply.code(400).send({ error: 'invalid_request', reason: 'invalid_id' });
       }
       const row = await dlq.get(id);
-      if (!row) return reply.code(404).send({ error: 'not_found', reason: 'dead_letter_not_found' });
+      if (!row)
+        return reply.code(404).send({ error: 'not_found', reason: 'dead_letter_not_found' });
       return reply.send({ ok: true, deadLetter: row });
     },
   );
@@ -84,7 +85,8 @@ export function registerDlqRoutes(
         return reply.code(400).send({ error: 'invalid_request', reason: 'invalid_id' });
       }
       const row = await dlq.get(id);
-      if (!row) return reply.code(404).send({ error: 'not_found', reason: 'dead_letter_not_found' });
+      if (!row)
+        return reply.code(404).send({ error: 'not_found', reason: 'dead_letter_not_found' });
       if (row.status === 'discarded') {
         return reply.code(409).send({ error: 'conflict', reason: 'already_discarded' });
       }
@@ -117,7 +119,8 @@ export function registerDlqRoutes(
         return reply.code(400).send({ error: 'invalid_request', reason: 'invalid_id' });
       }
       const row = await dlq.get(id);
-      if (!row) return reply.code(404).send({ error: 'not_found', reason: 'dead_letter_not_found' });
+      if (!row)
+        return reply.code(404).send({ error: 'not_found', reason: 'dead_letter_not_found' });
 
       await dlq.discard(id);
       audit('dlq_discard', { actor: req.keyId, dead_letter_id: id, message_id: row.message_id });

--- a/src/dlq/routes.js
+++ b/src/dlq/routes.js
@@ -1,0 +1,143 @@
+/**
+ * Operator API for the dead-letter queue: view, replay, or discard poisoned
+ * webhook messages (acceptance criterion: "Operator API allows manual replay
+ * or deletion of messages").
+ *
+ * Registered from createApp only when a DeadLetterStore is supplied (Postgres
+ * configured) — mirrors how webhooks/distributedLock are optional collaborators
+ * threaded through `extras`. Every route requires a real API key
+ * (requireApiKeyStrict, the same gate /usage uses) even in open mode: this
+ * surface reads and mutates in-flight settlement notifications, which is not
+ * data an unauthenticated caller should see or discard.
+ */
+import { attemptRedelivery } from './worker.js';
+
+/**
+ * @param {import('fastify').FastifyInstance} app
+ * @param {object} deps
+ * @param {import('./store.js').DeadLetterStore} deps.dlq
+ * @param {(record: object) => Promise<unknown>} deps.publish - redelivery function
+ * @param {Function} deps.requireApiKeyStrict
+ * @param {Function} deps.cors
+ * @param {Function} deps.preflight
+ * @param {Function} deps.audit
+ * @param {object} deps.retryOptions - maxDlqAttempts/baseBackoffMs, passed through to a manual replay
+ */
+export function registerDlqRoutes(
+  app,
+  { dlq, publish, requireApiKeyStrict, cors, preflight, audit, retryOptions },
+) {
+  /**
+   * GET /admin/dlq — list dead letters, newest first.
+   * Query: status (pending|exhausted|resolved|discarded), limit, offset.
+   */
+  app.get(
+    '/admin/dlq',
+    { onRequest: cors('authenticated'), preHandler: requireApiKeyStrict },
+    async (req, reply) => {
+      const { status } = req.query;
+      const VALID_STATUSES = new Set(['pending', 'exhausted', 'resolved', 'discarded']);
+      if (status && !VALID_STATUSES.has(status)) {
+        return reply.code(400).send({ error: 'invalid_request', reason: 'invalid_status' });
+      }
+
+      let limit = parseInt(req.query.limit, 10);
+      if (isNaN(limit)) limit = 50;
+      let offset = parseInt(req.query.offset, 10);
+      if (isNaN(offset)) offset = 0;
+
+      const result = await dlq.list({ status: status ?? null, limit, offset });
+      return reply.send({
+        ok: true,
+        items: result.items,
+        pagination: { limit, offset, total: result.total },
+      });
+    },
+  );
+
+  /** GET /admin/dlq/:id — a single dead letter. */
+  app.get(
+    '/admin/dlq/:id',
+    { onRequest: cors('authenticated'), preHandler: requireApiKeyStrict },
+    async (req, reply) => {
+      const id = Number(req.params.id);
+      if (!Number.isInteger(id)) {
+        return reply.code(400).send({ error: 'invalid_request', reason: 'invalid_id' });
+      }
+      const row = await dlq.get(id);
+      if (!row) return reply.code(404).send({ error: 'not_found', reason: 'dead_letter_not_found' });
+      return reply.send({ ok: true, deadLetter: row });
+    },
+  );
+
+  /**
+   * POST /admin/dlq/:id/replay — immediate redelivery attempt, outside the
+   * backoff schedule. Resolves synchronously so an operator sees the outcome
+   * of the action they took rather than having to poll.
+   */
+  app.post(
+    '/admin/dlq/:id/replay',
+    { onRequest: cors('authenticated'), preHandler: requireApiKeyStrict },
+    async (req, reply) => {
+      const id = Number(req.params.id);
+      if (!Number.isInteger(id)) {
+        return reply.code(400).send({ error: 'invalid_request', reason: 'invalid_id' });
+      }
+      const row = await dlq.get(id);
+      if (!row) return reply.code(404).send({ error: 'not_found', reason: 'dead_letter_not_found' });
+      if (row.status === 'discarded') {
+        return reply.code(409).send({ error: 'conflict', reason: 'already_discarded' });
+      }
+      if (row.status === 'resolved') {
+        return reply.code(409).send({ error: 'conflict', reason: 'already_resolved' });
+      }
+
+      const result = await attemptRedelivery({ dlq, row, publish, retryOptions });
+      audit('dlq_replay', {
+        actor: req.keyId,
+        dead_letter_id: id,
+        message_id: row.message_id,
+        outcome: result.delivered ? 'delivered' : 'failed',
+      });
+
+      if (result.delivered) {
+        return reply.send({ ok: true, status: 'resolved' });
+      }
+      return reply.code(502).send({ ok: false, status: 'redelivery_failed', error: result.error });
+    },
+  );
+
+  /** DELETE /admin/dlq/:id — permanently discard; never retried again. */
+  app.delete(
+    '/admin/dlq/:id',
+    { onRequest: cors('authenticated'), preHandler: requireApiKeyStrict },
+    async (req, reply) => {
+      const id = Number(req.params.id);
+      if (!Number.isInteger(id)) {
+        return reply.code(400).send({ error: 'invalid_request', reason: 'invalid_id' });
+      }
+      const row = await dlq.get(id);
+      if (!row) return reply.code(404).send({ error: 'not_found', reason: 'dead_letter_not_found' });
+
+      await dlq.discard(id);
+      audit('dlq_discard', { actor: req.keyId, dead_letter_id: id, message_id: row.message_id });
+      return reply.send({ ok: true, status: 'discarded' });
+    },
+  );
+
+  app.options(
+    '/admin/dlq',
+    { onRequest: cors('authenticated') },
+    preflight('authenticated', 'GET, OPTIONS'),
+  );
+  app.options(
+    '/admin/dlq/:id',
+    { onRequest: cors('authenticated') },
+    preflight('authenticated', 'GET, DELETE, OPTIONS'),
+  );
+  app.options(
+    '/admin/dlq/:id/replay',
+    { onRequest: cors('authenticated') },
+    preflight('authenticated', 'POST, OPTIONS'),
+  );
+}

--- a/src/dlq/store.js
+++ b/src/dlq/store.js
@@ -1,0 +1,186 @@
+/**
+ * Postgres-backed dead-letter store.
+ *
+ * The canonical DLQ regardless of which delivery path a message fell out of
+ * (outbox worker, Kafka consumer group, or the direct fire-and-forget path —
+ * see the callers in src/outbox/worker.js and src/webhooks/dispatcher.js).
+ * Centralising it here rather than per-path is what lets the operator API and
+ * the retry worker stay single implementations instead of three.
+ *
+ * STATE MACHINE. `pending` -> (retry worker attempts redelivery) -> `resolved`
+ * on success, or back to `pending` with a later `next_retry_at` on failure,
+ * until `dlq_attempts` hits the configured ceiling and it becomes `exhausted`.
+ * From `pending` or `exhausted` an operator can `discard` (permanent) or force
+ * an immediate `replay` outside the backoff schedule.
+ */
+
+export const DEAD_LETTERS_TABLE_SQL = `
+  CREATE TABLE IF NOT EXISTS dead_letters (
+      id BIGSERIAL PRIMARY KEY,
+      message_id TEXT NOT NULL,
+      source TEXT NOT NULL,
+      type TEXT,
+      payload JSONB NOT NULL,
+      error TEXT,
+      delivery_attempts INT NOT NULL DEFAULT 0,
+      dlq_attempts INT NOT NULL DEFAULT 0,
+      status TEXT NOT NULL DEFAULT 'pending'
+          CHECK (status IN ('pending', 'exhausted', 'resolved', 'discarded')),
+      next_retry_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      claimed_at TIMESTAMPTZ,
+      first_failed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      last_failed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      resolved_at TIMESTAMPTZ,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+  );
+  CREATE INDEX IF NOT EXISTS idx_dead_letters_retry ON dead_letters(status, next_retry_at);
+  CREATE INDEX IF NOT EXISTS idx_dead_letters_message_id ON dead_letters(message_id);
+`;
+
+export class DeadLetterStore {
+  /**
+   * @param {object} pool - pg Pool (or a test double with the same surface)
+   * @param {object} [options]
+   * @param {Function} [options.warn]
+   */
+  constructor(pool, { warn = msg => console.warn(msg) } = {}) {
+    this.pool = pool;
+    this.warn = warn;
+    this.ready = this._ensureTable();
+  }
+
+  async _ensureTable() {
+    await this.pool.query(DEAD_LETTERS_TABLE_SQL);
+  }
+
+  /**
+   * Records a message whose delivery path exhausted its own retry budget.
+   *
+   * @param {object} event
+   * @param {string} event.messageId
+   * @param {string} event.source - 'outbox' | 'kafka-consumer' | 'direct'
+   * @param {string} [event.type]
+   * @param {object} event.payload
+   * @param {string} [event.error]
+   * @param {number} [event.deliveryAttempts]
+   * @returns {Promise<number>} the new row's id
+   */
+  async insert({ messageId, source, type = null, payload, error = null, deliveryAttempts = 0 }) {
+    await this.ready;
+    const { rows } = await this.pool.query(
+      `INSERT INTO dead_letters (message_id, source, type, payload, error, delivery_attempts)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING id`,
+      [messageId, source, type, JSON.stringify(payload), error, deliveryAttempts],
+    );
+    return rows[0].id;
+  }
+
+  /**
+   * Claims up to `limit` rows due for a DLQ retry: `pending` rows whose
+   * `next_retry_at` has passed, plus claims whose lease expired (a worker
+   * that died mid-retry). Mirrors OutboxStore.claimBatch's `FOR UPDATE SKIP
+   * LOCKED` pattern so multiple replicas never race the same row.
+   */
+  async claimDue({ limit = 50, leaseMs = 60_000 } = {}) {
+    await this.ready;
+    const { rows } = await this.pool.query(
+      `UPDATE dead_letters SET
+         claimed_at = NOW(),
+         updated_at = NOW()
+       WHERE id IN (
+         SELECT id FROM dead_letters
+         WHERE status = 'pending'
+           AND next_retry_at <= NOW()
+           AND (claimed_at IS NULL OR claimed_at < NOW() - ($2::int * INTERVAL '1 millisecond'))
+         ORDER BY next_retry_at
+         LIMIT $1
+         FOR UPDATE SKIP LOCKED
+       )
+       RETURNING id, message_id, source, type, payload, error, delivery_attempts, dlq_attempts`,
+      [limit, leaseMs],
+    );
+    return rows;
+  }
+
+  /** A DLQ retry delivered successfully — terminal, kept for the audit trail. */
+  async markResolved(id) {
+    await this.pool.query(
+      `UPDATE dead_letters SET
+         status = 'resolved',
+         resolved_at = NOW(),
+         claimed_at = NULL,
+         updated_at = NOW()
+       WHERE id = $1`,
+      [id],
+    );
+  }
+
+  /**
+   * A DLQ retry failed: dlq_attempts++, exponential backoff on next_retry_at,
+   * `exhausted` once maxDlqAttempts is reached (an operator must act from there).
+   */
+  async markRetryFailed(id, error, { maxDlqAttempts = 5, baseBackoffMs = 30_000 } = {}) {
+    await this.pool.query(
+      `UPDATE dead_letters SET
+         dlq_attempts = dlq_attempts + 1,
+         error = $2,
+         last_failed_at = NOW(),
+         status = CASE WHEN dlq_attempts + 1 >= $3 THEN 'exhausted' ELSE 'pending' END,
+         next_retry_at = NOW() + ($4::float * POWER(2, dlq_attempts) * INTERVAL '1 millisecond'),
+         claimed_at = NULL,
+         updated_at = NOW()
+       WHERE id = $1`,
+      [id, String(error ?? '').slice(0, 2000), maxDlqAttempts, baseBackoffMs],
+    );
+  }
+
+  async get(id) {
+    await this.ready;
+    const { rows } = await this.pool.query(`SELECT * FROM dead_letters WHERE id = $1`, [id]);
+    return rows[0] ?? null;
+  }
+
+  /** Operator action: permanently discard a message — never retried again. */
+  async discard(id) {
+    await this.pool.query(
+      `UPDATE dead_letters SET status = 'discarded', updated_at = NOW() WHERE id = $1`,
+      [id],
+    );
+  }
+
+  /**
+   * Paginated listing for the operator API, newest first. `status` filters to
+   * one state; omitted means every state.
+   */
+  async list({ status = null, limit = 50, offset = 0 } = {}) {
+    await this.ready;
+    const clampedLimit = Math.min(Math.max(1, limit), 200);
+    const clampedOffset = Math.max(0, offset);
+    const params = status ? [status, clampedLimit, clampedOffset] : [clampedLimit, clampedOffset];
+    const where = status ? 'WHERE status = $1' : '';
+    const { rows } = await this.pool.query(
+      `SELECT * FROM dead_letters ${where}
+       ORDER BY created_at DESC
+       LIMIT $${status ? 2 : 1} OFFSET $${status ? 3 : 2}`,
+      params,
+    );
+    const { rows: countRows } = await this.pool.query(
+      `SELECT count(*)::int AS count FROM dead_letters ${where}`,
+      status ? [status] : [],
+    );
+    return { items: rows, total: countRows[0]?.count ?? 0 };
+  }
+
+  /** Depth per status — the DLQ_depth gauge and the alert-threshold check read this. */
+  async countByStatus() {
+    await this.ready;
+    const { rows } = await this.pool.query(
+      `SELECT status, count(*)::int AS count FROM dead_letters GROUP BY status`,
+    );
+    const counts = { pending: 0, exhausted: 0, resolved: 0, discarded: 0 };
+    for (const row of rows) counts[row.status] = row.count;
+    return counts;
+  }
+}

--- a/src/dlq/worker.js
+++ b/src/dlq/worker.js
@@ -1,0 +1,161 @@
+/**
+ * DLQ retry worker.
+ *
+ * A message here already exhausted its original delivery budget (see
+ * src/webhooks/dispatcher.js and src/outbox/worker.js), so this runs a
+ * second, slower, independent backoff schedule against the same receiver —
+ * useful for the outage-that-eventually-clears case without operator
+ * involvement, while `DLQ_MAX_RETRY_ATTEMPTS` bounds how long it tries before
+ * requiring a human (`exhausted`, see the operator API in src/dlq/routes.js).
+ *
+ * Shaped identically to src/outbox/worker.js on purpose: same claim/publish/
+ * mark cycle, same plain-interval runner, so the two are recognisably one
+ * pattern applied twice rather than two designs.
+ */
+
+/**
+ * Attempts one redelivery of a dead-lettered record. Shared by the background
+ * poll loop and the operator API's manual "replay now" action so both paths
+ * mark state identically.
+ *
+ * @param {object} options
+ * @param {import('./store.js').DeadLetterStore} options.dlq
+ * @param {object} row - a row from claimDue()/get(), carrying id and payload
+ * @param {(record: object) => Promise<unknown>} options.publish
+ * @param {object} [options.retryOptions] - maxDlqAttempts/baseBackoffMs, see markRetryFailed
+ * @returns {Promise<{delivered: boolean, error?: string}>}
+ */
+export async function attemptRedelivery({ dlq, row, publish, retryOptions }) {
+  try {
+    await publish(row.payload);
+    await dlq.markResolved(row.id);
+    return { delivered: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await dlq.markRetryFailed(row.id, message, retryOptions);
+    return { delivered: false, error: message };
+  }
+}
+
+/**
+ * Runs one poll/retry cycle, then reports the current depth so the caller can
+ * drive the alert-threshold check and the metrics gauge off one query.
+ *
+ * @param {object} options
+ * @param {import('./store.js').DeadLetterStore} options.dlq
+ * @param {(record: object) => Promise<unknown>} options.publish
+ * @param {number} [options.maxDlqAttempts]
+ * @param {number} [options.baseBackoffMs]
+ * @param {number} [options.batchSize]
+ * @param {number} [options.leaseMs]
+ * @param {(msg: string) => void} [options.log]
+ * @returns {Promise<{claimed: number, resolved: number, failed: number, depth: {pending: number, exhausted: number, resolved: number, discarded: number}}>}
+ */
+export async function pollDlqOnce({
+  dlq,
+  publish,
+  maxDlqAttempts = 5,
+  baseBackoffMs = 30_000,
+  batchSize = 50,
+  leaseMs = 60_000,
+  log = () => {},
+}) {
+  let rows;
+  try {
+    rows = await dlq.claimDue({ limit: batchSize, leaseMs });
+  } catch (err) {
+    log(`[DLQ] poll failed: ${err.message}`);
+    return { claimed: 0, resolved: 0, failed: 0, depth: null };
+  }
+
+  let resolved = 0;
+  let failed = 0;
+  for (const row of rows) {
+    const result = await attemptRedelivery({
+      dlq,
+      row,
+      publish,
+      retryOptions: { maxDlqAttempts, baseBackoffMs },
+    });
+    if (result.delivered) {
+      resolved++;
+    } else {
+      failed++;
+      log(
+        `[DLQ] retry failed for message ${row.message_id} (attempt ${row.dlq_attempts + 1}/${maxDlqAttempts}): ${result.error}`,
+      );
+    }
+  }
+
+  const depth = await dlq.countByStatus().catch(() => null);
+  return { claimed: rows.length, resolved, failed, depth };
+}
+
+/**
+ * Starts the periodic DLQ worker. Also owns the depth-alert check (#DLQ):
+ * when `pending + exhausted` crosses `alertThreshold`, `onAlert` fires — at
+ * most once per breach (it resets once depth drops back under threshold) so a
+ * stuck queue does not spam the sink every poll interval.
+ *
+ * @param {object} options - same as pollDlqOnce, plus:
+ * @param {number} [options.intervalMs]
+ * @param {number} [options.alertThreshold] - 0 disables the check
+ * @param {(depth: {pending: number, exhausted: number}) => void} [options.onAlert]
+ * @param {(gauge: {status: string, value: number}) => void} [options.onDepth] - metrics sink
+ */
+export function startDlqWorker({
+  intervalMs = 10_000,
+  alertThreshold = 0,
+  onAlert = depth =>
+    console.warn(
+      `[DLQ] ALERT: depth ${depth.pending + depth.exhausted} exceeds threshold (pending=${depth.pending}, exhausted=${depth.exhausted})`,
+    ),
+  onDepth = null,
+  ...pollOptions
+}) {
+  let timer = null;
+  let running = false;
+  let stopped = false;
+  let alerting = false;
+
+  const tick = async () => {
+    if (stopped) return;
+    try {
+      const { depth } = await pollDlqOnce(pollOptions);
+      if (!depth) return;
+
+      onDepth?.({ status: 'pending', value: depth.pending });
+      onDepth?.({ status: 'exhausted', value: depth.exhausted });
+
+      if (alertThreshold > 0) {
+        const actionable = depth.pending + depth.exhausted;
+        if (actionable > alertThreshold && !alerting) {
+          alerting = true;
+          onAlert(depth);
+        } else if (actionable <= alertThreshold) {
+          alerting = false;
+        }
+      }
+    } catch (err) {
+      pollOptions.log?.(`[DLQ] loop error: ${err.message}`);
+    }
+  };
+
+  return {
+    start() {
+      if (running || stopped) return this;
+      running = true;
+      timer = globalThis.setInterval(() => void tick(), intervalMs);
+      timer.unref?.();
+      return this;
+    },
+    async stop() {
+      stopped = true;
+      running = false;
+      if (timer) globalThis.clearInterval(timer);
+      timer = null;
+    },
+    /** Runs one cycle immediately — also what tests drive. */
+    tick,
+  };
+}

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -14,6 +14,8 @@
  *   x402_settlement_fee_stroops histogram{network}
  *   x402_rpc_retries_total{code}
  *   x402_signer_inflight{network,signer}
+ *   x402_dlq_depth{status} - dead-letter queue depth; alert if pending+exhausted
+ *     exceeds DLQ_ALERT_THRESHOLD (see src/dlq/worker.js)
  */
 
 const DURATION_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10];
@@ -173,6 +175,11 @@ export function createMetrics() {
     'In-flight settlements per signer — the sequence-contention signal (#9).',
     ['network', 'signer'],
   );
+  const dlqDepth = new Gauge(
+    'x402_dlq_depth',
+    'Dead-letter queue depth by status (pending, exhausted). Alert when pending+exhausted exceeds DLQ_ALERT_THRESHOLD.',
+    ['status'],
+  );
 
   return {
     incRequests: labels => requests.inc(labels),
@@ -183,9 +190,10 @@ export function createMetrics() {
     incRpcRetry: ({ code }) => rpcRetries.inc({ code: code ?? 'unknown' }),
     setSignerInflight: ({ network, signer, value }) =>
       signerInflight.set({ network, signer }, value),
+    setDlqDepth: ({ status, value }) => dlqDepth.set({ status }, value),
 
     render: () =>
-      [requests, duration, settlements, fee, rpcRetries, signerInflight]
+      [requests, duration, settlements, fee, rpcRetries, signerInflight, dlqDepth]
         .map(m => m.render())
         .join(''),
   };

--- a/src/outbox/worker.js
+++ b/src/outbox/worker.js
@@ -23,6 +23,9 @@
  * @param {number} [options.maxAttempts] - publish attempts before a row goes `failed`
  * @param {number} [options.batchSize]
  * @param {number} [options.leaseMs] - claim lease before a stuck row is re-claimed
+ * @param {import('../dlq/store.js').DeadLetterStore} [options.dlq] - when given, a
+ *   row that exhausts maxAttempts is also recorded as a dead letter (DLQ) so it
+ *   surfaces in the operator API instead of sitting unreachable as `failed`
  * @param {(msg: string) => void} [options.log]
  * @param {() => Date} [options.now] - injectable clock
  * @returns {Promise<{claimed: number, published: number, failed: number}>}
@@ -33,6 +36,7 @@ export async function pollOutboxOnce({
   maxAttempts = 10,
   batchSize = 50,
   leaseMs = 60_000,
+  dlq = null,
   log = () => {},
   now = () => new Date(),
 }) {
@@ -60,10 +64,25 @@ export async function pollOutboxOnce({
       published++;
     } catch (err) {
       failed++;
+      const exhausted = row.attempts + 1 >= maxAttempts;
       try {
         await outbox.markFailed(row.id, err.message, maxAttempts);
       } catch (markErr) {
         log(`[Outbox] markFailed for event ${row.event_id} failed: ${markErr.message}`);
+      }
+      if (exhausted && dlq) {
+        try {
+          await dlq.insert({
+            messageId: row.event_id,
+            source: 'outbox',
+            type: row.type,
+            payload: record,
+            error: err.message,
+            deliveryAttempts: row.attempts + 1,
+          });
+        } catch (dlqErr) {
+          log(`[DLQ] insert for event ${row.event_id} failed: ${dlqErr.message}`);
+        }
       }
       log(
         `[Outbox] publish failed for event ${row.event_id} (${maxAttempts - row.attempts} attempts left): ${err.message}`,

--- a/src/server.js
+++ b/src/server.js
@@ -28,6 +28,8 @@ import { buildSettlementStore } from './store/index.js';
 import { startReconciliationLoop } from './store/reconciliation.js';
 import { startOutboxWorker } from './outbox/index.js';
 import { createVaultManagedDatabase } from './vault/index.js';
+import { DeadLetterStore } from './dlq/store.js';
+import { startDlqWorker } from './dlq/worker.js';
 
 // A .env file is a development convenience, not a deployment mechanism — in
 // production the environment comes from the orchestrator, so a stray .env left
@@ -140,15 +142,6 @@ const distributedLock = config.redisNodes.length
   ? createDistributedLock({ nodes: config.redisNodes })
   : null;
 
-// Webhook delivery off the critical path (#117).
-const webhooks = await createWebhookDispatcher({
-  brokers: config.kafka.brokers,
-  clientId: config.kafka.clientId,
-  topic: config.kafka.topic,
-  groupId: config.kafka.groupId,
-  url: config.webhookUrl,
-});
-
 // Multi-region failover health (#126).
 const failoverHealth = config.region
   ? new FailoverHealthChecker({
@@ -160,6 +153,36 @@ const failoverHealth = config.region
   : null;
 const settlementStore = buildSettlementStore(config, { pool: vaultDatabase?.pool });
 const reconciliation = startReconciliationLoop(settlementStore, config);
+
+// Dead-letter queue (#DLQ): built ahead of the webhook dispatcher and the
+// outbox worker so both can be handed the same store — a message dead-letters
+// from whichever path exhausts its delivery budget first, and the operator
+// API (registered in createApp below) reads them all from one place. Only
+// built when there is somewhere durable to put it (Postgres). Uses the
+// Vault-managed pool when one exists; otherwise opens its own, the same
+// lazy-per-store pattern PostgresIdempotencyStore and the catalog store use
+// (rather than reaching into settlementStore's pool, which is itself built
+// asynchronously and is not guaranteed to exist yet at this point).
+const dlqPool = config.databaseUrl
+  ? (vaultDatabase?.pool ??
+    (await import('pg').then(({ default: pg }) => {
+      const p = new pg.Pool({ connectionString: config.databaseUrl, max: 5 });
+      p.on('error', err => console.warn(`[DLQ] pool error: ${err.message}`));
+      return p;
+    })))
+  : null;
+const dlqStore = dlqPool ? new DeadLetterStore(dlqPool, { warn: msg => console.warn(msg) }) : null;
+
+// Webhook delivery off the critical path (#117).
+const webhooks = await createWebhookDispatcher({
+  brokers: config.kafka.brokers,
+  clientId: config.kafka.clientId,
+  topic: config.kafka.topic,
+  groupId: config.kafka.groupId,
+  dlqTopic: config.kafka.dlqTopic,
+  dlq: dlqStore,
+  url: config.webhookUrl,
+});
 
 // Transactional outbox (#123): the settle path writes the notification in the
 // same transaction as the 'settled' state change (see app.js); this worker
@@ -174,10 +197,31 @@ const outboxWorker =
         outbox,
         publish: record => webhooks.publish(record),
         intervalMs: config.outboxPollIntervalMs,
+        dlq: dlqStore,
         log: msg => console.warn(msg),
       })
     : null;
 outboxWorker?.start();
+
+// DLQ retry worker (#DLQ): a second, slower backoff against the same
+// receiver for messages that exhausted their original delivery budget (see
+// src/dlq/worker.js). Also owns the depth-alert check and the
+// x402_dlq_depth gauge. Runs only when there is a DLQ store and something to
+// redeliver through.
+const dlqWorker =
+  dlqStore && typeof webhooks.publish === 'function'
+    ? startDlqWorker({
+        dlq: dlqStore,
+        publish: record => webhooks.publish(record),
+        intervalMs: config.dlq.pollIntervalMs,
+        maxDlqAttempts: config.dlq.maxRetryAttempts,
+        baseBackoffMs: config.dlq.baseBackoffMs,
+        alertThreshold: config.dlq.alertThreshold,
+        onDepth: ({ status, value }) => metrics.setDlqDepth({ status, value }),
+        log: msg => console.warn(msg),
+      })
+    : null;
+dlqWorker?.start();
 
 const app = await createApp(config, facilitator, rateLimiter, catalog, idempotency, {
   breakerStates: rpc?.getBreakerStates,
@@ -192,6 +236,13 @@ const app = await createApp(config, facilitator, rateLimiter, catalog, idempoten
 
   failoverHealth,
   settlementStore,
+  dlq: dlqStore
+    ? {
+        store: dlqStore,
+        publish: record => webhooks.publish(record),
+        retryOptions: { maxDlqAttempts: config.dlq.maxRetryAttempts, baseBackoffMs: config.dlq.baseBackoffMs },
+      }
+    : null,
 });
 
 // Set by the METRICS_PORT branch below; closed on shutdown when present.
@@ -234,6 +285,7 @@ app.listen({ port: config.port, host: '0.0.0.0' }, () => {
       webhooks.kind === 'kafka'
         ? `kafka webhooks (${config.kafka.brokers.length} broker(s))`
         : 'direct webhooks',
+      dlqStore ? 'dlq enabled' : 'dlq disabled (no DATABASE_URL)',
       config.region ? `region: ${config.region}` : null,
     ]
       .filter(Boolean)
@@ -293,6 +345,12 @@ async function shutdown(signal) {
     try {
       reconciliation?.stop();
       await outboxWorker?.stop();
+      await dlqWorker?.stop();
+      // Only end the DLQ pool if it is not the Vault-managed one — that pool
+      // is closed by vaultDatabase.stop() below, and ending it twice throws.
+      if (dlqPool && dlqPool !== vaultDatabase?.pool) {
+        await dlqPool.end().catch(() => {});
+      }
       await vaultDatabase?.stop();
       await app.close();
       await new Promise(resolve =>

--- a/src/server.js
+++ b/src/server.js
@@ -240,7 +240,10 @@ const app = await createApp(config, facilitator, rateLimiter, catalog, idempoten
     ? {
         store: dlqStore,
         publish: record => webhooks.publish(record),
-        retryOptions: { maxDlqAttempts: config.dlq.maxRetryAttempts, baseBackoffMs: config.dlq.baseBackoffMs },
+        retryOptions: {
+          maxDlqAttempts: config.dlq.maxRetryAttempts,
+          baseBackoffMs: config.dlq.baseBackoffMs,
+        },
       }
     : null,
 });

--- a/src/webhooks/dispatcher.js
+++ b/src/webhooks/dispatcher.js
@@ -16,6 +16,15 @@
  * back to direct fire-and-forget delivery — still off the critical path, but
  * without durability across restarts. That keeps single-binary deployments
  * working while production runs get the queue.
+ *
+ * DEAD-LETTERING. Every path that gives up on a message after exhausting
+ * deliverWebhook's own retry budget — direct-mode enqueue, and the Kafka
+ * consumer's eachMessage — records the message with the injected
+ * DeadLetterStore (`dlq`) when one is configured, instead of the message
+ * simply vanishing after the last warn(). The Kafka producer side also gets a
+ * broker-level DLQ: when `dlqTopic` is set, a message the consumer could not
+ * deliver is additionally published there for any other consumer watching the
+ * dead-letter topic.
  */
 
 import crypto from 'node:crypto';
@@ -70,6 +79,23 @@ export async function deliverWebhook({
   return { delivered: false };
 }
 
+/** Records a message that exhausted its delivery budget, when a DLQ store is configured. */
+async function recordDeadLetter({ dlq, source, record, error, deliveryAttempts, warn }) {
+  if (!dlq) return;
+  try {
+    await dlq.insert({
+      messageId: record.id,
+      source,
+      type: record.type,
+      payload: record,
+      error,
+      deliveryAttempts,
+    });
+  } catch (err) {
+    warn(`webhooks: DLQ insert failed for message ${record.id}: ${err.message}`);
+  }
+}
+
 /**
  * Creates the webhook dispatcher used by the transport.
  *
@@ -83,6 +109,11 @@ export async function deliverWebhook({
  * @param {string} [options.clientId]
  * @param {string} [options.topic]
  * @param {string} [options.groupId]
+ * @param {string} [options.dlqTopic] - Kafka DLQ topic; a message the consumer
+ *   could not deliver is republished here in addition to the `dlq` store, when set
+ * @param {import('../dlq/store.js').DeadLetterStore} [options.dlq] - when given,
+ *   messages that exhaust their delivery budget are recorded here instead of
+ *   only logged and dropped
  * @param {Function} [options.createKafka] - kafkajs factory (injectable for tests)
  * @param {(msg: string) => void} [options.log]
  * @returns {Promise<{enqueue: Function, start: Function, stop: Function, kind: string}>}
@@ -92,6 +123,8 @@ export async function createWebhookDispatcher({
   clientId = DEFAULT_CLIENT_ID,
   topic = DEFAULT_TOPIC,
   groupId = DEFAULT_GROUP_ID,
+  dlqTopic = null,
+  dlq = null,
   /** Default receiver; events may override with their own url. */
   url = null,
   createKafka,
@@ -115,9 +148,26 @@ export async function createWebhookDispatcher({
       enqueue(event) {
         const record = buildRecord(event);
         if (!record.url) return;
-        Promise.resolve().then(() =>
-          deliverWebhook({ url: record.url, body: record, warn, fetchImpl }),
-        );
+        const maxAttempts = 5; // deliverWebhook's own default, named here for the DLQ record
+        Promise.resolve().then(async () => {
+          const res = await deliverWebhook({
+            url: record.url,
+            body: record,
+            warn,
+            fetchImpl,
+            maxAttempts,
+          });
+          if (!res.delivered) {
+            await recordDeadLetter({
+              dlq,
+              source: 'direct',
+              record,
+              error: `webhook delivery to ${record.url} failed after ${maxAttempts} attempts`,
+              deliveryAttempts: maxAttempts,
+              warn,
+            });
+          }
+        });
       },
       /**
        * Awaitable publish for the outbox worker (#123): direct delivery with
@@ -170,11 +220,27 @@ export async function createWebhookDispatcher({
             messages: [{ key: record.id, value: JSON.stringify(record) }],
           });
         })
-        .catch(err => {
+        .catch(async err => {
           // Last-resort fallback so a broker blip does not drop the event.
           warn(`webhooks: publish failed (${err.message}); delivering directly`);
-          if (record.url) {
-            deliverWebhook({ url: record.url, body: record, warn, fetchImpl }).catch(() => {});
+          if (!record.url) return;
+          const maxAttempts = 5;
+          const res = await deliverWebhook({
+            url: record.url,
+            body: record,
+            warn,
+            fetchImpl,
+            maxAttempts,
+          }).catch(() => ({ delivered: false }));
+          if (!res.delivered) {
+            await recordDeadLetter({
+              dlq,
+              source: 'direct',
+              record,
+              error: `broker publish failed (${err.message}) and direct fallback delivery also failed`,
+              deliveryAttempts: maxAttempts,
+              warn,
+            });
           }
         });
     },
@@ -209,7 +275,33 @@ export async function createWebhookDispatcher({
             return;
           }
           if (!record.url) return;
-          await deliverWebhook({ url: record.url, body: record, warn, fetchImpl });
+          const maxAttempts = 5;
+          const res = await deliverWebhook({
+            url: record.url,
+            body: record,
+            warn,
+            fetchImpl,
+            maxAttempts,
+          });
+          if (res.delivered) return;
+
+          // Broker-level DLQ (issue: "Configure DLQs in the message broker"):
+          // republish to the dead-letter topic for any other consumer watching
+          // it, in addition to the operator-facing Postgres record below.
+          if (dlqTopic) {
+            await producer
+              .send({ topic: dlqTopic, messages: [{ key: record.id, value: JSON.stringify(record) }] })
+              .catch(dlqErr => warn(`webhooks: DLQ topic publish failed: ${dlqErr.message}`));
+          }
+
+          await recordDeadLetter({
+            dlq,
+            source: 'kafka-consumer',
+            record,
+            error: `webhook delivery to ${record.url} failed after ${maxAttempts} attempts (last status ${res.status ?? 'transport error'})`,
+            deliveryAttempts: maxAttempts,
+            warn,
+          });
         },
       });
       running = true;

--- a/src/webhooks/dispatcher.js
+++ b/src/webhooks/dispatcher.js
@@ -290,7 +290,10 @@ export async function createWebhookDispatcher({
           // it, in addition to the operator-facing Postgres record below.
           if (dlqTopic) {
             await producer
-              .send({ topic: dlqTopic, messages: [{ key: record.id, value: JSON.stringify(record) }] })
+              .send({
+                topic: dlqTopic,
+                messages: [{ key: record.id, value: JSON.stringify(record) }],
+              })
               .catch(dlqErr => warn(`webhooks: DLQ topic publish failed: ${dlqErr.message}`));
           }
 


### PR DESCRIPTION
## What changed

<!-- One or two sentences. What does this do that the tree did not do before? -->

## Why

<!-- The problem, not the patch. If it fixes an issue, link it: Closes #N -->

## How it was verified

<!-- Commands run and their result. "npm test passes" is fine; "should work" is not. -->

- [ ] `npm test`
- [ ] `npx eslint .`
- [ ] `npx prettier --check .`

## Wire format

Does this change anything a client can observe — a route, a status code, a
field name, a reason code, or the shape of a response?

- [ ] No
- [ ] Yes, and it is described below

<!--
Conformance here is judged at the wire level: reviewers point stock SDK code at
the service rather than read a claim. A field renamed by accident is a
conformance failure that passes every local test, so it needs saying out loud.
-->

## Anything a reviewer should push back on

<!-- Shortcuts taken, assumptions made, things you were unsure about. -->

Closes #131
Closes #132
Closes #133
