### PR TITLE
docs(env): document KEY_MANAGER_* vars introduced by signer rotation (#125)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -255,3 +255,20 @@ POSTGRES_PASSWORD=change_me_before_running
 # Required when running with cross-region failover.
 # Default: unset
 # REGIONS=us-east-1,us-west-2
+
+# ── Zero-downtime signer rotation (#125) ───────────────────────────────────
+# Optional HTTP endpoint the KeyManager polls for the current set of signing
+# secrets, so keys can be rotated without a restart. It must return a non-empty
+# {"keys": [...]} array of Stellar secrets (or {kid, secret} objects). Unset =
+# rotation is off and the signers from STELLAR_SECRET* are used for the process
+# lifetime. Set it when your secrets live in a manager (Vault, KMS) and you need
+# to retire a key while in-flight settlements still drain on the old one.
+# KEY_MANAGER_URL=https://vault.example.com/v1/x402/signers
+# KEY_MANAGER_URL_PUBNET=https://vault.example.com/v1/x402/signers-pubnet
+
+# How often to re-poll KEY_MANAGER_URL for a new key generation, in ms.
+# Default: 0 (fetch once at startup and never re-poll). Raise off zero only
+# when a key manager is configured; a shorter interval picks up a rotation
+# sooner at the cost of more requests to the manager.
+# KEY_MANAGER_POLL_INTERVAL_MS=0
+# KEY_MANAGER_POLL_INTERVAL_MS_PUBNET=0


### PR DESCRIPTION
#276 (zero-downtime signer rotation) was written before the `env-doc` check landed on `main`, so the four env vars it reads were never added to `.env.example`. That makes the `env-doc` job fail on `main` post-merge.

This documents them:

- `KEY_MANAGER_URL` / `KEY_MANAGER_URL_PUBNET`
- `KEY_MANAGER_POLL_INTERVAL_MS` / `KEY_MANAGER_POLL_INTERVAL_MS_PUBNET`

Verified locally: `check-env-doc.mjs` passes, eslint clean, prettier clean, 554/554 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)