### PR TITLE
fix(metrics): actually create the active_verifications gauge (#118)

### DIFF
--- a/src/metrics.js
+++ b/src/metrics.js
@@ -193,6 +193,13 @@ export function createMetrics() {
     ['status'],
   );
 
+  const activeVerifications = new Gauge(
+    'active_verifications',
+    'Verifies currently in flight — the scale signal the HPA reads through the Prometheus Adapter (#118).',
+    [],
+  );
+  activeVerifications.set({}, 0);
+
   return {
     incRequests: labels => requests.inc(labels),
     observeRequestDuration: ({ route, network, durationSeconds }) =>
@@ -203,9 +210,20 @@ export function createMetrics() {
     setSignerInflight: ({ network, signer, value }) =>
       signerInflight.set({ network, signer }, value),
     setDlqDepth: ({ status, value }) => dlqDepth.set({ status }, value),
+    incActiveVerifications: () => activeVerifications.inc({}),
+    decActiveVerifications: () => activeVerifications.dec({}),
 
     render: () =>
-      [requests, duration, settlements, fee, rpcRetries, signerInflight, dlqDepth]
+      [
+        requests,
+        duration,
+        settlements,
+        fee,
+        rpcRetries,
+        signerInflight,
+        dlqDepth,
+        activeVerifications,
+      ]
         .map(m => m.render())
         .join(''),
   };


### PR DESCRIPTION
Follow-up to #294.

That PR wired `src/app.js` to call `metrics.incActiveVerifications()` and `metrics.decActiveVerifications()`, and added tests asserting on an `active_verifications` series — but neither the gauge nor the two helper methods were ever defined in `src/metrics.js`. It only added the generic `Gauge.inc()` / `Gauge.dec()` primitives.

Effect on `main`: **every `POST /verify` threw `TypeError: metrics.incActiveVerifications is not a function`**, and 13 tests failed.

This registers the gauge (seeded at `0` so it renders before the first verify), exposes the two helpers, and includes it in `render()` — which is also what the HPA and Prometheus Adapter configs added in #294 actually read.

Verified locally against `main`: eslint clean, prettier clean, **555/555 tests pass** (was 542/555).

🤖 Generated with [Claude Code](https://claude.com/claude-code)