### PR TITLE
fix(sdk): repair the validate-discovery CLI import, and cover it with a test

### DIFF
--- a/src/sdk/cli.js
+++ b/src/sdk/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import fs from 'fs';
-import { validateDiscoveryPolicy } from './validation.js';
+import { validateDiscoveryPolicy } from '../catalog/validation.js';
 
 const file = process.argv[2];
 if (!file) {

--- a/test/sdk-cli.test.js
+++ b/test/sdk-cli.test.js
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * The offline validator sellers are told to run in docs/SELLER.md and
+ * docs/BAZAAR.md. Nothing else imports src/sdk/cli.js, so without this test a
+ * broken import in it stays green through the whole suite — which is exactly
+ * how it shipped once (it imported validateDiscoveryPolicy from ./validation.js,
+ * where that symbol does not live).
+ */
+const CLI = fileURLToPath(new URL('../src/sdk/cli.js', import.meta.url));
+
+function runCli(declaration) {
+  const file = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'x402-cli-')), 'decl.json');
+  fs.writeFileSync(file, JSON.stringify(declaration));
+  try {
+    return { status: 0, stdout: execFileSync(process.execPath, [CLI, file], { encoding: 'utf8' }) };
+  } catch (err) {
+    return { status: err.status, stdout: err.stdout ?? '', stderr: err.stderr ?? '' };
+  }
+}
+
+test('the CLI loads and accepts a well-formed declaration', () => {
+  const { status, stdout } = runCli({
+    routeTemplate: '/api/data/:id',
+    pricing: { amount: '1', asset: 'USDC' },
+  });
+  assert.equal(status, 0);
+  assert.match(stdout, /Validation passed/);
+});
+
+test('the CLI exits non-zero and names the reason on a hard drop', () => {
+  const { status, stderr } = runCli('not-an-object');
+  assert.equal(status, 1);
+  assert.match(stderr, /invalid_declaration/);
+});
+
+test('the CLI explains itself when given no argument', () => {
+  try {
+    execFileSync(process.execPath, [CLI], { encoding: 'utf8' });
+    assert.fail('expected a non-zero exit');
+  } catch (err) {
+    assert.equal(err.status, 1);
+    assert.match(err.stderr, /Usage:/);
+  }
+});


### PR DESCRIPTION
`src/sdk/cli.js` imported `validateDiscoveryPolicy` from `./validation.js`, but that symbol lives in `../catalog/validation.js`. The CLI died at module load:

```
SyntaxError: The requested module './validation.js' does not provide an export named 'validateDiscoveryPolicy'
```

**This was my regression, introduced in #304.** Resolving #275's conflicts I took the PR's `cli.js` while keeping `main`'s stricter `sdk/validation.js` — and missed that the two no longer agreed.

It stayed green because nothing in the repo imports `cli.js`, so 556/556 passed over a completely broken seller-facing tool. `docs/SELLER.md` and `docs/BAZAAR.md` both tell sellers to run it.

Adds `test/sdk-cli.test.js`, which actually executes the CLI: happy path, hard-drop exit code, and the usage line.

Verified: eslint clean, prettier clean, **559/559 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)